### PR TITLE
Support constraint visibility toggling

### DIFF
--- a/class_defines.py
+++ b/class_defines.py
@@ -1676,6 +1676,7 @@ curve = (SlvsCircle, SlvsArc)
 
 class GenericConstraint:
     failed: BoolProperty(name="Failed")
+    visible: BoolProperty(name="Visible", default=True, update=functions.update_cb)
     signature = ()
 
     def needs_wp(args):
@@ -1733,12 +1734,17 @@ class GenericConstraint:
                 continue
             _update(prop_name)
 
+    def is_visible(self, context):
+        if hasattr(self, "sketch"):
+            return self.sketch.is_visible(context) and self.visible
+        return self.visible
+
     def is_active(self, active_sketch):
         if not hasattr(self, "sketch"):
             return not active_sketch
 
         show_inactive = not functions.get_prefs().hide_inactive_constraints
-        if show_inactive and self.sketch.visible:
+        if show_inactive and self.is_visible():
             return True
 
         return self.sketch == active_sketch

--- a/gizmos.py
+++ b/gizmos.py
@@ -124,6 +124,8 @@ class VIEW3D_GT_slvs_constraint(ConstraintGizmo, Gizmo):
 
     def draw(self, context):
         constraint = self._get_constraint(context)
+        if not constraint.visible:
+            return
         col = self._set_colors(context, constraint)
         self._update_matrix_basis(context, constraint)
 
@@ -179,7 +181,8 @@ class VIEW3D_GT_slvs_constraint_value(ConstraintGizmo, Gizmo):
 
     def draw(self, context):
         constr = self._get_constraint(context)
-        if not hasattr(constr, "value_placement"):
+
+        if not constr.visible or not hasattr(constr, "value_placement"):
             return
         pos = constr.value_placement(context)
 
@@ -217,6 +220,8 @@ class ConstraintGizmoGeneric(ConstraintGizmo):
 
     def draw(self, context):
         constr = self._get_constraint(context)
+        if not constr.visible:
+            return
         self._set_colors(context, constr)
         self._update_matrix_basis(constr)
 
@@ -225,6 +230,8 @@ class ConstraintGizmoGeneric(ConstraintGizmo):
 
     def draw_select(self, context, select_id):
         constr = self._get_constraint(context)
+        if not constr.visible:
+            return
         self._create_shape(context, constr, select=True)
         self.draw_custom_shape(self.custom_shape, select_id=select_id)
 

--- a/operators.py
+++ b/operators.py
@@ -341,6 +341,10 @@ class View3D_OT_slvs_context_menu(Operator, HighlightElement):
                 element.draw_props(col)
                 col.separator()
 
+            if hasattr(element, "visible"):
+                col.prop(element, "visible")
+                col.separator()
+
             # Delete operator
             if is_entity:
                 col.operator(View3D_OT_slvs_delete_entity.bl_idname, icon='X').index = element.slvs_index
@@ -3212,6 +3216,36 @@ class VIEW3D_OT_slvs_add_ratio(
     type = "RATIO"
 
 
+class View3D_OT_slvs_set_all_constraints_visibility(Operator, HighlightElement):
+    """Set all constraints' visibility
+    """
+    bl_idname = "view3d.slvs_hide_all_constraints"
+    bl_label = "Hide all constraints"
+    bl_options = {"UNDO"}
+    bl_description = "Hide all constraints"
+
+    visibility: EnumProperty(
+        name="Visibility",
+        description="Visiblity",
+        items=[
+            ("HIDE", "Hide all", "Hide all constraints"),
+            ("SHOW", "Show all", "Show all constraints"),
+        ])
+
+    @classmethod
+    def poll(cls, context):
+        return True
+
+    def execute(self, context):
+        constraint_lists = context.scene.sketcher.constraints.get_lists()
+        for constraint_list in constraint_lists:
+            for constraint in constraint_list:
+                if not hasattr(constraint, "visible"):
+                    continue
+                constraint.visible = self.visibility == "SHOW"
+        return {"FINISHED"}
+
+
 class View3D_OT_slvs_delete_constraint(Operator, HighlightElement):
     """Delete constraint by type and index
     """
@@ -3472,6 +3506,7 @@ classes = (
     View3D_OT_slvs_test,
     View3D_OT_invoke_tool,
     View3D_OT_slvs_set_active_sketch,
+    View3D_OT_slvs_set_all_constraints_visibility,
     View3D_OT_slvs_delete_entity,
     *constraint_operators,
     View3D_OT_slvs_solve,

--- a/ui.py
+++ b/ui.py
@@ -235,6 +235,8 @@ class VIEW3D_PT_sketcher_constraints(Panel):
         col = box.column(align=True)
         col.scale_y = 0.8
 
+        layout.operator_enum(operators.View3D_OT_slvs_set_all_constraints_visibility.bl_idname, "visibility")
+
         sketch = context.scene.sketcher.active_sketch
         for c in context.scene.sketcher.constraints.all:
             if not c.is_active(sketch):
@@ -244,6 +246,14 @@ class VIEW3D_PT_sketcher_constraints(Panel):
             # Left part
             sub = row.row()
             sub.alignment = "LEFT"
+
+            sub.prop(
+                c,
+                "visible",
+                icon_only=True,
+                icon=("HIDE_OFF" if c.visible else "HIDE_ON"),
+                emboss=False,
+            )
 
             # Failed hint
             sub.label(


### PR DESCRIPTION
- With complex sketches, constraints are sometimes interfering into
  designing/reading process.
- Show/hide individual constraint in the constraint browser
- Also provide 3 button shortcuts to show/hide/toggle all contraints at
  once

![image](https://user-images.githubusercontent.com/29285869/173464684-2c1fd9fa-5ffd-4a39-8483-5d9e45407e8e.png)
