### PR TITLE
Default constraint names use the str() function.

### DIFF
--- a/class_defines.py
+++ b/class_defines.py
@@ -2179,11 +2179,9 @@ ENTITY_PROP_NAMES = ("entity1", "entity2", "entity3", "entity4")
 
 
 class GenericConstraint:
+
     def _name_getter(self):
-        name = self.get("name")
-        if not name:
-            return type(self).__name__
-        return name
+        return self.get("name", str(self))
 
     def _name_setter(self, new_name):
         self["name"] = new_name
@@ -2827,7 +2825,10 @@ class SlvsDiameter(GenericConstraint, PropertyGroup):
             # Avoid triggering the property's update callback
             self["value"] = distance
 
-    label = "Diameter"
+    @property
+    def label(self):
+        return "Radius" if self.setting else "Diameter"
+
     value: FloatProperty(
         name="Size",
         subtype="DISTANCE",


### PR DESCRIPTION
This reverts the default naming back to the previously used `label`.

In the case of the diameter constraint, it will return either "Radius" or "Diameter"
depending on the setting.

If you edit the name of the Diameter constraint, it replaces the default naming.

Fixes #263 

Note: When you switch the constraint between Diameter <-> Radius, it changes the constraint name, unless it is user defined.

![image](https://user-images.githubusercontent.com/24782867/185905966-5745f531-6ebb-491e-afd3-232100b5e88f.png)


Let me know If I should do the same for the `SlvsGenericEntity`s.