### PR TITLE
VSCodium/VSCode: Remote debugger

### DIFF
--- a/.vscode/debugpy_port.py
+++ b/.vscode/debugpy_port.py
@@ -1,0 +1,19 @@
+import debugpy
+
+try:
+    from colorama import Fore
+    YELLOW, GREEN, RED, RESET = Fore.YELLOW, Fore.GREEN, Fore.RED, Fore.RESET
+except ImportError:
+    YELLOW, GREEN, RED, RESET = [""]*4
+
+# https://code.visualstudio.com/docs/python/debugging#_debugging-by-attaching-over-a-network-connection
+
+# 5678 is the default attach port in the VS Code debug configurations. Unless a host and port are specified, host defaults to 127.0.0.1
+debugpy.listen(5678)
+print(f"{YELLOW}Waiting for debugger attach{RESET}")
+debugpy.wait_for_client()
+if debugpy.is_client_connected():
+    print(f"{GREEN}Debugger attached to client{RESET}")
+else:
+    print(f"{RED}Failed to connect to client{RESET}")
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,40 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": "Pytest+debugger",
+            "type": "python",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "preLaunchTask": "Run Blender+testing",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ],
+            "justMyCode": true
+        },
+        {
+            "name": "Interactive+debugger",
+            "type": "python",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "preLaunchTask": "Run Blender interactively",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ],
+            "justMyCode": true
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,65 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Blender+testing",
+            "detail": "Runs testfiles using Blender in the background + opens debugpy port and waits for connection",
+            "command": "blender",
+            "args": ["--background", "--addons", "CAD_Sketcher","--python","./.vscode/debugpy_port.py","--python","./testing/__init__.py", "--", "--log_level=DEBUG"],
+            "type": "shell",
+            "isBackground": true,
+            "problemMatcher": {
+                "owner": "python",
+                "source": "python",
+                "fileLocation": ["relative", "${workspaceFolder}"],
+                "pattern": {
+                    // Example error that we want to regex-catch
+                    //   File "/abs/path/to/CAD_Sketcher/class_defines.py", line 3467, in register
+                    //     bpy.utils.register_class(cls)
+                    //   ValueError: bpy_struct "SlvsPoint3D" registration error: 'slvs_index' PointerProperty could not register (see previous error)
+                    "regexp": "^ *File \"([\/\\w.]+)\", line (\\d+), in (\\w+)\n *(.*)\\n(\\w+: .*)$",
+                    "file": 1,
+                    "line": 2,
+                    // "message": 3, // The function name
+                    "code": 4,
+                    "message": 5
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^Blender.*$",
+                    "endsPattern": "Waiting for debugger attach", // See debugpy_port.py
+                }
+            }
+        },
+        {
+            "label": "Run Blender interactively",
+            "detail": "Starts remote debugpy session and Blender gui with solely this addon activated",
+            "command": "blender",
+            "args": ["--addons", "CAD_Sketcher", "--python","./.vscode/debugpy_port.py", "--", "--log_level=DEBUG", "--interactive"],
+            "type": "shell",
+            "isBackground": true,
+            "problemMatcher": {
+                "owner": "python",
+                "source": "python",
+                "fileLocation": ["relative", "${workspaceFolder}"],
+                "pattern": {
+                    // Example error that we want to regex-catch
+                    //   File "/abs/path/to/CAD_Sketcher/class_defines.py", line 3467, in register
+                    //     bpy.utils.register_class(cls)
+                    //   ValueError: bpy_struct "SlvsPoint3D" registration error: 'slvs_index' PointerProperty could not register (see previous error)
+                    "regexp": "^ *File \"([\/\\w.]+)\", line (\\d+), in (\\w+)\n *(.*)\\n(\\w+: .*)$",
+                    "file": 1,
+                    "line": 2,
+                    // "message": 3, // The function name
+                    "code": 4,
+                    "message": 5
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "^Blender.*$",
+                    "endsPattern": "Waiting for debugger attach", // See debugpy_port.py
+                }
+            }
+        },
+    ]
+}


### PR DESCRIPTION
Adds config files for Codium, / VS Code to
- start Blender with the CADSketcher add on
- Create a remote debug session in Blender
- Connect to said remote debugger

Introduces optional dependency to `colorama` for coloring stdout if it's on a terminal

I will make a short write-up of the steps to set the dev env up for linux (requires to add a symlink of the CAD_Sketcher repo to the Blender add-on folder)