### PR TITLE
Blender 3.4.1 now says "PIP" instead of PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Minimum version: Blender 2.92
 CAD sketcher heavily depends on the [solvespace python module](https://pypi.org/project/py-slvs/) and won't be functional without it.
 
 - Inside the addon's preferences check the "Solver Module" tab to see if the module is already available
-- Press "Install from PyPi"
+- Press "Install from PIP"
 
 Check the [installation](https://hlorus.github.io/CAD_Sketcher/installation) chapter for in-depth instructions.
 


### PR DESCRIPTION
Neither are wrong, but it could be confusing to non-Python nerds, so it's probably best to state what's actually shown there.