### PR TITLE
Fix tangent typo

### DIFF
--- a/operators/add_geometric_constraints.py
+++ b/operators/add_geometric_constraints.py
@@ -156,7 +156,7 @@ class VIEW3D_OT_slvs_add_perpendicular(Operator, GenericConstraintOp):
 
 
 class VIEW3D_OT_slvs_add_tangent(Operator, GenericConstraintOp):
-    """Add a tagent constraint"""
+    """Add a tangent constraint"""
 
     bl_idname = Operators.AddTangent
     bl_label = "Tangent"


### PR DESCRIPTION
The UI description for the tangent operator shows `tagent` instead of `tangent`.
I think this is where that typo is coming from...