### PR TITLE
Display shortcut hints for operators

### DIFF
--- a/declarations.py
+++ b/declarations.py
@@ -1,0 +1,82 @@
+# Please keep this file in alphabetical order
+
+from enum import  Enum
+
+class Gizmos(str, Enum):
+    Angle = "VIEW3D_GT_slvs_angle"
+    Constraint = "VIEW3D_GT_slvs_constraint"
+    ConstraintValue = "VIEW3D_GT_slvs_constraint_value"
+    Diameter = "VIEW3D_GT_slvs_diameter"
+    Distance = "VIEW3D_GT_slvs_distance"
+    Preselection = "VIEW3D_GT_slvs_preselection"
+
+class GizmoGroups(str, Enum):
+    Angle = "VIEW3D_GGT_slvs_angle"
+    Constraint = "VIEW3D_GGT_slvs_constraint"
+    Diameter = "VIEW3D_GGT_slvs_diameter"
+    Distance = "VIEW3D_GGT_slvs_distance"
+    Preselection = "VIEW3D_GGT_slvs_preselection"
+
+class Menus(str, Enum):
+    Sketches = "VIEW3D_MT_sketches"
+
+class Operators(str, Enum):
+    AddAngle = "view3d.slvs_add_angle"
+    AddArc2D = "view3d.slvs_add_arc2d"
+    AddCircle2D = "view3d.slvs_add_circle2d"
+    AddCoincident = "view3d.slvs_add_coincident"
+    AddDiameter = "view3d.slvs_add_diameter"
+    AddDistance = "view3d.slvs_add_distance"
+    AddEqual = "view3d.slvs_add_equal"
+    AddHorizontal = "view3d.slvs_add_horizontal"
+    AddLine2D = "view3d.slvs_add_line2d"
+    AddLine3D = "view3d.slvs_add_line3d"
+    AddMidPoint = "view3d.slvs_add_midpoint"
+    AddParallel = "view3d.slvs_add_parallel"
+    AddPerpendicular = "view3d.slvs_add_perpendicular"
+    AddPoint2D = "view3d.slvs_add_point2d"
+    AddPoint3D = "view3d.slvs_add_point3d"
+    AddPresetTheme = "bgs.theme_preset_add"
+    AddRatio = "view3d.slvs_add_ratio"
+    AddRectangle = "view3d.slvs_add_rectangle"
+    AddSketch = "view3d.slvs_add_sketch"
+    AddTangent = "view3d.slvs_add_tangent"
+    AddVertical = "view3d.slvs_add_vertical"
+    AddWorkPlane = "view3d.slvs_add_workplane"
+    AddWorkPlaneFace = "view3d.slvs_add_workplane_face"
+    ContextMenu = "view3d.slvs_context_menu"
+    DeleteConstraint = "view3d.slvs_delete_constraint"
+    DeleteEntity = "view3d.slvs_delete_entity"
+    InvokeTool = "view3d.invoke_tool"
+    InstallPackage = "view3d.slvs_install_package"
+    RegisterDrawCB = "view3d.slvs_register_draw_cb"
+    Select = "view3d.slvs_select"
+    SelectAll = "view3d.slvs_select_all"
+    SetActiveSketch = "view3d.slvs_set_active_sketch"
+    SetAllConstraintsVisibility = "view3d.slvs_set_all_constraints_visibility"
+    ShowSolverState =  "view3d.slvs_show_solver_state"
+    Solve = "view3d.slvs_solve"
+    Test = "view3d.slvs_test"
+    Trim = "view3d.slvs_trim"
+    Tweak = "view3d.slvs_tweak"
+    TweakConstraintValuePos = "view3d.slvs_tweak_constraint_value_pos"
+    UnregisterDrawCB = "view3d.slvs_unregister_draw_cb"
+    WriteSelectionTexture = "view3d.slvs_write_selection_texture"
+
+class Panels(str, Enum):
+    Sketcher = "VIEW3D_PT_sketcher"
+    SketcherContraints = "VIEW3D_PT_sketcher_constraints"
+    SketcherEntities = "VIEW3D_PT_sketcher_entities"
+
+class WorkSpaceTools(str, Enum):
+    AddArc2D = "sketcher.slvs_add_arc2d"
+    AddCircle2D = "sketcher.slvs_add_circle2d"
+    AddLine2D = "sketcher.slvs_add_line2d"
+    AddLine3D = "sketcher.slvs_add_line3d"
+    AddPoint2D = "sketcher.slvs_add_point2d"
+    AddPoint3D = "sketcher.slvs_add_point3d"
+    AddRectangle = "sketcher.slvs_add_rectangle"
+    AddWorkplane = "sketcher.slvs_add_workplane"
+    AddWorkplaneFace = "sketcher.slvs_add_workplane_face"
+    Select = "sketcher.slvs_select"
+    Trim = "sketcher.slvs_trim"

--- a/gizmos.py
+++ b/gizmos.py
@@ -1,13 +1,13 @@
 import bpy, bgl, gpu, blf
-from . import functions, operators, global_data, class_defines, preferences, icon_manager
-
+from . import functions, operators, global_data, class_defines, icon_manager
+from .declarations import GizmoGroups, Gizmos, Operators
 from bpy.types import Gizmo, GizmoGroup
 from mathutils import Vector, Matrix
 
 # NOTE: idealy gizmo would expose active element as a property and
 # operators would access hovered element from there
 class VIEW3D_GT_slvs_preselection(Gizmo):
-    bl_idname = "VIEW3D_GT_slvs_preselection"
+    bl_idname = Gizmos.Preselection
 
     __slots__ = ()
 
@@ -25,6 +25,7 @@ class VIEW3D_GT_slvs_preselection(Gizmo):
             context.area.tag_redraw()
 
         # ensure selection texture is up to date
+        # TODO: avoid dependency on operators module?
         operators.ensure_selection_texture(context)
 
         # sample selection texture and mark hovered entity
@@ -85,7 +86,7 @@ class ConstraintGizmo:
         return col
 
 class VIEW3D_GT_slvs_constraint(ConstraintGizmo, Gizmo):
