### PR TITLE
Fix cache py3.8

### DIFF
--- a/icon_manager.py
+++ b/icon_manager.py
@@ -2,7 +2,6 @@ import gpu
 from gpu_extras.batch import batch_for_shader
 from bpy.app import background
 
-from functools import cache
 from pathlib import Path
 
 from . import functions

--- a/shaders.py
+++ b/shaders.py
@@ -1,7 +1,12 @@
 import gpu
 from gpu.types import GPUShader
 
-from functools import cache
+import sys
+if sys.version_info >= (3, 9):
+    from functools import cache
+else:
+    from functools import lru_cache
+    cache = lru_cache(maxsize=None)
 
 class Shaders:
 


### PR DESCRIPTION
At install Python complained about the cache decorator.
As documented here: https://docs.python.org/3/library/functools.html
the cache decorator "Returns the same as lru_cache(maxsize=None)"
So I fixed the issue with a conditional import.