### PR TITLE
Use USERBASE based package installation into local directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ notes.md
 # Utilities
 utils/*
 
+# USERBASE paths into which pip will install dependencies
+Python*/

--- a/base/install_op.py
+++ b/base/install_op.py
@@ -3,7 +3,8 @@ from bpy.types import Operator
 
 from .. import functions, global_data
 from ..declarations import Operators
-from ..utilities.install import check_module
+from ..utilities import install
+
 
 class View3D_OT_slvs_install_package(Operator):
     """Install module from local .whl file or from PyPi"""
@@ -18,10 +19,11 @@ class View3D_OT_slvs_install_package(Operator):
         return not global_data.registered
 
     def execute(self, context):
-        if not functions.ensure_pip():
+        if not install.ensure_pip():
             self.report(
                 {"WARNING"},
-                "PIP is not available and cannot be installed, please install PIP manually",
+                "PIP is not available and cannot be installed, please install PIP"
+                " manually",
             )
             return {"CANCELLED"}
 
@@ -29,15 +31,21 @@ class View3D_OT_slvs_install_package(Operator):
             self.report({"WARNING"}, "Specify package to be installed")
             return {"CANCELLED"}
 
-        if functions.install_package(self.package):
+        if install.install_package(self.package):
             try:
-                check_module("py_slvs")
+                install.check_module("py_slvs")
                 from ..registration import register_full
+
                 register_full()
 
                 self.report({"INFO"}, "Package successfully installed")
+                global_data.registered = True
             except ModuleNotFoundError:
-                self.report({"WARNING"}, "Package should be available but cannot be found, check console for detailed info. Try restarting blender, otherwise get in contact.")
+                self.report(
+                    {"WARNING"},
+                    "Package should be available but cannot be found, check console for"
+                    " detailed info. Try restarting blender, otherwise get in contact.",
+                )
             functions.show_package_info("py_slvs")
         else:
             self.report({"WARNING"}, "Cannot install package: {}".format(self.package))

--- a/functions.py
+++ b/functions.py
@@ -66,7 +66,6 @@ def check_pip_installed():
         # Modifies global_data to make it persist for other commands.
         global_data.pip_environment.pop("PYTHONNOUSERSITE", None)
         return subprocess.call(args, env=global_data.pip_environment) == 0
-    return True
 
 def ensure_pip():
     if not check_pip_installed():

--- a/global_data.py
+++ b/global_data.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from enum import Enum
 from mathutils import Vector
@@ -5,6 +6,11 @@ from mathutils import Vector
 registered = False
 
 PYPATH = sys.executable
+
+# Add/Overwrite the PYTHONNOUSERSITE to make pip use the local version
+# partially resolves issue: https://github.com/hlorus/CAD_Sketcher/issues/243
+# will get set to 0 if pip doesn't exist in blender.
+pip_environment = {**dict(os.environ), "PYTHONNOUSERSITE": "1"}
 
 entities = {}
 batches = {}
@@ -28,7 +34,7 @@ draw_handle = None
 
 # Workplane requirement options
 class WpReq(Enum):
