### PR TITLE
__init__.py: Fix version check

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -80,6 +80,7 @@ def update_logger():
 def ensure_addon_presets(force_write=False):
     import os
     import shutil
+    import sys
 
     scripts_folder = bpy.utils.user_resource("SCRIPTS")
     presets_dir = os.path.join(scripts_folder, "presets", "bgs")
@@ -94,7 +95,7 @@ def ensure_addon_presets(force_write=False):
         files = os.listdir(bundled_presets)
 
         kwargs = {}
-        if sys.version >= (3, 8):
+        if sys.version_info >= (3, 8):
             kwargs = {"dirs_exist_ok": True}
 
         shutil.copytree(bundled_presets, presets_dir, **kwargs)


### PR DESCRIPTION
Super exciting project! I really like Solvespace and its workflow but having some of that capability built into Blender will be fantastic.

Sorry for such a trivial PR. 😅 

I got this import error when first trying to install the add-on via the git method on Windows 10.
You can then just try to install again and it'll "succeed" because the `bgs` directory got created, but the actual theme presets then don't get copied over.

![image](https://user-images.githubusercontent.com/1646397/165746137-a2a2ad3b-b5cb-43da-998c-7e2235081226.png)
```
Blender:
====================================

version: 3.1.2, branch: master, commit date: 2022-03-31 17:40, hash: cc66d1020c3b, type: release
build date: 2022-03-31, 23:39:57
platform: 'Windows-10-10.0.19043-SP0'
binary path: 'C:\\Program Files\\WindowsApps\\BlenderFoundation.Blender_3.1.2.0_x64__ppwjx1n5r4v9t\\Blender\\blender.exe'
```