-    bl_idname = "VIEW3D_GT_slvs_constraint"
+    bl_idname = Gizmos.Constraint
 
     __slots__ = (
         "custom_shape",
@@ -162,7 +163,7 @@ def _get_formatted_value(context, constr):
 
 class VIEW3D_GT_slvs_constraint_value(ConstraintGizmo, Gizmo):
     """Display the value of a dimensional constraint"""
-    bl_idname = "VIEW3D_GT_slvs_constraint_value"
+    bl_idname = Gizmos.ConstraintValue
 
     __slots__ = (
         "type",
@@ -277,7 +278,7 @@ def get_arrow_size(dist, scale):
 
 
 class VIEW3D_GT_slvs_distance(Gizmo, ConstraintGizmoGeneric):
-    bl_idname = "VIEW3D_GT_slvs_distance"
+    bl_idname = Gizmos.Distance
     type = class_defines.SlvsDistance.type
 
     bl_target_properties = ({"id": "offset", "type": "FLOAT", "array_length": 1},)
@@ -373,7 +374,7 @@ class VIEW3D_GT_slvs_distance(Gizmo, ConstraintGizmoGeneric):
 
 
 class VIEW3D_GT_slvs_angle(Gizmo, ConstraintGizmoGeneric):
-    bl_idname = "VIEW3D_GT_slvs_angle"
+    bl_idname = Gizmos.Angle
     type = class_defines.SlvsAngle.type
 
     bl_target_properties = ({"id": "offset", "type": "FLOAT", "array_length": 1},)
@@ -445,7 +446,7 @@ class VIEW3D_GT_slvs_angle(Gizmo, ConstraintGizmoGeneric):
 
 
 class VIEW3D_GT_slvs_diameter(Gizmo, ConstraintGizmoGeneric):
-    bl_idname = "VIEW3D_GT_slvs_diameter"
+    bl_idname = Gizmos.Diameter
     type = class_defines.SlvsDiameter.type
 
     bl_target_properties = ({"id": "offset", "type": "FLOAT", "array_length": 1},)
@@ -524,7 +525,7 @@ class VIEW3D_GT_slvs_diameter(Gizmo, ConstraintGizmoGeneric):
 
 
 class VIEW3D_GGT_slvs_preselection(GizmoGroup):
-    bl_idname = "VIEW3D_GGT_slvs_preselection"
+    bl_idname = GizmoGroups.Preselection
     bl_label = "preselection ggt"
     bl_space_type = "VIEW_3D"
     bl_region_type = "WINDOW"
@@ -611,9 +612,7 @@ class ConstraintGenericGGT:
             gz.use_draw_modal = True
             gz.target_set_prop("offset", c, "draw_offset")
 
-            props = gz.target_set_operator(
-                operators.View3D_OT_slvs_tweak_constraint_value_pos.bl_idname
-            )
+            props = gz.target_set_operator(Operators.TweakConstraintValuePos)
             props.type = self.type
             props.index = gz.index
 
@@ -629,7 +628,7 @@ class ConstraintGenericGGT:
 
 
 class VIEW3D_GGT_slvs_distance(GizmoGroup, ConstraintGenericGGT):
-    bl_idname = "VIEW3D_GGT_slvs_distance"
+    bl_idname = GizmoGroups.Distance
     bl_label = "Distance Constraint Gizmo Group"
 
     type = class_defines.SlvsDistance.type
@@ -637,7 +636,7 @@ class VIEW3D_GGT_slvs_distance(GizmoGroup, ConstraintGenericGGT):
 
 
 class VIEW3D_GGT_slvs_angle(GizmoGroup, ConstraintGenericGGT):
-    bl_idname = "VIEW3D_GGT_slvs_angle"
+    bl_idname = GizmoGroups.Angle
     bl_label = "Angle Constraint Gizmo Group"
 
     type = class_defines.SlvsAngle.type
@@ -645,7 +644,7 @@ class VIEW3D_GGT_slvs_angle(GizmoGroup, ConstraintGenericGGT):
 
 
 class VIEW3D_GGT_slvs_diameter(GizmoGroup, ConstraintGenericGGT):
-    bl_idname = "VIEW3D_GGT_slvs_diameter"
+    bl_idname = GizmoGroups.Diameter
     bl_label = "Diameter Gizmo Group"
 
     type = class_defines.SlvsDiameter.type
@@ -659,7 +658,7 @@ def iter_dimenional_constraints(context):
             yield c
 
 class VIEW3D_GGT_slvs_constraint(GizmoGroup):
-    bl_idname = "VIEW3D_GGT_slvs_constraint"
+    bl_idname = GizmoGroups.Constraint
     bl_label = "Constraint Gizmo Group"
     bl_space_type = "VIEW_3D"
     bl_region_type = "WINDOW"
@@ -704,7 +703,7 @@ class VIEW3D_GGT_slvs_constraint(GizmoGroup):
 
                 gz.use_draw_modal = True
 
-                op = operators.View3D_OT_slvs_context_menu.bl_idname
+                op = Operators.ContextMenu
                 props = gz.target_set_operator(op)
                 props.type = c.type
                 props.index = gz.index
@@ -722,7 +721,7 @@ class VIEW3D_GGT_slvs_constraint(GizmoGroup):
             gz.type = c.type
             gz.index = index
 
-            props = gz.target_set_operator(operators.View3D_OT_slvs_tweak_constraint_value_pos.bl_idname)
+            props = gz.target_set_operator(Operators.TweakConstraintValuePos)
             props.type = c.type
             props.index = index
 

--- a/install.py
+++ b/install.py
@@ -10,6 +10,9 @@ from . import (
     ui,
     keymaps,
 )
+
+from .declarations import Operators
+
 from bpy.types import Operator
 
 modules = (
@@ -66,7 +69,7 @@ def check_module():
 class View3D_OT_slvs_install_package(Operator):
     """Install module from local .whl file or from PyPi"""
 
-    bl_idname = "view3d.slvs_install_package"
+    bl_idname = Operators.InstallPackage
     bl_label = "Install"
 
     package: bpy.props.StringProperty(subtype="FILE_PATH")

--- a/keymaps.py
+++ b/keymaps.py
@@ -1,7 +1,172 @@
 import bpy
 
+from .declarations import Operators, WorkSpaceTools
+
+def tool_invoke_kmi(button, tool, operator):
+    return (
+        Operators.InvokeTool,
+        {"type": button, "value": "PRESS"},
+        {"properties": [("tool_name", tool), ("operator", operator)]},
+    )
+
+constraint_access = (
+    (
+        Operators.AddCoincident,
+        {"type": "C", "value": "PRESS", "shift": True},
+        {"properties": [("wait_for_input", True), ]}
+    ),
+    (
+        Operators.AddVertical,
+        {"type": "V", "value": "PRESS", "shift": True},
+        {"properties": [("wait_for_input", True), ]}
+    ),
+    (
+        Operators.AddHorizontal,
+        {"type": "H", "value": "PRESS", "shift": True},
+        {"properties": [("wait_for_input", True), ]}
+    ),
+    (
+        Operators.AddEqual,
+        {"type": "E", "value": "PRESS", "shift": True},
+        {"properties": [("wait_for_input", True), ]}
+    ),
+    (
+        Operators.AddParallel,
+        {"type": "A", "value": "PRESS", "shift": True},
+        {"properties": [("wait_for_input", True), ]}
+    ),
+    (
+        Operators.AddPerpendicular,
+        {"type": "P", "value": "PRESS", "shift": True},
+        {"properties": [("wait_for_input", True), ]}
+    ),
+    (
+        Operators.AddTangent,
+        {"type": "T", "value": "PRESS", "shift": True},
+        {"properties": [("wait_for_input", True), ]}
+    ),
+    (
+        Operators.AddMidPoint,
+        {"type": "M", "value": "PRESS", "shift": True},
+        {"properties": [("wait_for_input", True), ]}
+    ),
+    (
+        Operators.AddRatio,
+        {"type": "R", "value": "PRESS", "shift": True},
+        {"properties": [("wait_for_input", True), ]}
+    ),
+
+    # Dimensional Constraints
+    (
+        Operators.AddDistance,
+        {"type": "D", "value": "PRESS", "alt": True},
+        {"properties": [("wait_for_input", True), ]}
+    ),
+    (
+        Operators.AddDistance,
+        {"type": "V", "value": "PRESS", "alt": True},
+        {"properties": [("wait_for_input", True), ("align", "VERTICAL")]}
+    ),
+    (
+        Operators.AddDistance,
+        {"type": "H", "value": "PRESS", "alt": True},
+        {"properties": [("wait_for_input", True), ("align", "HORIZONTAL")]}
+    ),
+    (
+        Operators.AddAngle,
+        {"type": "A", "value": "PRESS", "alt": True},
+        {"properties": [("wait_for_input", True), ]}
+    ),
+    (
+        Operators.AddDiameter,
+        {"type": "O", "value": "PRESS", "alt": True},
+        {"properties": [("wait_for_input", True), ]}
+    ),
+    (
+        Operators.AddDiameter,
+        {"type": "R", "value": "PRESS", "alt": True},
+        {"properties": [("wait_for_input", True), ("setting", True)]}
+    ),
+)
+
+tool_access = (
+    tool_invoke_kmi(
+        "P",
+        WorkSpaceTools.AddPoint2D,
+        Operators.AddPoint2D,
+    ),
+    tool_invoke_kmi(
+        "L",
+        WorkSpaceTools.AddLine2D,
+        Operators.AddLine2D,
+    ),
+    tool_invoke_kmi(
+        "C",
+        WorkSpaceTools.AddCircle2D,
+        Operators.AddCircle2D,
+    ),
+    tool_invoke_kmi(
+        "A",
+        WorkSpaceTools.AddArc2D,
+        Operators.AddArc2D,
+    ),
+    tool_invoke_kmi(
+        "R",
+        WorkSpaceTools.AddRectangle,
+        Operators.AddRectangle,
+    ),
+    tool_invoke_kmi(
+        "Y",
+        WorkSpaceTools.Trim,
+        Operators.Trim,
+    ),
+    (
+        Operators.AddSketch,
+        {"type": "S", "value": "PRESS"},
+        {"properties": [("wait_for_input", True), ]}
+    ),
+    *constraint_access,
+)
 
 addon_keymaps = []
+
+def get_key_map_desc(id_name1, id_name2=None, filter_func=None) -> str:
+    key_maps = []
+    for key_map in tool_access:
+        if key_map[0] == id_name1:
+            if not filter_func or filter_func(id_name2, key_map):
+                key_maps.append(key_map)
+
+    key_map_count = len(key_maps)
+    if key_map_count == 0:
+        return ""
+    
+    def _append_key_map_modifier(key_map, key_map_info, modifer, modifer_name):
+        if modifer in key_map_info and key_map_info[modifer]:
+            key_map = f"{key_map}{modifer_name} + "
+        return key_map
+
+    def _get_key_map(key_map_info):
+        key_map = ""
+        key_map_type = key_map_info["type"]
+        key_map = _append_key_map_modifier(key_map, key_map_info, "ctl", "Ctrl")
+        key_map = _append_key_map_modifier(key_map, key_map_info, "alt", "Alt")
+        key_map = _append_key_map_modifier(key_map, key_map_info, "shift", "Shift")
+        key_map = f"{key_map}{key_map_type}"
+
+        return key_map
+
+    final_key_map_desc = ""
+    for key_map in key_maps:
+        key_map_info = key_map[1]
+        key_map_desc = _get_key_map(key_map_info)
+        if len(final_key_map_desc) > 0:
+            final_key_map_desc = f"{final_key_map_desc}, {key_map_desc}"
+        else:
+            final_key_map_desc = key_map_desc
+    
+    return f" ({final_key_map_desc})" if final_key_map_desc else ""
+
 
 def register():
     wm = bpy.context.window_manager
@@ -10,11 +175,11 @@ def register():
 
         # Select
         kmi = km.keymap_items.new('wm.tool_set_by_id', 'ESC', 'PRESS', shift=True)
-        kmi.properties.name = "sketcher.slvs_select"
+        kmi.properties.name = WorkSpaceTools.Select
         addon_keymaps.append((km, kmi))
 
         # Add Sketch
-        kmi = km.keymap_items.new('view3d.slvs_add_sketch', 'A', 'PRESS', ctrl=True, shift=True)
+        kmi = km.keymap_items.new(Operators.AddSketch, 'A', 'PRESS', ctrl=True, shift=True)
         kmi.properties.wait_for_input = True
         addon_keymaps.append((km, kmi))
 

--- a/ui.py
+++ b/ui.py
@@ -1,6 +1,8 @@
 import bpy
 from bpy.types import Panel, Menu, UIList
-from . import operators, functions, class_defines
+from . import functions, class_defines
+from .declarations import Menus, Operators, Panels
+from .operators import constraint_operators
 
 
 class VIEW3D_UL_sketches(UIList):
@@ -27,7 +29,7 @@ class VIEW3D_UL_sketches(UIList):
 
                 if item.solver_state != "OKAY":
                     row.operator(
-                        operators.View3D_OT_slvs_show_solver_state.bl_idname,
+                        Operators.ShowSolverState,
                         text="",
                         emboss=False,
                         icon_value=layout.enum_item_icon(
@@ -36,7 +38,7 @@ class VIEW3D_UL_sketches(UIList):
                     ).index = item.slvs_index
 
                 row.operator(
-                    operators.View3D_OT_slvs_set_active_sketch.bl_idname,
+                    Operators.SetActiveSketch,
                     icon="OUTLINER_DATA_GP_LAYER",
                     text="",
                     emboss=False,
@@ -44,7 +46,7 @@ class VIEW3D_UL_sketches(UIList):
 
                 if active:
                     row.operator(
-                        operators.View3D_OT_slvs_delete_entity.bl_idname,
+                        Operators.DeleteEntity,
                         text="",
                         icon="X",
                         emboss=False,
@@ -62,7 +64,7 @@ class VIEW3D_UL_sketches(UIList):
 
 class VIEW3D_PT_sketcher(Panel):
     bl_label = "Sketcher"
-    bl_idname = "VIEW3D_PT_sketcher"
+    bl_idname = Panels.Sketcher
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_category = "Sketcher"
@@ -83,7 +85,7 @@ class VIEW3D_PT_sketcher(Panel):
             if sketch.solver_state != "OKAY":
                 state = sketch.get_solver_state()
                 row.operator(
-                    operators.View3D_OT_slvs_show_solver_state.bl_idname,
+                    Operators.ShowSolverState,
                     text=state.name,
                     icon=state.icon,
                     emboss=False,
@@ -104,7 +106,7 @@ class VIEW3D_PT_sketcher(Panel):
                 layout.prop(sketch, "fill_shape")
 
             layout.operator(
-                operators.View3D_OT_slvs_delete_entity.bl_idname,
+                Operators.DeleteEntity,
                 text="Delete Sketch",
                 icon="X",
             ).index = sketch.slvs_index
@@ -123,7 +125,7 @@ class VIEW3D_PT_sketcher(Panel):
 
         layout.label(text="Constraints:")
         col = layout.column(align=True)
-        for op in operators.constraint_operators:
+        for op in constraint_operators:
             col.operator(op.bl_idname)
 
         prefs = functions.get_prefs()
@@ -133,13 +135,13 @@ class VIEW3D_PT_sketcher(Panel):
             layout.label(text="Debug:")
             layout.label(text="Version: " + str(context.scene.sketcher.version[:]))
 
-            layout.operator(operators.VIEW3D_OT_slvs_write_selection_texture.bl_idname)
-            layout.operator(operators.View3D_OT_slvs_solve.bl_idname)
+            layout.operator(Operators.WriteSelectionTexture)
+            layout.operator(Operators.Solve)
             layout.operator(
-                operators.View3D_OT_slvs_solve.bl_idname, text="Solve All"
+                Operators.Solve, text="Solve All"
             ).all = True
 
-            layout.operator(operators.View3D_OT_slvs_test.bl_idname)
+            layout.operator(Operators.Test)
             layout.prop(context.scene.sketcher, "show_origin")
             layout.prop(prefs, "hide_inactive_constraints")
             layout.prop(prefs, "all_entities_selectable")
@@ -148,7 +150,7 @@ class VIEW3D_PT_sketcher(Panel):
 
 class VIEW3D_PT_sketcher_entities(Panel):
     bl_label = "Entities"
-    bl_idname = "VIEW3D_PT_sketcher_entities"
+    bl_idname = Panels.SketcherEntities
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_category = "Sketcher"
@@ -176,7 +178,7 @@ class VIEW3D_PT_sketcher_entities(Panel):
 
             # Select operator
             props = sub.operator(
-                operators.View3D_OT_slvs_select.bl_idname,
+                Operators.Select,
                 text="",
                 emboss=False,
                 icon=("RADIOBUT_ON" if e.selected else "RADIOBUT_OFF"),
@@ -201,7 +203,7 @@ class VIEW3D_PT_sketcher_entities(Panel):
 
             # Context menu
             props = sub.operator(
-                operators.View3D_OT_slvs_context_menu.bl_idname,
+                Operators.ContextMenu,
                 text="",
                 icon="OUTLINER_DATA_GP_LAYER",
                 emboss=False
@@ -212,7 +214,7 @@ class VIEW3D_PT_sketcher_entities(Panel):
 
             # Delete operator
             props = sub.operator(
-                operators.View3D_OT_slvs_delete_entity.bl_idname,
+                Operators.DeleteEntity,
                 text="",
                 icon="X",
                 emboss=False
@@ -223,7 +225,7 @@ class VIEW3D_PT_sketcher_entities(Panel):
 
 class VIEW3D_PT_sketcher_constraints(Panel):
     bl_label = "Constraints"
-    bl_idname = "VIEW3D_PT_sketcher_constraints"
+    bl_idname = Panels.SketcherContraints
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_category = "Sketcher"
@@ -235,7 +237,7 @@ class VIEW3D_PT_sketcher_constraints(Panel):
         col = box.column(align=True)
         col.scale_y = 0.8
 
-        layout.operator_enum(operators.View3D_OT_slvs_set_all_constraints_visibility.bl_idname, "visibility")
+        layout.operator_enum(Operators.SetAllConstraintsVisibility, "visibility")
 
         sketch = context.scene.sketcher.active_sketch
         for c in context.scene.sketcher.constraints.all:
@@ -265,7 +267,7 @@ class VIEW3D_PT_sketcher_constraints(Panel):
 
             # Context menu, shows constraint name
             props = sub.operator(
-                operators.View3D_OT_slvs_context_menu.bl_idname,
+                Operators.ContextMenu,
                 text=str(c),
                 emboss=False
                 )
@@ -280,7 +282,7 @@ class VIEW3D_PT_sketcher_constraints(Panel):
 
             # Delete operator
             props = sub.operator(
-                operators.View3D_OT_slvs_delete_constraint.bl_idname,
+                Operators.DeleteConstraint,
                 text="",
                 icon="X",
                 emboss=False
@@ -292,13 +294,13 @@ class VIEW3D_PT_sketcher_constraints(Panel):
 
 class VIEW3D_MT_sketches(Menu):
     bl_label = "Sketches"
-    bl_idname = "VIEW3D_MT_sketches"
+    bl_idname = Menus.Sketches
 
     def draw(self, context):
         layout = self.layout
         sse = context.scene.sketcher.entities
         layout.operator(
-            operators.View3D_OT_slvs_add_sketch.bl_idname
+            Operators.AddSketch
         ).wait_for_input = True
 
         if len(sse.sketches):
@@ -306,7 +308,7 @@ class VIEW3D_MT_sketches(Menu):
 
         for i, sk in enumerate(sse.sketches):
             layout.operator(
-                operators.View3D_OT_slvs_set_active_sketch.bl_idname, text=sk.name
+                Operators.SetActiveSketch, text=sk.name
             ).index = sk.slvs_index
 
 
@@ -322,7 +324,7 @@ def sketch_selector(context, layout, is_header=False, show_selector=True):
         name = sketch.name
 
         row.operator(
-            operators.View3D_OT_slvs_set_active_sketch.bl_idname,
+            Operators.SetActiveSketch,
             text="Leave: " + name,
             icon="BACK",
             depress=True,
@@ -335,7 +337,7 @@ def sketch_selector(context, layout, is_header=False, show_selector=True):
         row.scale_y = scale_y
         # TODO: Don't show text when is_header
         row.operator(
-            operators.View3D_OT_slvs_add_sketch.bl_idname, icon="ADD"
+            Operators.AddSketch, icon="ADD"
         ).wait_for_input = True
 
         if not is_header:
@@ -348,7 +350,7 @@ def draw_object_context_menu(self, context):
     ob = context.active_object
     row = layout.row()
 
-    props = row.operator(operators.View3D_OT_slvs_set_active_sketch.bl_idname, text="Edit Sketch")
+    props = row.operator(Operators.SetActiveSketch, text="Edit Sketch")
 
     if ob and ob.sketch_index != -1:
         row.active = True

--- a/workspacetools.py
+++ b/workspacetools.py
@@ -1,140 +1,16 @@
 from bpy.types import WorkSpaceTool
-from . import operators, gizmos
 import os
-
-tool_prefix = "sketcher."
-
+from .declarations import GizmoGroups, Operators, WorkSpaceTools
+from .keymaps import tool_access, get_key_map_desc
+from .operators import numeric_events
 
 def get_addon_icon_path(icon_name):
     return os.path.join(os.path.dirname(__file__), "icons", icon_name)
 
 
-def tool_invoke_kmi(button, tool, operator):
-    return (
-        operators.View3D_OT_invoke_tool.bl_idname,
-        {"type": button, "value": "PRESS"},
-        {"properties": [("tool_name", tool), ("operator", operator)]},
-    )
-
-constraint_access = (
-    (
-        operators.VIEW3D_OT_slvs_add_coincident.bl_idname,
-        {"type": "C", "value": "PRESS", "shift": True},
-        {"properties": [("wait_for_input", True), ]}
-    ),
-    (
-        operators.VIEW3D_OT_slvs_add_vertical.bl_idname,
-        {"type": "V", "value": "PRESS", "shift": True},
-        {"properties": [("wait_for_input", True), ]}
-    ),
-    (
-        operators.VIEW3D_OT_slvs_add_horizontal.bl_idname,
-        {"type": "H", "value": "PRESS", "shift": True},
-        {"properties": [("wait_for_input", True), ]}
-    ),
-    (
-        operators.VIEW3D_OT_slvs_add_equal.bl_idname,
-        {"type": "E", "value": "PRESS", "shift": True},
-        {"properties": [("wait_for_input", True), ]}
-    ),
-    (
-        operators.VIEW3D_OT_slvs_add_parallel.bl_idname,
-        {"type": "A", "value": "PRESS", "shift": True},
-        {"properties": [("wait_for_input", True), ]}
-    ),
-    (
-        operators.VIEW3D_OT_slvs_add_perpendicular.bl_idname,
-        {"type": "P", "value": "PRESS", "shift": True},
-        {"properties": [("wait_for_input", True), ]}
-    ),
-    (
-        operators.VIEW3D_OT_slvs_add_tangent.bl_idname,
-        {"type": "T", "value": "PRESS", "shift": True},
-        {"properties": [("wait_for_input", True), ]}
-    ),
-    (
-        operators.VIEW3D_OT_slvs_add_midpoint.bl_idname,
-        {"type": "M", "value": "PRESS", "shift": True},
-        {"properties": [("wait_for_input", True), ]}
-    ),
-    (
-        operators.VIEW3D_OT_slvs_add_ratio.bl_idname,
-        {"type": "R", "value": "PRESS", "shift": True},
-        {"properties": [("wait_for_input", True), ]}
-    ),
-
-    # Dimensional Constraints
-    (
-        operators.VIEW3D_OT_slvs_add_distance.bl_idname,
-        {"type": "D", "value": "PRESS", "alt": True},
-        {"properties": [("wait_for_input", True), ]}
-    ),
-    (
-        operators.VIEW3D_OT_slvs_add_distance.bl_idname,
-        {"type": "V", "value": "PRESS", "alt": True},
-        {"properties": [("wait_for_input", True), ("align", "VERTICAL")]}
-    ),
-    (
-        operators.VIEW3D_OT_slvs_add_distance.bl_idname,
-        {"type": "H", "value": "PRESS", "alt": True},
-        {"properties": [("wait_for_input", True), ("align", "HORIZONTAL")]}
-    ),
-    (
-        operators.VIEW3D_OT_slvs_add_angle.bl_idname,
-        {"type": "A", "value": "PRESS", "alt": True},
-        {"properties": [("wait_for_input", True), ]}
-    ),
-    (
-        operators.VIEW3D_OT_slvs_add_diameter.bl_idname,
-        {"type": "O", "value": "PRESS", "alt": True},
-        {"properties": [("wait_for_input", True), ]}
-    ),
-    (
-        operators.VIEW3D_OT_slvs_add_diameter.bl_idname,
-        {"type": "R", "value": "PRESS", "alt": True},
-        {"properties": [("wait_for_input", True), ("setting", True)]}
-    ),
-
-)
-
-tool_access = (
-    tool_invoke_kmi(
-        "P",
-        "sketcher.slvs_add_point2d",
-        operators.View3D_OT_slvs_add_point2d.bl_idname,
-    ),
-    tool_invoke_kmi(
-        "L", "sketcher.slvs_add_line2d", operators.View3D_OT_slvs_add_line2d.bl_idname
-    ),
-    tool_invoke_kmi(
-        "C",
-        "sketcher.slvs_add_circle2d",
-        operators.View3D_OT_slvs_add_circle2d.bl_idname,
-    ),
-    tool_invoke_kmi(
-        "A", "sketcher.slvs_add_arc2d", operators.View3D_OT_slvs_add_arc2d.bl_idname
-    ),
-    tool_invoke_kmi(
-        "R",
-        "sketcher.slvs_add_rectangle",
-        operators.View3D_OT_slvs_add_rectangle.bl_idname,
-    ),
-    tool_invoke_kmi(
-        "Y",
-        "sketcher.slvs_trim",
-        operators.View3D_OT_slvs_trim.bl_idname,
-    ),
-    (
-        operators.View3D_OT_slvs_add_sketch.bl_idname,
-        {"type": "S", "value": "PRESS"},
-        {"properties": [("wait_for_input", True), ]}
-    ),
-    *constraint_access,
-)
-
 def tool_numeric_invoke_km(operator):
     km = []
-    for event in operators.numeric_events:
+    for event in numeric_events:
         km.append(
             (
                 operator,
@@ -148,44 +24,44 @@ def tool_numeric_invoke_km(operator):
 class VIEW3D_T_slvs_select(WorkSpaceTool):
     bl_space_type = "VIEW_3D"
     bl_context_mode = "OBJECT"
-    bl_idname = tool_prefix + "slvs_select"
+    bl_idname = WorkSpaceTools.Select
     bl_label = "Solvespace Select"
     bl_description = "Select Solvespace Entities"
     bl_icon = "ops.generic.select"
-    bl_widget = gizmos.VIEW3D_GGT_slvs_preselection.bl_idname
+    bl_widget = GizmoGroups.Preselection
     bl_keymap = (
         (
-            operators.View3D_OT_slvs_select_all.bl_idname,
+            Operators.SelectAll,
             {"type": "ESC", "value": "PRESS"},
             {"properties": [("deselect", True)]},
         ),
         (
-            operators.View3D_OT_slvs_select_all.bl_idname,
+            Operators.SelectAll,
             {"type": "A", "value": "PRESS", "ctrl": True},
             {"properties": [("deselect", False)]},
         ),
         (
-            operators.View3D_OT_slvs_select.bl_idname,
+            Operators.Select,
             {"type": "LEFTMOUSE", "value": "CLICK"},
             None,
         ),
         (
-            operators.View3D_OT_slvs_tweak.bl_idname,
+            Operators.Tweak,
             {"type": "LEFTMOUSE", "value": "CLICK_DRAG"},
             None,
         ),
         (
-            operators.View3D_OT_slvs_tweak.bl_idname,
+            Operators.Tweak,
             {"type": "LEFTMOUSE", "value": "PRESS", "ctrl": True},
             None,
         ),
         (
-            operators.View3D_OT_slvs_context_menu.bl_idname,
+            Operators.ContextMenu,
             {"type": "RIGHTMOUSE", "value": "PRESS"},
             None,
         ),
         (
-            operators.View3D_OT_slvs_delete_entity.bl_idname,
+            Operators.DeleteEntity,
             {"type": "DEL", "value": "PRESS"},
             None,
         ),
@@ -193,7 +69,7 @@ class VIEW3D_T_slvs_select(WorkSpaceTool):
     )
 
     def draw_settings(context, layout, tool):
-        props = tool.operator_properties(operators.View3D_OT_slvs_select.bl_idname)
+        props = tool.operator_properties(Operators.Select)
 
 
 tool_keymap = (
@@ -220,8 +96,8 @@ def operator_access(operator):
         ),
     )
 
-
 class GenericStateTool():
+
     @classmethod
     def bl_description(cls, context, item, keymap):
         op_name = cls.bl_operator if hasattr(cls, "bl_operator") else ""
@@ -231,168 +107,167 @@ class GenericStateTool():
             import _bpy
             desc = _bpy.ops.get_rna_type(op_name).description
 
-        for kmi in tool_access:
-            if kmi[0] == operators.View3D_OT_invoke_tool.bl_idname:
-                props = kmi[2]["properties"]
-                i = [prop[0] for prop in props].index("tool_name")
-                if props[i][1] == cls.bl_idname:
-                    button = kmi[1]["type"]
-                    desc += "\n\nInvoke Shortcut: " + button
-
         return desc
+    
+    def get_label(id_name, label):
+        def _filter_key_map(id_name, key_map):
+            properties = key_map[2]["properties"]
+            tool_name_index = [property[0] for property in properties].index("tool_name")
+            return properties[tool_name_index][1] == id_name
+        return f"{label}{get_key_map_desc(Operators.InvokeTool, id_name, _filter_key_map)}"
 
 class View3D_T_slvs_add_point3d(GenericStateTool, WorkSpaceTool):
     bl_space_type = "VIEW_3D"
     bl_context_mode = "OBJECT"
-    bl_idname = tool_prefix + "slvs_add_point3d"
-    bl_label = "Add 3D Point"
-    bl_operator = operators.View3D_OT_slvs_add_point3d.bl_idname
+    bl_idname = WorkSpaceTools.AddPoint3D
+    bl_label = GenericStateTool.get_label(WorkSpaceTools.AddPoint3D, "Add 3D Point")
+    bl_operator = Operators.AddPoint3D
     bl_icon = get_addon_icon_path("ops.bgs.add_point")
-    bl_widget = gizmos.VIEW3D_GGT_slvs_preselection.bl_idname
+    bl_widget = GizmoGroups.Preselection
     bl_keymap = (
         *tool_keymap,
         *tool_access,
-        *operator_access(operators.View3D_OT_slvs_add_point3d.bl_idname),
+        *operator_access(Operators.AddPoint3D),
     )
 
 
 class View3D_T_slvs_add_point2d(GenericStateTool, WorkSpaceTool):
     bl_space_type = "VIEW_3D"
     bl_context_mode = "OBJECT"
-    bl_idname = tool_prefix + "slvs_add_point2d"
-    bl_label = "Add 2D Point"
-    bl_operator = operators.View3D_OT_slvs_add_point2d.bl_idname
+    bl_idname = WorkSpaceTools.AddPoint2D
+    bl_label = GenericStateTool.get_label(WorkSpaceTools.AddPoint2D, "Add 2D Point")
+    bl_operator = Operators.AddPoint2D
     bl_icon = get_addon_icon_path("ops.bgs.add_point")
-    bl_widget = gizmos.VIEW3D_GGT_slvs_preselection.bl_idname
+    bl_widget = GizmoGroups.Preselection
     bl_keymap = (
         *tool_keymap,
         *tool_access,
-        *operator_access(operators.View3D_OT_slvs_add_point2d.bl_idname),
+        *operator_access(Operators.AddPoint2D),
     )
 
 
 class View3D_T_slvs_add_line3d(GenericStateTool, WorkSpaceTool):
     bl_space_type = "VIEW_3D"
     bl_context_mode = "OBJECT"
-    bl_idname = tool_prefix + "slvs_add_line3d"
-    bl_label = "Add 3D Line"
-    bl_operator = operators.View3D_OT_slvs_add_line3d.bl_idname
+    bl_idname = WorkSpaceTools.AddLine3D
+    bl_label = GenericStateTool.get_label(WorkSpaceTools.AddLine3D, "Add 3D Line")
+    bl_operator = Operators.AddLine3D
     bl_icon = "ops.gpencil.primitive_line"
-    bl_widget = gizmos.VIEW3D_GGT_slvs_preselection.bl_idname
+    bl_widget = GizmoGroups.Preselection
     bl_keymap = (
         *tool_keymap,
         *tool_access,
-        *operator_access(operators.View3D_OT_slvs_add_line3d.bl_idname),
+        *operator_access(Operators.AddLine3D),
     )
 
     def draw_settings(context, layout, tool):
-        props = tool.operator_properties(operators.View3D_OT_slvs_add_line3d.bl_idname)
+        props = tool.operator_properties(Operators.AddLine3D)
         layout.prop(props, "continuous_draw")
 
 
 class View3D_T_slvs_add_line2d(GenericStateTool, WorkSpaceTool):
     bl_space_type = "VIEW_3D"
     bl_context_mode = "OBJECT"
-    bl_idname = tool_prefix + "slvs_add_line2d"
-    bl_label = "Add 2D Line"
-    bl_operator = operators.View3D_OT_slvs_add_line2d.bl_idname
+    bl_idname = WorkSpaceTools.AddLine2D
+    bl_label = GenericStateTool.get_label(WorkSpaceTools.AddLine2D, "Add 2D Line")
+    bl_operator = Operators.AddLine2D
     bl_icon = "ops.gpencil.primitive_line"
-    bl_widget = gizmos.VIEW3D_GGT_slvs_preselection.bl_idname
+    bl_widget = GizmoGroups.Preselection
     bl_keymap = (
         *tool_keymap,
         *tool_access,
-        *operator_access(operators.View3D_OT_slvs_add_line2d.bl_idname),
+        *operator_access(Operators.AddLine2D),
     )
 
     def draw_settings(context, layout, tool):
-        props = tool.operator_properties(operators.View3D_OT_slvs_add_line2d.bl_idname)
+        props = tool.operator_properties(Operators.AddLine2D)
         layout.prop(props, "continuous_draw")
 
 
 class View3D_T_slvs_add_circle2d(GenericStateTool, WorkSpaceTool):
     bl_space_type = "VIEW_3D"
     bl_context_mode = "OBJECT"
-    bl_idname = tool_prefix + "slvs_add_circle2d"
-    bl_label = "Add 2D Circle"
-    bl_operator = operators.View3D_OT_slvs_add_circle2d.bl_idname
+    bl_idname = WorkSpaceTools.AddCircle2D
+    bl_label = GenericStateTool.get_label(WorkSpaceTools.AddCircle2D, "Add 2D Circle")
+    bl_operator = Operators.AddCircle2D
     bl_icon = "ops.gpencil.primitive_circle"
-    bl_widget = gizmos.VIEW3D_GGT_slvs_preselection.bl_idname
+    bl_widget = GizmoGroups.Preselection
     bl_keymap = (
         *tool_keymap,
         *tool_access,
-        *operator_access(operators.View3D_OT_slvs_add_circle2d.bl_idname),
+        *operator_access(Operators.AddCircle2D),
     )
 
 
 class View3D_T_slvs_add_arc2d(GenericStateTool, WorkSpaceTool):
     bl_space_type = "VIEW_3D"
     bl_context_mode = "OBJECT"
-    bl_idname = tool_prefix + "slvs_add_arc2d"
-    bl_label = "Add 2D Arc"
-    bl_operator = operators.View3D_OT_slvs_add_arc2d.bl_idname
+    bl_idname = WorkSpaceTools.AddArc2D
+    bl_label = GenericStateTool.get_label(WorkSpaceTools.AddArc2D, "Add 2D Arc")
+    bl_operator = Operators.AddArc2D
     bl_icon = "ops.gpencil.primitive_arc"
-    bl_widget = gizmos.VIEW3D_GGT_slvs_preselection.bl_idname
+    bl_widget = GizmoGroups.Preselection
     bl_keymap = (
         *tool_keymap,
         *tool_access,
-        *operator_access(operators.View3D_OT_slvs_add_arc2d.bl_idname),
+        *operator_access(Operators.AddArc2D),
     )
 
 
 class View3D_T_slvs_add_rectangle(GenericStateTool, WorkSpaceTool):
     bl_space_type = "VIEW_3D"
     bl_context_mode = "OBJECT"
-    bl_idname = tool_prefix + "slvs_add_rectangle"
-    bl_label = "Add Rectangle"
-    bl_operator = operators.View3D_OT_slvs_add_rectangle.bl_idname
+    bl_idname = WorkSpaceTools.AddRectangle
+    bl_label = GenericStateTool.get_label(WorkSpaceTools.AddRectangle, "Add Rectangle")
+    bl_operator = Operators.AddRectangle
     bl_icon = "ops.gpencil.primitive_box"
-    bl_widget = gizmos.VIEW3D_GGT_slvs_preselection.bl_idname
+    bl_widget = GizmoGroups.Preselection
     bl_keymap = (
         *tool_keymap,
         *tool_access,
-        *operator_access(operators.View3D_OT_slvs_add_rectangle.bl_idname),
+        *operator_access(Operators.AddRectangle),
     )
 
 class View3D_T_slvs_trim(GenericStateTool, WorkSpaceTool):
     bl_space_type = "VIEW_3D"
     bl_context_mode = "OBJECT"
-    bl_idname = tool_prefix + "slvs_trim"
-    bl_label = "Trim"
-    bl_operator = operators.View3D_OT_slvs_trim.bl_idname
+    bl_idname = WorkSpaceTools.Trim
+    bl_label = GenericStateTool.get_label(WorkSpaceTools.Trim, "Trim")
+    bl_operator = Operators.Trim
     bl_icon = "ops.gpencil.stroke_cutter"
-    bl_widget = gizmos.VIEW3D_GGT_slvs_preselection.bl_idname
+    bl_widget = GizmoGroups.Preselection
     bl_keymap = (
         *tool_keymap,
         *tool_access,
-        *operator_access(operators.View3D_OT_slvs_trim.bl_idname),
+        *operator_access(Operators.Trim),
     )
 
 class View3D_T_slvs_add_workplane_face(GenericStateTool, WorkSpaceTool):
     bl_space_type = "VIEW_3D"
     bl_context_mode = "OBJECT"
-    bl_idname = tool_prefix + "slvs_add_workplane_face"
-    bl_label = "Add Workplane on mesh face"
-    bl_operator = operators.View3D_OT_slvs_add_workplane_face.bl_idname
+    bl_idname = WorkSpaceTools.AddWorkplaneFace
+    bl_label = GenericStateTool.get_label(WorkSpaceTools.AddWorkplaneFace, "Add Workplane on mesh face")
+    bl_operator = Operators.AddWorkPlaneFace
     bl_icon = "ops.mesh.primitive_grid_add_gizmo"
-    bl_widget = gizmos.VIEW3D_GGT_slvs_preselection.bl_idname
+    bl_widget = GizmoGroups.Preselection
     bl_keymap = (
         *tool_keymap,
         *tool_access,
-        *operator_access(operators.View3D_OT_slvs_add_workplane_face.bl_idname),
+        *operator_access(Operators.AddWorkPlaneFace),
     )
 
 class View3D_T_slvs_add_workplane(GenericStateTool, WorkSpaceTool):
     bl_space_type = "VIEW_3D"
     bl_context_mode = "OBJECT"
-    bl_idname = tool_prefix + "slvs_add_workplane"
-    bl_label = "Add Workplane"
-    bl_operator = operators.View3D_OT_slvs_add_workplane.bl_idname
+    bl_idname = WorkSpaceTools.AddWorkplane
+    bl_label = GenericStateTool.get_label(WorkSpaceTools.AddWorkplane, "Add Workplane")
+    bl_operator = Operators.AddWorkPlane
     bl_icon = "ops.mesh.primitive_grid_add_gizmo"
-    bl_widget = gizmos.VIEW3D_GGT_slvs_preselection.bl_idname
+    bl_widget = GizmoGroups.Preselection
     bl_keymap = (
         *tool_keymap,
         *tool_access,
-        *operator_access(operators.View3D_OT_slvs_add_workplane.bl_idname),
+        *operator_access(Operators.AddWorkPlane),
     )
 
 


### PR DESCRIPTION
This is proposal for #95 

- Extract out all the operators' names into a separate module to be
  reused without introducing cycle dependencies. Also put all the names
  in one place
- Original thought was to have each operator defines its own keymap (makes
  more sense in term single responsibility) but due to the nature of key
  mapping where management/cross reference are more important, move them
  to a common place keymaps.py to be shared across.

Multiple shortcuts:
![image](https://user-images.githubusercontent.com/29285869/174170305-8775f0aa-9fbf-4f83-9833-d862bdf31175.png)

Single shortcut:
![image](https://user-images.githubusercontent.com/29285869/174170365-99522ec2-b91c-44ab-bfff-d080c3b5ae8e.png)
