### PR TITLE
Fix set_value for complementary angle constraint.

### DIFF
--- a/model/angle.py
+++ b/model/angle.py
@@ -27,11 +27,6 @@ class SlvsAngle(DimensionalConstraint, PropertyGroup):
     The constraint's setting can be used to to constrain the supplementary angle.
     """
 
-    def _set_value_force(self, value):
-        DimensionalConstraint._set_value_force(
-            self, HALF_TURN - value if self.setting else value
-        )
-
     def assign_init_props(self, context: Context = None):
         # Updating self.setting will create recursion loop
         _value, _ = self.init_props()
@@ -69,6 +64,9 @@ class SlvsAngle(DimensionalConstraint, PropertyGroup):
         return WpReq.NOT_FREE
 
     def to_displayed_value(self, value):
+        return HALF_TURN - value if self.setting else value
+
+    def from_displayed_value(self, value):
         return HALF_TURN - value if self.setting else value
 
     def create_slvs_data(self, solvesys, group=Solver.group_fixed):
@@ -125,7 +123,6 @@ class SlvsAngle(DimensionalConstraint, PropertyGroup):
 
         x = A.dot(B) / divisor
         x = max(-1, min(x, 1))
-
         return math.degrees(math.acos(x))
 
     def init_props(self, **kwargs):

--- a/model/base_constraint.py
+++ b/model/base_constraint.py
@@ -190,23 +190,23 @@ class DimensionalConstraint(GenericConstraint):
     value: Property
     setting: BoolProperty
 
-    def _set_value(self, val: float):
+    def _set_value(self, displayed_value: float):
         # NOTE: function signature _set_value(self, val: float, force=False)
         #       will fail when bpy tries to register the value property.
         #       See `_set_value_force()`
         if not self.is_reference:
-            self._set_value_force(val)
+            self._set_value_force(self.from_displayed_value(displayed_value))
 
-    def _set_value_force(self, val: float):
-        self["value"] = val
+    def _set_value_force(self, value: float):
+        self["value"] = value
 
     def _get_value(self):
         if self.is_reference:
             val, _ = self.init_props()
             return self.to_displayed_value(val)
-        if not self.get("value"):
+        if self.get("value") is None:
             self.assign_init_props()
-        return self["value"]
+        return self.to_displayed_value(self["value"])
 
     def assign_init_props(self, context: Context = None):
         # self.value, self.setting = self.init_props()
@@ -229,7 +229,21 @@ class DimensionalConstraint(GenericConstraint):
         raise NotImplementedError()
 
     def to_displayed_value(self, value):
+        """
+        Overwrite this function to convert the property value into 
+        something to display on the user interface.
+        NOTE: If the value is writeable, do not forget to change 
+              ``from_displayed_value()`` to apply the reverse operation.
+        """
         return value
+
+    def from_displayed_value(self, displayed_value):
+        """
+        Convert the displayed value of the property into 
+        a variable to store.
+        NOTE: See ``to_displayed_value()``
+        """
+        return displayed_value
 
     def py_data(self, solvesys, **kwargs):
         if self.is_reference:


### PR DESCRIPTION
/!\ This might break some save files, as angles measured as "complementary" will be displayed as 180 - their.value 

This is a consequence of one of my previous problematic PRs, where the value of the constraints always refer to the same physical attribute. (e.g. the direct angle between 2 lines)

Although it introduces more functions, I still believe the idea is sound though, as we can guarantee that my_angle_property["value"] always refers to the direct angle.

Perhaps the functions `to/from_displayed_values()` do not fit in the class `DimensionalConstraint` because it should not be concerned with the UI. Please let me know if there is a better place to have it.

Hopefully fixes #310 please test on your side too :see_no_evil: 

N.B. Fixes a corner case where an initial direct angle of value 0 would not display properly.