### PR TITLE
Fix description for constraints' visibility setters

### DIFF
--- a/declarations.py
+++ b/declarations.py
@@ -76,6 +76,11 @@ class Panels(str, Enum):
     SketcherEntities = "VIEW3D_PT_sketcher_entities"
 
 
+class VisibilityTypes(str, Enum):
+    Hide = "HIDE"
+    Show = "SHOW"
+
+
 class WorkSpaceTools(str, Enum):
     AddArc2D = "sketcher.slvs_add_arc2d"
     AddCircle2D = "sketcher.slvs_add_circle2d"

--- a/operators.py
+++ b/operators.py
@@ -3,7 +3,7 @@ import bpy, bgl, gpu
 from bpy.types import Operator
 from . import global_data, functions, class_defines, convertors
 from .keymaps import get_key_map_desc
-from .declarations import Operators, GizmoGroups, WorkSpaceTools
+from .declarations import Operators, GizmoGroups, VisibilityTypes, WorkSpaceTools
 
 from bpy.props import (
     IntProperty,
@@ -3498,6 +3498,11 @@ class VIEW3D_OT_slvs_add_ratio(
 class View3D_OT_slvs_set_all_constraints_visibility(Operator, HighlightElement):
     """Set all constraints' visibility
     """
+    _visibility_items = [
+        (VisibilityTypes.Hide, "Hide all", "Hide all constraints"),
+        (VisibilityTypes.Show, "Show all", "Show all constraints"),
+    ]
+
     bl_idname = Operators.SetAllConstraintsVisibility
     bl_label = "Set all constraints' visibility"
     bl_options = {"UNDO"}
@@ -3506,14 +3511,18 @@ class View3D_OT_slvs_set_all_constraints_visibility(Operator, HighlightElement):
     visibility: EnumProperty(
         name="Visibility",
         description="Visiblity",
-        items=[
-            ("HIDE", "Hide all", "Hide all constraints"),
-            ("SHOW", "Show all", "Show all constraints"),
-        ])
+        items=_visibility_items)
 
     @classmethod
     def poll(cls, context):
         return True
+
+    @classmethod
+    def description(cls, context, properties):
+        for vi in cls._visibility_items:
+            if vi[0] == properties.visibility:
+                return vi[2]
+        return None
 
     def execute(self, context):
         constraint_lists = context.scene.sketcher.constraints.get_lists()


### PR DESCRIPTION
Before the fix, hovering "Hide all"/"Show all", it shows tooltips using the description of the operator which is "Set all constraints' visibility" for both.

This fix now is to use correct description using the enum item's description instead.