### PR TITLE
Support entity naming

### DIFF
--- a/class_defines.py
+++ b/class_defines.py
@@ -27,8 +27,15 @@ from .functions import unique_attribute_setter
 logger = logging.getLogger(__name__)
 
 
+def entity_name_getter(self):
+    return self.get("name", str(self))
+
+def entity_name_setter(self, new_name):
+    self["name"] = new_name
+
 class SlvsGenericEntity:
     slvs_index: IntProperty(name="Global Index", default=-1)
+    name: StringProperty(name="Name", get=entity_name_getter, set=entity_name_setter, options={"SKIP_SAVE"})
     fixed: BoolProperty(name="Fixed")
     visible: BoolProperty(name="Visible", default=True, update=functions.update_cb)
     origin: BoolProperty(name="Origin")
@@ -1164,7 +1171,6 @@ class SlvsCircle(SlvsGenericEntity, PropertyGroup, Entity2D):
         nm (SlvsNormal2D):
         sketch (SlvsSketch): The sketch this entity belongs to
     """
-
     radius: FloatProperty(
         name="Radius",
         description="The radius of the circle",
@@ -1278,7 +1284,6 @@ class SlvsCircle(SlvsGenericEntity, PropertyGroup, Entity2D):
 slvs_entity_pointer(SlvsCircle, "nm")
 slvs_entity_pointer(SlvsCircle, "ct")
 slvs_entity_pointer(SlvsCircle, "sketch")
-
 
 def update_pointers(scene, index_old, index_new):
     """Replaces all references to an entity index with it's new index"""

--- a/operators.py
+++ b/operators.py
@@ -322,6 +322,8 @@ class View3D_OT_slvs_context_menu(Operator, HighlightElement):
                     col.label(text="Index: " + str(element.slvs_index))
                 col.label(text="Is Origin: " + str(element.origin))
                 col.separator()
+                col.prop(element, "name", text="")
+                col.separator()
                 col.prop(element, "visible")
                 col.prop(element, "fixed")
                 col.prop(element, "construction")

--- a/ui.py
+++ b/ui.py
@@ -174,6 +174,16 @@ class VIEW3D_PT_sketcher_entities(Panel):
             sub = row.row()
             sub.alignment = "LEFT"
 
+            # Select operator
+            props = sub.operator(
+                operators.View3D_OT_slvs_select.bl_idname,
+                text="",
+                emboss=False,
+                icon=("RADIOBUT_ON" if e.selected else "RADIOBUT_OFF"),
+            )
+            props.index = e.slvs_index
+            props.highlight_hover = True
+
             # Visibility toggle
             sub.prop(
                 e,
@@ -183,15 +193,7 @@ class VIEW3D_PT_sketcher_entities(Panel):
                 emboss=False,
             )
 
-            # Select operator
-            props = sub.operator(
-                operators.View3D_OT_slvs_select.bl_idname,
-                text=str(e),
-                emboss=False
-                )
-            props.index = e.slvs_index
-            props.highlight_hover = True
-
+            sub.prop(e, "name", text="")
 
             # Right part
             sub = row.row()


### PR DESCRIPTION
- By default, name will be generated by combining type and index.
- Naming could be done through entity's context menu and also in entity
  browser
- In entity browser, selector had been changed to the radio button in first column
- name is introduced as StringProperty on SlvsGenericEntity as a wrapper of name property to provide default name value for entities saved by previous CAD Sketch plugin where name were not populated

This is to address issue #53 

Change name in context menu
![image](https://user-images.githubusercontent.com/29285869/172983242-1d4f2637-eba7-4a79-a281-2eef2581c676.png)

Change name in entity browser
![image](https://user-images.githubusercontent.com/29285869/172983424-1ff209dc-14b3-493e-96dc-b61bc0bdd8a1.png)

Selection mode
![image](https://user-images.githubusercontent.com/29285869/172983469-468fe209-c0f5-4cce-b7ee-5773f1d58fc3.png)
