### PR TITLE
Fixes cross product expression.

### DIFF
--- a/model/distance.py
+++ b/model/distance.py
@@ -27,13 +27,15 @@ from .circle import SlvsCircle
 logger = logging.getLogger(__name__)
 
 
-def get_side_of_line(line_start, line_end, point):
-    line_end = line_end - line_start
-    point = point - line_start
-    return -(
-        (line_end.x - line_start.x) * (point.y - line_start.y)
-        - (line_end.y - line_start.y) * (point.x - line_start.x)
-    )
+def get_side_of_line(line_start: Vector, line_end: Vector, point: Vector):
+    """
+    Returns the 2D cross product between the line as
+    a vector (start_line, end_line) and the vector (start_line, point).
+
+    Helps to determine the position of the point relative to the line.
+    """
+    return (point - line_start).cross(line_end - line_start)
+
 
 
 align_items = [

--- a/model/distance.py
+++ b/model/distance.py
@@ -37,7 +37,6 @@ def get_side_of_line(line_start: Vector, line_end: Vector, point: Vector):
     return (point - line_start).cross(line_end - line_start)
 
 
-
 align_items = [
     ("NONE", "None", "", 0),
     ("HORIZONTAL", "Horizontal", "", 1),


### PR DESCRIPTION
It seems like the function was incorrect when created, as it didn't replace the initial code faithfully.

See lines L=1335-L1339 of `class_defines.py` in https://github.com/hlorus/CAD_Sketcher/commit/fb2fdfb9ec4e378eb85e742af62ff392fcadec37#diff-914af6373e4216743c31966cef6f105afddbe553fe7973aebcf1bc1999467733L1336-L1339