### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The project accepts donations through Open Collective.
 </a>
 </p>
  
-Alternativley individual developers can link their donation links here:
+Alternatively individual developers can link their donation links here:
 
 <a href="https://www.paypal.com/donate/?business=4A9SCSHAU3ZP6&no_recurring=0&currency_code=CHF">
 hlorus - Lead Dev

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -22,7 +22,7 @@ system terminal. Follow the guide below to access blender's system console.
 ## Console Output VScode dependency
 
 CAD sketcher for debugging purposes depends on the library [debugpy](https://pypi.org/project/debugpy/) when debugging is done
-throught VSCode. Installing this library with ```$pip install```  will further mean that the window in VSCode will need to be reloaded using  ```command Palette > Reload window``` .
+through VSCode. Installing this library with ```$pip install```  will further mean that the window in VSCode will need to be reloaded using  ```command Palette > Reload window``` .
 
 ## Access Logs
 Logs are helpful for debugging. Note that there are logs from the addon as well as from blender itself.

--- a/docs/code_docs.md
+++ b/docs/code_docs.md
@@ -46,7 +46,7 @@ entity itself can then be looked up by:
 entity = bpy.context.scene.sketcher.entities.get(index)
 ```
 
-For convenience theres the slvs_entity_pointer function which registers the IntProperty
+For convenience there's the slvs_entity_pointer function which registers the IntProperty
 with a "_i" prefix and adds getter/setter methods to directly get the entity without
 having to deal with the index itself.
 
@@ -125,7 +125,7 @@ import inspect
 inspect.signature(sys.addEqual)
 ```
 
-The solver data isn't persistent, so whenever the solver is triggerd it will create a
+The solver data isn't persistent, so whenever the solver is triggered it will create a
 new "py_slvs.slvs.System" object.Then the solver will go through the relevant entities and
 call their create_slvs_data method and pass the system object to it. Same applies
 to the constraints.

--- a/global_data.py
+++ b/global_data.py
@@ -78,7 +78,7 @@ solver_state_items = [
         "Redundant Constraints",
         (
             f"Some constraints seem to be redundant, this might cause an error once the constraints are no longer consistent. "
-            f"Check through the marked constraints and only keep what's neccessary."
+            f"Check through the marked constraints and only keep what's necessary."
         ),
         "INFO",
         5,  # SLVS_RESULT_REDUNDANT_OK

--- a/operators/bevel.py
+++ b/operators/bevel.py
@@ -122,7 +122,7 @@ class View3D_OT_slvs_bevel(Operator, Operator2d):
         point = self.p1
         radius = self.radius
 
-        # Get connected entites from point
+        # Get connected entities from point
         connected = []
         for e in (*sse.lines2D, *sse.arcs):
             # TODO: Priorize non_construction entities

--- a/operators/constraint_visibility.py
+++ b/operators/constraint_visibility.py
@@ -20,7 +20,7 @@ class View3D_OT_slvs_set_all_constraints_visibility(Operator, HighlightElement):
     ]
 
     visibility: EnumProperty(
-        name="Visibility", description="Visiblity", items=_visibility_items
+        name="Visibility", description="Visibility", items=_visibility_items
     )
 
     @classmethod

--- a/operators/trim.py
+++ b/operators/trim.py
@@ -69,7 +69,7 @@ class View3D_OT_slvs_trim(Operator, Operator2d):
                 # print("intersect", co)
                 trim.add(e, co)
 
-        # Find points that are connected to the segment through a conincident constraint
+        # Find points that are connected to the segment through a coincident constraint
         for c in (
             *context.scene.sketcher.constraints.coincident,
             *context.scene.sketcher.constraints.midpoint,


### PR DESCRIPTION
Found via `codespell -q 3 -L alot,bu,didnt,ressources,therefor`