### PR TITLE
Optimise UI and better resize behaviour

### DIFF
--- a/model/diameter.py
+++ b/model/diameter.py
@@ -18,7 +18,6 @@ from ..utilities.solver import update_system_cb
 
 logger = logging.getLogger(__name__)
 
-
 class SlvsDiameter(DimensionalConstraint, PropertyGroup):
     """Sets the diameter of an arc or a circle."""
 

--- a/ui/panels/constraints_list.py
+++ b/ui/panels/constraints_list.py
@@ -15,12 +15,8 @@ def draw_constraint_listitem(
     index = context.scene.sketcher.constraints.get_index(constraint)
     row = layout.row()
 
-    left_sub = row.row(align=True)
-
-    # Left part
-    left_sub.alignment = "LEFT"
-
-    left_sub.prop(
+    # Visible/Hidden property
+    row.prop(
         constraint,
         "visible",
         icon_only=True,
@@ -29,33 +25,22 @@ def draw_constraint_listitem(
     )
 
     # Failed hint
-    left_sub.label(
+    row.label(
         text="",
         icon=("ERROR" if constraint.failed else "CHECKMARK"),
     )
+
     # Label
-    left_sub.prop(constraint, "name", text="")
+    row.prop(constraint, "name", text="")
 
-    # Middle Part
-    center_sub = row.row()
-    center_sub.alignment = "LEFT"
+    # Constraint Values
+    middle_sub = row.row()
 
-    # Dimensional Constraint Values
     for constraint_prop in constraint.props:
-        center_sub.prop(constraint, constraint_prop, text="")
-
-    # # Disable interaction with element if it is "readonly"
-    # center_sub.enabled = not (
-    #     isinstance(constraint, DimensionalConstraint)
-    #     and constraint.is_reference
-    # )
-
-    # Right part
-    right_sub = row.row()
-    right_sub.alignment = "RIGHT"
+        middle_sub.prop(constraint, constraint_prop, text="")
 
     # Context menu, shows constraint name
-    props = right_sub.operator(
+    props = row.operator(
         declarations.Operators.ContextMenu,
         text="",
         icon="OUTLINER_DATA_GP_LAYER",
@@ -68,7 +53,7 @@ def draw_constraint_listitem(
     props.highlight_members = True
 
     # Delete operator
-    props = right_sub.operator(
+    props = row.operator(
         declarations.Operators.DeleteConstraint,
         text="",
         icon="X",
@@ -78,7 +63,6 @@ def draw_constraint_listitem(
     props.index = index
     props.highlight_hover = True
     props.highlight_members = True
-
 
 class VIEW3D_PT_sketcher_constraints(VIEW3D_PT_sketcher_base):
     """

--- a/ui/panels/entities_list.py
+++ b/ui/panels/entities_list.py
@@ -30,12 +30,8 @@ class VIEW3D_PT_sketcher_entities(VIEW3D_PT_sketcher_base):
             row = col.row()
             row.alert = e.selected
 
-            # Left part
-            sub = row.row(align=True)
-            sub.alignment = "LEFT"
-
             # Select operator
-            props = sub.operator(
+            props = row.operator(
                 declarations.Operators.Select,
                 text="",
                 emboss=False,
@@ -46,7 +42,7 @@ class VIEW3D_PT_sketcher_entities(VIEW3D_PT_sketcher_base):
             props.highlight_hover = True
 
             # Visibility toggle
-            sub.prop(
+            row.prop(
                 e,
                 "visible",
                 icon_only=True,
@@ -54,17 +50,10 @@ class VIEW3D_PT_sketcher_entities(VIEW3D_PT_sketcher_base):
                 emboss=False,
             )
 
-            # Middle Part
-            sub = row.row()
-            sub.alignment = "LEFT"
-            sub.prop(e, "name", text="")
-
-            # Right part
-            sub = row.row()
-            sub.alignment = "RIGHT"
+            row.prop(e, "name", text="")
 
             # Context menu
-            props = sub.operator(
+            props = row.operator(
                 declarations.Operators.ContextMenu,
                 text="",
                 icon="OUTLINER_DATA_GP_LAYER",
@@ -75,7 +64,7 @@ class VIEW3D_PT_sketcher_entities(VIEW3D_PT_sketcher_base):
             props.index = e.slvs_index
 
             # Delete operator
-            props = sub.operator(
+            props = row.operator(
                 declarations.Operators.DeleteEntity,
                 text="",
                 icon="X",


### PR DESCRIPTION
The names and values of the constraints and entities had a fixed ratio, which meant when the panel was larger, both names and values of the rows were not expanding, effectively wasting space that could have been used to show information.

If it this had already been done and there's any reason why wouldn't we have these changes, let me know!


| Before | After |
|--------|--------|
| https://user-images.githubusercontent.com/4479527/231173541-51af97d9-b19c-4abb-a9f2-ef8b332f3c4d.mp4 |  https://user-images.githubusercontent.com/4479527/231172428-d22244bd-cb00-491d-bec0-45e2dea2148d.mp4 |





