### PR TITLE
replace pi/tau constants with fractions of a turn

### DIFF
--- a/class_defines.py
+++ b/class_defines.py
@@ -31,9 +31,9 @@ from .solver import solve_system, Solver
 from .functions import pol2cart, unique_attribute_setter
 from .declarations import Operators
 from .global_data import WpReq
+from .utilities.constants import FULL_TURN, HALF_TURN, QUARTER_TURN
 
 logger = logging.getLogger(__name__)
-
 
 class SlvsGenericEntity:
 
@@ -1172,7 +1172,7 @@ class SlvsArc(SlvsGenericEntity, PropertyGroup, Entity2D):
             angle = functions.range_2pi(p2.angle_signed(p1))
 
             # TODO: resolution should depend on segment length?!
-            segments = round(CURVE_RESOLUTION * (angle / (math.pi * 2)))
+            segments = round(CURVE_RESOLUTION * (angle / FULL_TURN))
 
             coords = functions.coords_arc_2d(
                 0, 0, radius, segments, angle=angle, offset=offset
@@ -1232,7 +1232,7 @@ class SlvsArc(SlvsGenericEntity, PropertyGroup, Entity2D):
             return point == self.end
 
     def bezier_segment_count(self):
-        max_angle = math.pi / 2
+        max_angle = QUARTER_TURN
         return math.ceil(self.angle / max_angle)
 
     def bezier_point_count(self):
@@ -1270,8 +1270,8 @@ class SlvsArc(SlvsGenericEntity, PropertyGroup, Entity2D):
         if set_startpoint:
             startpoint.co = locations[0].to_3d()
 
-        n = 2 * math.pi / angle
-        q = (4 / 3) * math.tan(math.pi / (2 * n))
+        n = FULL_TURN / angle
+        q = (4 / 3) * math.tan(HALF_TURN / (2 * n))
         base_offset = Vector((radius, q * radius))
 
         create_bezier_curve(
@@ -1504,12 +1504,12 @@ class SlvsCircle(SlvsGenericEntity, PropertyGroup, Entity2D):
         bezier_points = [startpoint, *midpoints]
 
         locations = get_bezier_curve_midpoint_positions(
-            self, segment_count, bezier_points, 2 * math.pi, cyclic=True
+            self, segment_count, bezier_points, FULL_TURN, cyclic=True
         )
-        angle = 2 * math.pi / segment_count
+        angle = FULL_TURN / segment_count
 
-        n = 2 * math.pi / angle
-        q = (4 / 3) * math.tan(math.pi / (2 * n))
+        n = FULL_TURN / angle
+        q = (4 / 3) * math.tan(HALF_TURN / (2 * n))
         base_offset = Vector((radius, q * radius))
 
         create_bezier_curve(
@@ -1944,7 +1944,7 @@ class SlvsEntities(PropertyGroup):
             self.origin = p
 
         # axis
-        pi_2 = math.pi / 2
+        pi_2 = QUARTER_TURN
         for name, angles in zip(
             ("origin_axis_X", "origin_axis_Y", "origin_axis_Z"),
             (Euler((pi_2, 0.0, pi_2)), Euler((pi_2, 0.0, 0.0)), Euler()),
@@ -2448,7 +2448,7 @@ class SlvsDistance(GenericConstraint, PropertyGroup):
             line = e2
             orig = line.p1.co
             end = line.p2.co - orig
-            angle = functions.range_2pi(math.atan2(end[1], end[0])) + math.pi / 2
+            angle = functions.range_2pi(math.atan2(end[1], end[0])) + QUARTER_TURN
 
             mat_rot = Matrix.Rotation(angle, 2, "Z")
             p1 = e1.co - orig
@@ -2648,7 +2648,7 @@ class SlvsAngle(GenericConstraint, PropertyGroup):
         return self.get("setting", self.bl_rna.properties["setting"].default)
 
     def invert_angle_setter(self, setting):
-        self["value"] = math.pi - self.value
+        self["value"] = HALF_TURN - self.value
         self["setting"] = setting
 
     label = "Angle"
@@ -2700,7 +2700,7 @@ class SlvsAngle(GenericConstraint, PropertyGroup):
         )
 
         if self.setting:
-            rotation = rotation - math.pi / 2
+            rotation = rotation - QUARTER_TURN
 
         mat_rot = Matrix.Rotation(rotation, 2, "Z")
         mat_local = Matrix.Translation(origin.to_3d()) @ mat_rot.to_4x4()

--- a/functions.py
+++ b/functions.py
@@ -1,6 +1,6 @@
 from collections import deque
 import math
-from math import pi, cos, sin, tau
+from math import sin, cos
 import subprocess
 import re
 import site
@@ -20,7 +20,7 @@ from mathutils import Vector, Matrix
 from mathutils.bvhtree import BVHTree
 
 from . import global_data
-
+from .utilities.constants import FULL_TURN
 
 def get_prefs():
     return bpy.context.preferences.addons[__package__].preferences
@@ -102,7 +102,7 @@ def draw_circle_2d(cx: float, cy: float, r: float, num_segments: int):
     """ NOTE: Not used?"""
     # circle outline
     # NOTE: also see gpu_extras.presets.draw_circle_2d
-    theta = 2 * pi / num_segments
+    theta = FULL_TURN / num_segments
 
     # precalculate the sine and cosine
     c = math.cos(theta)
@@ -181,7 +181,7 @@ def draw_cube_3d(cx: float, cy: float, cz: float, width: float):
 
 def coords_circle_2d(x: float, y: float, radius: float, segments: int):
     coords = []
-    m = (1.0 / (segments - 1)) * (pi * 2)
+    m = (1.0 / (segments - 1)) * FULL_TURN
 
     for p in range(segments):
         p1 = x + cos(m * p) * radius
@@ -195,7 +195,7 @@ def coords_arc_2d(
     y: float,
     radius: float,
     segments: int,
-    angle=tau,
+    angle=FULL_TURN,
     offset: float = 0.0,
     type="LINE_STRIP",
 ):
@@ -220,7 +220,7 @@ def coords_arc_2d(
 
 def range_2pi(angle: float) -> float:
     """Map angle range -Pi/+Pi to 0/2*Pi"""
-    return (angle + tau) % tau
+    return (angle + FULL_TURN) % FULL_TURN
 
 
 def pol2cart(radius: float, angle: float) -> Vector:

--- a/gizmos.py
+++ b/gizmos.py
@@ -6,6 +6,7 @@ from mathutils import Vector, Matrix
 from . import functions, operators, global_data, class_defines, icon_manager
 from .declarations import GizmoGroups, Gizmos, Operators
 from .draw_handler import ensure_selection_texture
+from .utilities.constants import HALF_TURN, QUARTER_TURN
 
 # NOTE: idealy gizmo would expose active element as a property and
 # operators would access hovered element from there
@@ -259,7 +260,7 @@ from mathutils import Matrix
 
 def draw_arrow_shape(target, shoulder, width, is_3d=False):
     v = shoulder - target
-    mat = Matrix.Rotation(math.pi / 2, (3 if is_3d else 2), "Z")
+    mat = Matrix.Rotation(QUARTER_TURN, (3 if is_3d else 2), "Z")
     v.rotate(mat)
     v.length = abs(width / 2)
 
@@ -446,7 +447,7 @@ class VIEW3D_GT_slvs_angle(Gizmo, ConstraintGizmoGeneric):
             # So we rotate the arrowhead by a quarter-turn plus (or minus)
             #     half the amount the arc segment underneath it rotates.
             segment = length / abs(radius)
-            rotation = (math.tau/4 + segment/2) if constr.text_inside() else (math.tau/4 - segment/2)
+            rotation = (QUARTER_TURN + segment/2) if constr.text_inside() else (QUARTER_TURN - segment/2)
             return rotation
 
         rv3d = context.region_data
@@ -577,10 +578,10 @@ class VIEW3D_GT_slvs_diameter(Gizmo, ConstraintGizmoGeneric):
                     ),
                     p2,
                     functions.pol2cart(offset, angle),
-                    functions.pol2cart(dist + (3 * arrow_2[0]), angle + math.pi), #limit length to 3 arrowheads
+                    functions.pol2cart(dist + (3 * arrow_2[0]), angle + HALF_TURN), #limit length to 3 arrowheads
                     p1,
                     *draw_arrow_shape(
-                        p1, functions.pol2cart(dist + arrow_2[0], angle + math.pi), arrow_2[1]
+                        p1, functions.pol2cart(dist + arrow_2[0], angle + HALF_TURN), arrow_2[1]
                     ),
                 )
 

--- a/global_data.py
+++ b/global_data.py
@@ -6,7 +6,6 @@ registered = False
 
 PYPATH = sys.executable
 
-
 entities = {}
 batches = {}
 

--- a/operators/add_angle.py
+++ b/operators/add_angle.py
@@ -3,6 +3,8 @@ import logging, math
 from bpy.types import Operator, Context
 from bpy.props import FloatProperty, BoolProperty
 
+from ..utilities.constants import HALF_TURN
+
 from ..declarations import Operators
 from ..stateful_operator.utilities.register import register_stateops_factory
 from .base_constraint import GenericConstraintOp
@@ -14,7 +16,7 @@ def invert_angle_getter(self):
 
 
 def invert_angle_setter(self, setting):
-    self["value"] = math.pi - self.value
+    self["value"] = HALF_TURN - self.value
     self["setting"] = setting
 
 

--- a/operators/add_line_2d.py
+++ b/operators/add_line_2d.py
@@ -4,6 +4,8 @@ from bpy.types import Operator, Context
 from bpy.props import BoolProperty
 from mathutils import Vector
 
+from ..utilities.constants import HALF_TURN, QUARTER_TURN
+
 from ..declarations import Operators
 from ..stateful_operator.utilities.register import register_stateops_factory
 from ..stateful_operator.state import state_from_args
@@ -56,9 +58,9 @@ class View3D_OT_slvs_add_line2d(Operator, Operator2d):
             angle = vec_dir.angle(Vector((1, 0)))
 
             threshold = 0.1
-            if angle < threshold or angle > math.pi - threshold:
+            if angle < threshold or angle > HALF_TURN - threshold:
                 constraints.add_horizontal(self.target, sketch=self.sketch)
-            elif (math.pi / 2 - threshold) < angle < (math.pi / 2 + threshold):
+            elif (QUARTER_TURN - threshold) < angle < (QUARTER_TURN + threshold):
                 constraints.add_vertical(self.target, sketch=self.sketch)
 
         ignore_hover(self.target)

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -1,0 +1,5 @@
+from math import tau
+
+FULL_TURN = tau
+HALF_TURN = tau/2
+QUARTER_TURN = tau/4


### PR DESCRIPTION
It's no secret that I'm a fan of TAU over PI, but better yet is to replace "magic numbers" with pre-defined constants to improve readability.
This especially benefits the less mathematically adept.
