### PR TITLE
[#327] Add construction mode toggle

### DIFF
--- a/declarations.py
+++ b/declarations.py
@@ -79,7 +79,7 @@ class Panels(str, Enum):
     Sketcher = "VIEW3D_PT_sketcher"
     SketcherDebugPanel = "VIEW3D_PT_sketcher_debug_panel"
     SketcherAddContraint = "VIEW3D_PT_sketcher_add_contraint"
-    SketcherContraints = "VIEW3D_PT_sketcher_constraints"
+    SketcherConstraints = "VIEW3D_PT_sketcher_constraints"
     SketcherEntities = "VIEW3D_PT_sketcher_entities"
 
 

--- a/declarations.py
+++ b/declarations.py
@@ -78,7 +78,7 @@ class Macros(str, Enum):
 class Panels(str, Enum):
     Sketcher = "VIEW3D_PT_sketcher"
     SketcherDebugPanel = "VIEW3D_PT_sketcher_debug_panel"
-    SketcherAddContraint = "VIEW3D_PT_sketcher_add_contraint"
+    SketcherTools = "VIEW3D_PT_sketcher_tools"
     SketcherConstraints = "VIEW3D_PT_sketcher_constraints"
     SketcherEntities = "VIEW3D_PT_sketcher_entities"
 

--- a/keymaps.py
+++ b/keymaps.py
@@ -214,6 +214,18 @@ disable_gizmos = (
     ),
 )
 
