### PR TITLE
limit length of opposite-side diameter leader / scale overshoot:  comments addressed

### DIFF
--- a/gizmos.py
+++ b/gizmos.py
@@ -263,6 +263,7 @@ def draw_arrow_shape(target, shoulder, width, is_3d=False):
 def get_overshoot(scale, dir):
     if dir == 0:
         return 0
+    #use factor of 0.005 for one-half arrowhead
     overshoot = scale * 0.005 * functions.get_prefs().arrow_scale
     return -math.copysign(overshoot, dir)
 

--- a/gizmos.py
+++ b/gizmos.py
@@ -259,11 +259,12 @@ def draw_arrow_shape(target, shoulder, width, is_3d=False):
         ((shoulder + v)),
     )
 
-DEFAULT_OVERSHOOT = 0.01
+
 def get_overshoot(scale, dir):
     if dir == 0:
         return 0
-    return -math.copysign(DEFAULT_OVERSHOOT * scale, dir)
+    overshoot = (scale/100) * functions.get_prefs().arrow_scale
+    return -math.copysign(overshoot, dir)
 
 
 def get_arrow_size(dist, scale):
@@ -457,9 +458,10 @@ class VIEW3D_GT_slvs_diameter(Gizmo, ConstraintGizmoGeneric):
     )
 
     def _create_shape(self, context, constr, select=False):
+        ui_scale = context.preferences.system.ui_scale
         angle = constr.leader_angle
-        offset = constr.draw_offset / context.preferences.system.ui_scale
-        dist = constr.radius / context.preferences.system.ui_scale
+        offset = constr.draw_offset / ui_scale
+        dist = constr.radius / ui_scale
 
         rv3d = context.region_data
 
@@ -514,10 +516,10 @@ class VIEW3D_GT_slvs_diameter(Gizmo, ConstraintGizmoGeneric):
                     ),
                     p2,
                     functions.pol2cart(offset, angle),
-                    functions.pol2cart(offset, angle+math.pi),
+                    functions.pol2cart(min(offset, dist + (4 * arrow_2[0])), angle + math.pi), #limit length to 4 arrowheads
                     p1,
                     *draw_arrow_shape(
-                        p1, functions.pol2cart(dist + arrow_2[0], angle+math.pi), arrow_2[1]
+                        p1, functions.pol2cart(dist + arrow_2[0], angle + math.pi), arrow_2[1]
                     ),
                 )
 

--- a/gizmos.py
+++ b/gizmos.py
@@ -263,14 +263,14 @@ def draw_arrow_shape(target, shoulder, width, is_3d=False):
 def get_overshoot(scale, dir):
     if dir == 0:
         return 0
-    overshoot = (scale/100) * functions.get_prefs().arrow_scale
+    overshoot = scale * 0.005 * functions.get_prefs().arrow_scale
     return -math.copysign(overshoot, dir)
 
 
 def get_arrow_size(dist, scale):
     size = math.copysign(
         min(
-            scale * functions.get_prefs().arrow_scale / 100,
+            scale * 0.01 * functions.get_prefs().arrow_scale,
             abs(dist * 0.8),
         ),
         dist,
@@ -516,7 +516,7 @@ class VIEW3D_GT_slvs_diameter(Gizmo, ConstraintGizmoGeneric):
                     ),
                     p2,
                     functions.pol2cart(offset, angle),
-                    functions.pol2cart(min(offset, dist + (4 * arrow_2[0])), angle + math.pi), #limit length to 4 arrowheads
+                    functions.pol2cart(dist + (3 * arrow_2[0]), angle + math.pi), #limit length to 3 arrowheads
                     p1,
                     *draw_arrow_shape(
                         p1, functions.pol2cart(dist + arrow_2[0], angle + math.pi), arrow_2[1]


### PR DESCRIPTION
These improvements are needed (IMO) to make my earlier changes more correct.

First, making the Arrow Size user-settable suddenly made the overshoot constant seem out of proportion.  I've roughly approximated one arrowhead length for the overshoot.

Second, the Diameter constraint (outside mode) should not let the opposite-side leader get out of hand.  I've set a limit of 4 arrowheads  (BTW a great measurement unit!)
