### PR TITLE
WIP (one bug known) add circle-line and circle-point distance constraint

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -3549,6 +3549,14 @@ class View3D_OT_slvs_delete_constraint(Operator, HighlightElement):
         constr = constraints.get_from_type_index(self.type, self.index)
         logger.debug("Delete: {}".format(constr))
 
+        for c in constr.constr_delete:
+            constraints.remove(c)
+        constr.constr_delete.clear()
+
+        for e in constr.entity_delete:
+            context.scene.sketcher.entities.remove(e)
+        constr.entity_delete.clear()
+
         constraints.remove(constr)
 
         sketch = context.scene.sketcher.active_sketch


### PR DESCRIPTION
i could not find a native py-slvs function for this constraint, so i faked it with an invisible construction line from the circle's centerpoint to the target and a point on the circle and a point on the target line (if applicable).

Constraints are applied to tie it all together.

The generic constraint now has lists for temporary, subordinate entities and constraints.  They will be deleted when the primary constraint is deleted.

HOWEVER, THERE IS STILL ABUG that leaves one subordinate constraint alive after its parent constraint is deleted.
Anybody who spots the bug wins a gold star!
