### PR TITLE
make consistant order of member variables, spacings, and parenthesis;…

### DIFF
--- a/class_defines.py
+++ b/class_defines.py
@@ -833,7 +833,7 @@ class SlvsPoint2D(Point2D, PropertyGroup):
 
     co: FloatVectorProperty(
         name="Coordinates",
-        description="The coordinates of the point on it's sketch",
+        description="The coordinates of the point on its sketch",
         subtype="XYZ",
         size=2,
         unit="LENGTH",
@@ -1397,7 +1397,7 @@ slvs_entity_pointer(SlvsArc, "sketch")
 
 class SlvsCircle(SlvsGenericEntity, PropertyGroup, Entity2D):
     """Representation of a circle in 2D space. The circle is centered at ct with
-    it's size defined by the radius and is resoulution independent.
+    its size defined by the radius and is resoulution independent.
 
     Arguments:
         ct (SlvsPoint2D): Circle's centerpoint
@@ -1586,7 +1586,7 @@ slvs_entity_pointer(SlvsCircle, "sketch")
 
 
 def update_pointers(scene, index_old, index_new):
-    """Replaces all references to an entity index with it's new index"""
+    """Replaces all references to an entity index with its new index"""
     logger.debug("Update references {} -> {}".format(index_old, index_new))
     # NOTE: this should go through all entity pointers and update them if necessary.
     # It might be possible to use the msgbus to notify and update the IntProperty pointers
@@ -2141,7 +2141,7 @@ class GenericConstraint:
         return int(self.path_from_id().split('[')[1].split(']')[0])
 
 
-# NOTE: When tweaking it's necessary to constrain a point that is only temporary available
+# NOTE: When tweaking, it's necessary to constrain a point that is only temporary available
 # and has no SlvsPoint representation
 def make_coincident(solvesys, point_handle, e2, wp, group, entity_type=None):
     func = None
@@ -3194,7 +3194,7 @@ class SlvsConstraints(PropertyGroup):
         return list[index]
 
     def get_index(self, constr: GenericConstraint) -> int:
-        """Get the index of a constraint in it's collection.
+        """Get the index of a constraint in its collection.
 
         Arguments:
             constr: Constraint to get the index for.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -8,7 +8,7 @@ Whenever encountering a bug follow these steps:
 - Post the bug on [github](https://github.com/hlorus/CAD_Sketcher/issues/new?assignees=&labels=bug&template=bug-report.md&title=%5BBUG%5D)
 
 ## Console Output
-Blender doesn't print system output in it's info editor but only in the
+Blender doesn't print system output in its info editor but only in the
 system terminal. Follow the guide below to access blender's system console.
 
 === "Linux / Mac"

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ CAD Sketcher is a constraint-based sketcher addon for [Blender](https://www.blen
 
 ## Overview
 
-CAD Sketcher integrates the solver of Solvespace and closely follows it's design.
+CAD Sketcher integrates the solver of Solvespace and closely follows its design.
 Therefore the [Solvespace Documentation](https://solvespace.readthedocs.io/en/latest/) is generally also relevant.
 
 In order to have a parametric representation of a geometric system where curves

--- a/docs/interaction_system.md
+++ b/docs/interaction_system.md
@@ -5,7 +5,7 @@ selection matters. As the existing system of selection isn't ideal in this conte
 
 Most tools in the addon are implemented as stateful tools. In this context a state represents one target like a selection or a value. When running a tool you will iterate through these states until all states have valid input.
 
-Let's take the "Add Circle" tool as an example. Since a circle is represented by it's center and radius the tool will have two states. One to define the center element and one to set the radius.
+Let's take the "Add Circle" tool as an example. Since a circle is represented by its center and radius the tool will have two states. One to define the center element and one to set the radius.
 
 ### State Types
 
@@ -36,10 +36,10 @@ To be as flexible as possible the interaction system allows to work in different
 ![!Mixed Paradigm](images/selection_paradigm3.gif){style="width:100%;height:200px; object-fit:cover;"}
 
 ### Numerical Edit
-In order to precisely edit a states property it's possible to edit values directly by entering numbers. When the stateproperty is a set of multiple values (e.g. XYZ Location) they will be treated as sub-states, meaning you can iterate (TAB) through them and enter values sequentially.
+In order to precisely edit a states property, it's possible to edit values directly by entering numbers. When the stateproperty is a set of multiple values (e.g. XYZ Location) they will be treated as sub-states, meaning you can iterate (TAB) through them and enter values sequentially.
 
 ### Description
-When learning how a new tool works it's best to take a look at it's tooltip, this will list the different states of the tool. For pointer states this will additionally display the accepted types that can be picked.
+When learning how a new tool works it's best to take a look at its tooltip, this will list the different states of the tool. For pointer states this will additionally display the accepted types that can be picked.
 
 ![!tooltip_arc.png](images/tooltip_arc.png){align=left style="height:160px; width:calc(50% - 1em); object-fit:cover;"}
 
@@ -52,6 +52,6 @@ While running an operation the statusbar will display that information for the c
 ### Immediate Execution
 Most tools support immediate execution which will invoke the tools operations when switching to it and a valid
 selection is given.
->Note that the execution is only triggered when a tool is invoked by it's shortcut.
+>Note that the execution is only triggered when a tool is invoked by its shortcut.
 
 ![!Immediate Execution](images/immediate_execution.gif){style="width:100%;height:200px;object-fit:cover;"}

--- a/docs/user_interface.md
+++ b/docs/user_interface.md
@@ -2,7 +2,7 @@
 ![!Sidebar](images/sidebar.png){style="width:200px; height:220px; object-fit:cover;" align=right}
 
 The addon adds a some panels to the "N"-sidebar under the category "Sketcher". From
-here you can set the active sketch, access it's properties, add constraints and
+here you can set the active sketch, access its properties, add constraints and
 interact with elements via the browsers.
 {style="display:block; height:220px"}
 
@@ -31,7 +31,7 @@ state on the left and allows to invoke the constraint's context menu.
 Gizmos are used to display constraints. There are specific gizmo
 types for the three dimensional constraints, angle, distance and diameter.
 
-To interact with the settings of a constraint click it's gizmo to open a menu.
+To interact with the settings of a constraint click its gizmo to open a menu.
 ![!Dimensional Gizmos](images/dimensional_gizmos.png){align=left style="height:300px; width:calc(65% - 1em); object-fit:cover;"}
 ![!Constraint Menu](images/constraint_menu.png){align=right style="height:300px; width:calc(35% - 1em); object-fit:cover;"}
 

--- a/operators/add_angle.py
+++ b/operators/add_angle.py
@@ -31,8 +31,8 @@ class VIEW3D_OT_slvs_add_angle(Operator, GenericConstraintOp):
         name="Angle",
         subtype="ANGLE",
         unit="ROTATION",
-        options={"SKIP_SAVE"},
         precision=5,
+        options={"SKIP_SAVE"},
     )
     setting: BoolProperty(name="Measure supplementary angle", default = False, get=invert_angle_getter, set=invert_angle_setter)
     type = "ANGLE"

--- a/operators/add_diameter.py
+++ b/operators/add_diameter.py
@@ -22,10 +22,9 @@ class VIEW3D_OT_slvs_add_diameter(Operator, GenericConstraintOp):
         name="Size",
         subtype="DISTANCE",
         unit="LENGTH",
-        options={"SKIP_SAVE"},
         precision=5,
+        options={"SKIP_SAVE"},
     )
-
     setting: BoolProperty(name="Use Radius")
     type = "DIAMETER"
 

--- a/operators/add_geometric_constraints.py
+++ b/operators/add_geometric_constraints.py
@@ -105,13 +105,13 @@ class VIEW3D_OT_slvs_add_midpoint(Operator, GenericConstraintOp):
 class VIEW3D_OT_slvs_add_ratio(Operator, GenericConstraintOp):
     """Add a ratio constraint"""
 
-    value: FloatProperty(
-        name="Ratio", subtype="UNSIGNED", options={"SKIP_SAVE"}, min=0.0, precision=5,
-    )
     bl_idname = Operators.AddRatio
     bl_label = "Ratio"
     bl_options = {"UNDO", "REGISTER"}
 
+    value: FloatProperty(
+        name="Ratio", subtype="UNSIGNED", options={"SKIP_SAVE"}, min=0.0, precision=5,
+    )
     type = "RATIO"
 
 

--- a/operators/add_point_2d.py
+++ b/operators/add_point_2d.py
@@ -19,6 +19,7 @@ class View3D_OT_slvs_add_point2d(Operator, Operator2d):
     bl_idname = Operators.AddPoint2D
     bl_label = "Add Solvespace 2D Point"
     bl_options = {"REGISTER", "UNDO"}
+
     p2d_state1_doc = ("Coordinates", "Set point's coordinates on the sketch.")
 
     coordinates: FloatVectorProperty(name="Coordinates", size=2, precision=5)

--- a/operators/add_point_3d.py
+++ b/operators/add_point_3d.py
@@ -18,6 +18,7 @@ class View3D_OT_slvs_add_point3d(Operator, Operator3d):
     bl_idname = Operators.AddPoint3D
     bl_label = "Add Solvespace 3D Point"
     bl_options = {"REGISTER", "UNDO"}
+
     p3d_state1_doc = ("Location", "Set point's location.")
 
     location: FloatVectorProperty(name="Location", subtype="XYZ", precision=5)

--- a/operators/base_stateful.py
+++ b/operators/base_stateful.py
@@ -127,7 +127,7 @@ class GenericEntityOp(StatefulOperator):
         if retval:
             return retval
 
-        # Creates pointer from it's implicitly stored props
+        # Creates pointer from its implicitly stored props
         if index is None:
             index = self.state_index
 

--- a/operators/constraint_visibility.py
+++ b/operators/constraint_visibility.py
@@ -8,21 +8,22 @@ from ..declarations import Operators, VisibilityTypes
 
 class View3D_OT_slvs_set_all_constraints_visibility(Operator, HighlightElement):
     """Set all constraints' visibility"""
-    
+
+    bl_idname = Operators.SetAllConstraintsVisibility
+    bl_label = "Set all constraints' visibility"
+    bl_description = "Set all constraints' visibility"
+    bl_options = {"UNDO"}
+
     _visibility_items = [
         (VisibilityTypes.Hide, "Hide all", "Hide all constraints"),
         (VisibilityTypes.Show, "Show all", "Show all constraints"),
     ]
 
-    bl_idname = Operators.SetAllConstraintsVisibility
-    bl_label = "Set all constraints' visibility"
-    bl_options = {"UNDO"}
-    bl_description = "Set all constraints' visibility"
-
     visibility: EnumProperty(
         name="Visibility",
         description="Visiblity",
-        items=_visibility_items)
+        items=_visibility_items
+    )
 
     @classmethod
     def poll(cls, context: Context):

--- a/operators/delete_constraint.py
+++ b/operators/delete_constraint.py
@@ -18,8 +18,8 @@ class View3D_OT_slvs_delete_constraint(Operator, HighlightElement):
 
     bl_idname = Operators.DeleteConstraint
     bl_label = "Delete Constraint"
-    bl_options = {"UNDO"}
     bl_description = "Delete Constraint"
+    bl_options = {"UNDO"}
 
     type: StringProperty(name="Type")
     index: IntProperty(default=-1)
@@ -35,7 +35,7 @@ class View3D_OT_slvs_delete_constraint(Operator, HighlightElement):
         constraints = context.scene.sketcher.constraints
 
         # NOTE: It's not really necessary to first get the
-        # constraint from it's index before deleting
+        # constraint from its index before deleting
 
         constr = constraints.get_from_type_index(self.type, self.index)
         logger.debug("Delete: {}".format(constr))

--- a/operators/delete_entity.py
+++ b/operators/delete_entity.py
@@ -24,10 +24,10 @@ class View3D_OT_slvs_delete_entity(Operator, HighlightElement):
 
     bl_idname = Operators.DeleteEntity
     bl_label = "Delete Solvespace Entity"
-    bl_options = {"UNDO"}
     bl_description = (
         "Delete Entity by index or based on the selection if index isn't provided"
     )
+    bl_options = {"UNDO"}
 
     index: IntProperty(default=-1)
     do_report: BoolProperty(

--- a/operators/trim.py
+++ b/operators/trim.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 from ..utilities.trimming import TrimSegment
 
 class View3D_OT_slvs_trim(Operator, Operator2d):
-    """Trim segment to it's closest intersections"""
+    """Trim segment to its closest intersections"""
 
     bl_idname = Operators.Trim
     bl_label = "Trim Segment"

--- a/operators/tweak_constraint.py
+++ b/operators/tweak_constraint.py
@@ -12,8 +12,8 @@ from ..declarations import Operators
 class View3D_OT_slvs_tweak_constraint_value_pos(Operator):
     bl_idname = Operators.TweakConstraintValuePos
     bl_label = "Tweak Constraint"
-    bl_options = {"UNDO"}
     bl_description = "Tweak constraint's value or display position"
+    bl_options = {"UNDO"}
 
     type: StringProperty(name="Type")
     index: IntProperty(default=-1)

--- a/stateful_operator/docs.md
+++ b/stateful_operator/docs.md
@@ -36,10 +36,10 @@ gather_selection(self, context) -> selected(list(ANY))
 state_func(self, context, coords) property_value(ANY)
   method to get the value for the state property from mouse coordinates
 
-pick_element(self, context, coords) -> element or it's implicit props
+pick_element(self, context, coords) -> element or its implicit props
   method to pick a matching element from mouse coordinates, either return the
-  element or it's implicit prop values, has to set the type of the picked element
+  element or its implicit prop values, has to set the type of the picked element
 
-create_element(self, context, value, state, state_data) -> element or it's implicit props
+create_element(self, context, value, state, state_data) -> element or its implicit props
   method to create state element when no existing element gets picked,
   has to set the type of the created element

--- a/stateful_operator/integration.py
+++ b/stateful_operator/integration.py
@@ -75,7 +75,7 @@ class StatefulOperator(StatefulOperatorLogic):
         index: Optional[int] = None,
         implicit: Optional[bool] = False
     ):
-        # Creates pointer value from it's implicitly stored props
+        # Creates pointer value from its implicitly stored props
         if index is None:
             index = self.state_index
 


### PR DESCRIPTION
Since the apostropy is use both for contractions and possessives,  the famously insane English language has had to face the dilemma presented by the word "it".
An arbitrary decision was made to go with "its" for possessive and "it's" for "it is"

The other notable change here is to make sure all the bl_* variables are listed first, with bl_options always the last of those.

A couple of line spacing and parenthesis changes aren't worth mentioning.