-    OPTIONAL, FREE, NOT_FREE = range(3)
+    OPTIONAL, FREE, NOT_FREE = range(3) 
 
 
 solver_state_items = [

--- a/global_data.py
+++ b/global_data.py
@@ -1,16 +1,21 @@
 import os
 import sys
 from enum import Enum
+from pathlib import Path
+
 from mathutils import Vector
 
 registered = False
 
 PYPATH = sys.executable
 
-# Add/Overwrite the PYTHONNOUSERSITE to make pip use the local version
-# partially resolves issue: https://github.com/hlorus/CAD_Sketcher/issues/243
-# will get set to 0 if pip doesn't exist in blender.
-pip_environment = {**dict(os.environ), "PYTHONNOUSERSITE": "1"}
+# Custom userbase for this addon.
+# Python will make a subfolder of this
+# where dependencies will be installed.
+CUSTOM_USER_BASE = str((Path(__file__).parent).resolve())
+
+# Add CUSTOM_USER_SITE to PYTHONUSERBASE for subprocesses to use
+env_vars = {**dict(os.environ), "PYTHONUSERBASE": CUSTOM_USER_BASE}
 
 entities = {}
 batches = {}
@@ -34,7 +39,7 @@ draw_handle = None
 
 # Workplane requirement options
 class WpReq(Enum):
-    OPTIONAL, FREE, NOT_FREE = range(3) 
+    OPTIONAL, FREE, NOT_FREE = range(3)
 
 
 solver_state_items = [

--- a/utilities/install.py
+++ b/utilities/install.py
@@ -11,9 +11,9 @@ logger = logging.getLogger(__name__)
 
 
 def check_module(package):
-    # Note: Blender might be installed in a directory that needs admin rights and thus defaulting to a user installation.
-    # That path however might not be in sys.path....
     refresh_path()
+    # This was done in the past to make sure modules in usersite can be found.
+    # Since using USERBASE this shouldnt be necessary, but it's left as a fallback.
     p = site.USER_SITE
     if p not in sys.path:
         sys.path.insert(0, p)
@@ -24,10 +24,13 @@ def check_module(package):
         raise e
 
 
-def install_pip():
+def install_pip() -> int:
     import ensurepip
 
+    # ensurepip.bootstrap just hides the return
+    # code which is needed for the currect error messages.
     ret_val = ensurepip._bootstrap()
+    # Env var left over from pip installation, needs to be removed
     os.environ.pop("PIP_REQ_TRACKER", None)
     return ret_val
 
@@ -39,7 +42,7 @@ def check_pip_installed() -> bool:
     return False
 
 
-def ensure_pip():
+def ensure_pip() -> bool:
     refresh_path()
     if not check_pip_installed():
         return install_pip() == 0
@@ -51,16 +54,18 @@ def refresh_path():
 
     # set the user base directory
     os.environ["PYTHONUSERBASE"] = global_data.CUSTOM_USER_BASE
+    # Applies the PYTHONUSERBASE env var
     importlib.reload(site)
 
 
-def install_package(package: str, no_deps: bool = True):
+def install_package(package: str, no_deps: bool = True) -> bool:
     refresh_path()
-    _install_package("pip")  # update pip
+    _install_package("pip")  # update pip if needed
     return _install_package(package, no_deps)
 
 
-def _install_package(package: str, no_deps: bool = True):
+def _install_package(package: str, no_deps: bool = True) -> bool:
+    # --user is needed to ensure install always happens into USERBASE
     cmd = [global_data.PYPATH, "-m", "pip", "install", "--upgrade", "--user"]
 
     if no_deps:

--- a/utilities/install.py
+++ b/utilities/install.py
@@ -1,15 +1,73 @@
-import site, sys, importlib
+import importlib
+import logging
+import os
+import site
+import subprocess
+import sys
+
+from .. import global_data
+
+logger = logging.getLogger(__name__)
 
 
 def check_module(package):
     # Note: Blender might be installed in a directory that needs admin rights and thus defaulting to a user installation.
     # That path however might not be in sys.path....
-
+    refresh_path()
     p = site.USER_SITE
     if p not in sys.path:
-        sys.path.append(p)
+        sys.path.insert(0, p)
     try:
         importlib.import_module(package)
 
     except ModuleNotFoundError as e:
         raise e
+
+
+def install_pip():
+    import ensurepip
+
+    ret_val = ensurepip._bootstrap()
+    os.environ.pop("PIP_REQ_TRACKER", None)
+    return ret_val
+
+
+def check_pip_installed() -> bool:
+    cmd = [global_data.PYPATH, "-m", "pip", "--version"]
+    if subprocess.call(cmd, env=global_data.env_vars) == 0:
+        return True
+    return False
+
+
+def ensure_pip():
+    refresh_path()
+    if not check_pip_installed():
+        return install_pip() == 0
+    return True
+
+
+def refresh_path():
+    """refresh path to packages found after install"""
+
+    # set the user base directory
+    os.environ["PYTHONUSERBASE"] = global_data.CUSTOM_USER_BASE
+    importlib.reload(site)
+
+
+def install_package(package: str, no_deps: bool = True):
+    refresh_path()
+    _install_package("pip")  # update pip
+    return _install_package(package, no_deps)
+
+
+def _install_package(package: str, no_deps: bool = True):
+    cmd = [global_data.PYPATH, "-m", "pip", "install", "--upgrade", "--user"]
+
+    if no_deps:
+        cmd += ["--no-deps"]
+
+    cmd = cmd + package.split(" ")
+
+    ret_val = subprocess.call(cmd, env=global_data.env_vars)
+    refresh_path()
+    return ret_val == 0


### PR DESCRIPTION
This PR sets and uses USERBASE for pip installations. This has the advantage of never interacting with the systems python installation and should prevent bugs which might happend due to wrong versions of pip (shimmed by conda)

This also localises the dependencies within the addons folder to make sure permission errors don't happen.

This is after i deletd both py-slvs and pip from any python packages directories blender can see, and clicking the "install from pip" button once:
![image](https://user-images.githubusercontent.com/24855949/184519636-f47df471-0b85-4eab-a221-d663009c754e.png)

closes: #243

also i formatted the files i touched with black, which is in line with #248 so i hope its fine even before that is closed.

TODO:
- [] test how well this works with .whl installation