### PR TITLE
adds debugpy python lib dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,15 @@ CAD sketcher heavily depends on the [solvespace python module](https://pypi.org/
 Check the [installation](https://hlorus.github.io/CAD_Sketcher/installation) chapter for in-depth instructions.
 
 Additionally CAD sketcher for debugging purposes depends on the library [debugpy](https://pypi.org/project/debugpy/) when debugging is done
-throught VSCode. Installing this library with '''$pip install''' will further mean that the window in VSCode will need to be reloaded using '''command Palette > Reload window '''.
+throught VSCode. Installing this library with 
+
+'''$pip install''' 
+
+will further mean that the window in VSCode will need to be reloaded using 
+
+'''command Palette > Reload window '''
+
+
 
 ## Usage
 Follow the [getting started](https://hlorus.github.io/CAD_Sketcher/getting_started) guide to get familiar with the addon.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ CAD sketcher heavily depends on the [solvespace python module](https://pypi.org/
 
 Check the [installation](https://hlorus.github.io/CAD_Sketcher/installation) chapter for in-depth instructions.
 
+Additionally CAD sketcher for debugging purposes depends on the library [debugpy](https://pypi.org/project/debugpy/) when debugging is done
+throught VSCode. Installing this library with '''$pip install''' will further mean that the window in VSCode will need to be reloaded using '''command Palette > Reload window '''.
+
 ## Usage
 Follow the [getting started](https://hlorus.github.io/CAD_Sketcher/getting_started) guide to get familiar with the addon.
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,6 @@ CAD sketcher heavily depends on the [solvespace python module](https://pypi.org/
 
 Check the [installation](https://hlorus.github.io/CAD_Sketcher/installation) chapter for in-depth instructions.
 
-Additionally CAD sketcher for debugging purposes depends on the library [debugpy](https://pypi.org/project/debugpy/) when debugging is done
-throught VSCode. Installing this library with ```$pip install```  will further mean that the window in VSCode will need to be reloaded using  ```command Palette > Reload window``` .
-
-
-
 ## Usage
 Follow the [getting started](https://hlorus.github.io/CAD_Sketcher/getting_started) guide to get familiar with the addon.
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,9 @@ Check the [installation](https://hlorus.github.io/CAD_Sketcher/installation) cha
 Additionally CAD sketcher for debugging purposes depends on the library [debugpy](https://pypi.org/project/debugpy/) when debugging is done
 throught VSCode. Installing this library with 
 
-'''$pip install''' 
+```$pip install```  will further mean that the window in VSCode will need to be reloaded using 
 
-will further mean that the window in VSCode will need to be reloaded using 
-
-'''command Palette > Reload window '''
+```command Palette > Reload window```
 
 
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -19,6 +19,10 @@ system terminal. Follow the guide below to access blender's system console.
 
 === "Windows"
     - In blender click Window->Toggle System Console
+## Console Output VScode dependency
+
+CAD sketcher for debugging purposes depends on the library [debugpy](https://pypi.org/project/debugpy/) when debugging is done
+throught VSCode. Installing this library with ```$pip install```  will further mean that the window in VSCode will need to be reloaded using  ```command Palette > Reload window``` .
 
 ## Access Logs
 Logs are helpful for debugging. Note that there are logs from the addon as well as from blender itself.


### PR DESCRIPTION
this edit adds in the necessary to install dependency of ```debugpy``` to the dependencies section of the readme. 