### PR TITLE
Remove references to old name from documentation

### DIFF
--- a/docs/entities.md
+++ b/docs/entities.md
@@ -1,4 +1,4 @@
-Entities are the basic elements which are used to draw geometry in BGS. They differ from regular blender mesh or curve elements which means native blender tools aren't able to interact with it as long as they aren't converted. See the chapter [integration](integration.md) for further details on how to process addon specific geometry.
+Entities are the basic elements which are used to draw geometry in CAD Sketcher. They differ from regular blender mesh or curve elements which means native blender tools aren't able to interact with it as long as they aren't converted. See the chapter [integration](integration.md) for further details on how to process addon specific geometry.
 
 Entities are defined by a set of parameters and pointers to other entities which are editable at any point in time. This allows non-destructive workflows and also ensures that geometry is resolution independent. A curve will always follow a given radius no matter how it's transformed. Entities can be created with the various [Workspacetools](user_interface.md#workspacetools).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,9 +11,9 @@ CAD Sketcher integrates the solver of Solvespace and closely follows its design.
 Therefore the [Solvespace Documentation](https://solvespace.readthedocs.io/en/latest/) is generally also relevant.
 
 In order to have a parametric representation of a geometric system where curves
-are independent of resolution, BGS introduces a set of [Entities](entities.md).
+are independent of resolution, CAD Sketcher introduces a set of [Entities](entities.md).
 
-Those Entities can be both in 2d and 3d. BGS isn't strictly limited to but mainly
+Those Entities can be both in 2d and 3d. CAD Sketcher isn't strictly limited to but mainly
 focuses on 2d entities. In order to group a set of 2d entities we use [Sketches](entities.md#SlvsSketch).
 
 The final position and dimensions of a drawn shape is defined by [Constraints](constraints.md).
@@ -21,7 +21,7 @@ The final position and dimensions of a drawn shape is defined by [Constraints](c
 In order to have entities follow the defined constraints,
 a [Solver](solver.md) is needed.
 
-To further process the resulting geometry BGS uses [Converters](integration.md)
+To further process the resulting geometry CAD Sketcher uses [Converters](integration.md)
 to get native Blender geometry types which then allow further modifications with native tools.
 
 <!-- Check the [Workflow](solver.md#Workflow) section to see how it's intended to be used. -->

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -15,7 +15,7 @@ that either of those use the same [interaction system](interaction_system.md).
 
 Workspacetools are used to interactively create entities. You can access them from
 the viewport's "T"-panel. Check the [tools section](tools.md) to get familiar with
-the behavior of BGS tools.
+the behavior of CAD Sketcher tools.
 
 > **INFO:** Interaction with addon geometry is only possible when one of the
 addon tools is active.


### PR DESCRIPTION
Updated all references of the old name to CAD Sketcher in the documentation. #408 