+use_construction = (
+    (
+        "wm.context_toggle",
+        {"type": "C", "value": "PRESS", "alt": True, "shift": True},
+        {
+            "properties": [
+                ("data_path", "scene.sketcher.use_construction"),
+            ]
+        },
+    )
+)
+
 tool_use_select = (
     (
         "wm.tool_set_by_id",
@@ -229,6 +241,7 @@ tool_use_select = (
 
 tool_generic = (
     *disable_gizmos,
+    use_construction,
     *tool_use_select,
     *tool_access,
 )

--- a/keymaps.py
+++ b/keymaps.py
@@ -180,7 +180,7 @@ tool_access = (
 
 disable_gizmos = (
     # Disabling gizmos when pressing ctrl + shift
-    # Add two etries so it doesn't matter which key is pressed first
+    # Add two entries so it doesn't matter which key is pressed first
     # NOTE: This cannot be done as a normal modifier key to selection since it has to toggle a global property
     (
         "wm.context_set_boolean",

--- a/model/group_sketcher.py
+++ b/model/group_sketcher.py
@@ -23,6 +23,13 @@ class SketcherProps(PropertyGroup):
     entities: PointerProperty(type=SlvsEntities)
     constraints: PointerProperty(type=SlvsConstraints)
     show_origin: BoolProperty(name="Show Origin Entities")
+    use_construction: BoolProperty(
+        name="Construction Mode",
+        description="Draw all subsequent entities in construction mode",
+        default=False,
+        options={"SKIP_SAVE"},
+        update=update_cb,
+    )
     selectable_constraints: BoolProperty(
         name="Constraints Selectability",
         default=True,

--- a/operators/add_arc.py
+++ b/operators/add_arc.py
@@ -91,6 +91,8 @@ class View3D_OT_slvs_add_arc2d(Operator, Operator2d):
 
         ignore_hover(arc)
         self.target = arc
+        if context.scene.sketcher.use_construction:
+            self.target.construction = True
         return True
 
     def fini(self, context: Context, succeede: bool):

--- a/operators/add_circle.py
+++ b/operators/add_circle.py
@@ -64,6 +64,8 @@ class View3D_OT_slvs_add_circle2d(Operator, Operator2d):
         self.target = context.scene.sketcher.entities.add_circle(
             wp.nm, ct, self.radius, self.sketch
         )
+        if context.scene.sketcher.use_construction:
+            self.target.construction = True
         ignore_hover(self.target)
         return True
 

--- a/operators/add_line_2d.py
+++ b/operators/add_line_2d.py
@@ -50,6 +50,8 @@ class View3D_OT_slvs_add_line2d(Operator, Operator2d):
         p1, p2 = self.get_point(context, 0), self.get_point(context, 1)
 
         self.target = context.scene.sketcher.entities.add_line_2d(p1, p2, self.sketch)
+        if context.scene.sketcher.use_construction:
+            self.target.construction = True
 
         # auto vertical/horizontal constraint
         constraints = context.scene.sketcher.constraints

--- a/operators/add_line_3d.py
+++ b/operators/add_line_3d.py
@@ -46,6 +46,8 @@ class View3D_OT_slvs_add_line3d(Operator, Operator3d):
         p1, p2 = self.get_point(context, 0), self.get_point(context, 1)
 
         self.target = context.scene.sketcher.entities.add_line_3d(p1, p2)
+        if context.scene.sketcher.use_construction:
+            self.target.construction = True
         ignore_hover(self.target)
         return True
 

--- a/operators/add_point_2d.py
+++ b/operators/add_point_2d.py
@@ -37,6 +37,8 @@ class View3D_OT_slvs_add_point2d(Operator, Operator2d):
         self.target = context.scene.sketcher.entities.add_point_2d(
             self.coordinates, sketch
         )
+        if context.scene.sketcher.use_construction:
+            self.target.construction = True
 
         # Store hovered entity to use for auto-coincident since it doesn't get
         # stored for non-interactive tools

--- a/operators/add_point_3d.py
+++ b/operators/add_point_3d.py
@@ -33,6 +33,8 @@ class View3D_OT_slvs_add_point3d(Operator, Operator3d):
 
     def main(self, context: Context):
         self.target = context.scene.sketcher.entities.add_point_3d(self.location)
+        if context.scene.sketcher.use_construction:
+            self.target.construction = True
 
         # Store hovered entity to use for auto-coincident since it doesn't get
         # stored for non-interactive tools

--- a/operators/add_rectangle.py
+++ b/operators/add_rectangle.py
@@ -51,12 +51,20 @@ class View3D_OT_slvs_add_rectangle(Operator, Operator2d):
         p_rb = sse.add_point_2d((p_rt.co.x, p_lb.co.y), sketch)
         p_lt = sse.add_point_2d((p_lb.co.x, p_rt.co.y), sketch)
 
+        if context.scene.sketcher.use_construction:
+            p_lb.construction = True
+            p_rb.construction = True
+            p_rt.construction = True
+            p_lt.construction = True
+
         lines = []
         points = (p_lb, p_rb, p_rt, p_lt)
         for i, start in enumerate(points):
             end = points[i + 1 if i < len(points) - 1 else 0]
 
             line = sse.add_line_2d(start, end, sketch)
+            if context.scene.sketcher.use_construction:
+                line.construction = True
             lines.append(line)
 
         self.lines = lines
@@ -109,6 +117,8 @@ class View3D_OT_slvs_add_rectangle(Operator, Operator2d):
         sse = context.scene.sketcher.entities
         point = sse.add_point_2d(value, self.sketch)
         ignore_hover(point)
+        if context.scene.sketcher.use_construction:
+            point.construction = True
 
         self.add_coincident(context, point, state, state_data)
         state_data["type"] = SlvsPoint2D

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -6,7 +6,7 @@ from .. import icon_manager
 from ..model import types
 from ..stateful_operator import constants
 from ..utilities import preferences
-from .panels.add_constraint import VIEW3D_PT_sketcher_add_constraints
+from .panels.tools import VIEW3D_PT_sketcher_tools
 from .panels.constraints_list import VIEW3D_PT_sketcher_constraints
 from .panels.debug import VIEW3D_PT_sketcher_debug
 from .panels.entities_list import VIEW3D_PT_sketcher_entities
@@ -41,7 +41,7 @@ def draw_add_sketch_in_add_menu(self, context: Context):
 classes = [
     VIEW3D_UL_sketches,
     VIEW3D_PT_sketcher,
-    VIEW3D_PT_sketcher_add_constraints,
+    VIEW3D_PT_sketcher_tools,
     VIEW3D_PT_sketcher_entities,
     VIEW3D_PT_sketcher_constraints,
     VIEW3D_PT_sketcher_debug,

--- a/ui/panels/constraints_list.py
+++ b/ui/panels/constraints_list.py
@@ -87,7 +87,7 @@ class VIEW3D_PT_sketcher_constraints(VIEW3D_PT_sketcher_base):
     """
 
     bl_label = "Constraints"
-    bl_idname = declarations.Panels.SketcherContraints
+    bl_idname = declarations.Panels.SketcherConstraints
     bl_options = {"DEFAULT_CLOSED"}
 
     def draw(self, context: Context):

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -23,3 +23,9 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
 
         for op in declarations.ConstraintOperators:
             col.operator(op, icon_value=icon_manager.get_constraint_icon(op))
+
+        layout.separator()
+
+        # Drawing
+        layout.label(text="Drawing:")
+        layout.prop(context.scene.sketcher, "use_construction")

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -5,18 +5,19 @@ from .. import icon_manager
 from . import VIEW3D_PT_sketcher_base
 
 
-class VIEW3D_PT_sketcher_add_constraints(VIEW3D_PT_sketcher_base):
+class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
     """
-    Add Constraint Menu: List of buttons with the constraint you want
-    to create.
+    Tools Menu: List of useful tools for sketching
     """
 
-    bl_label = "Add Constraints"
-    bl_idname = declarations.Panels.SketcherAddContraint
+    bl_label = "Tools"
+    bl_idname = declarations.Panels.SketcherTools
     bl_options = {"DEFAULT_CLOSED"}
 
     def draw(self, context: Context):
         layout = self.layout
+
+        # Constraints
         layout.label(text="Constraints:")
         col = layout.column(align=True)
 


### PR DESCRIPTION
This PR fixes #327 and adds a construction mode checkbox to draw all subsequent entities in construction mode. As per the suggestion of @hlorus, the "Add Constraints" panel is renamed to "Tools", and the construction mode checkbox is added there. You can toggle the construction mode using shortcut "Alt + Shift + C".


https://user-images.githubusercontent.com/11031519/223594299-790db4a8-d758-49c0-9da4-6068c12d9288.mp4

