### PR TITLE
Driver Usability Features to improve parametric design workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+
+
+**This fork includes a number of enhancements related to the use of drivers in CAD_Sketcher.**
+The improvements to this fork share the same license as the original project. 
+I'd love to see these changes brought back into the official main branch someday. Enjoy!
+
+Please refer to [fork-ecosky.md]([url](https://github.com/ecosky/CAD_Sketcher/blob/main/fork-ecosky.md)) for more information. 
+
+
+
+Original readme below:
+==================================================================================================================================
+
+
 [![CAD Sketcher](/resources/logos/wide_dark.png)](https://hlorus.github.io/CAD_Sketcher/#gh-light-mode-only)
 [![CAD Sketcher](/resources/logos/wide_light.png)](https://hlorus.github.io/CAD_Sketcher/#gh-dark-mode-only)
 

--- a/declarations.py
+++ b/declarations.py
@@ -76,7 +76,9 @@ class Operators(str, Enum):
     WriteSelectionTexture = "view3d.slvs_write_selection_texture"
     DriverMenu = "view3d.driver_menu"
     SetDriver = "view3d.set_driver"
+    AddDriverSource = "view3d.add_driver_source"
     AddLocalDriverSource = "view3d.add_local_driver_source"
+    DeleteDriverSource = "view3d.delete_driver_source"
     DeleteLocalDriverSource = "view3d.delete_local_driver_source"
 
 class Macros(str, Enum):
@@ -95,6 +97,7 @@ class Panels(str, Enum):
     SketcherConstraints = "VIEW3D_PT_sketcher_constraints"
     SketcherEntities = "VIEW3D_PT_sketcher_entities"
     SketcherDrivers = "VIEW3D_PT_sketcher_drivers"
+    SketcherLocalDrivers = "VIEW3D_PT_sketcher_local_drivers"
 
 
 class VisibilityTypes(str, Enum):

--- a/declarations.py
+++ b/declarations.py
@@ -74,7 +74,10 @@ class Operators(str, Enum):
     TweakConstraintValuePos = "view3d.slvs_tweak_constraint_value_pos"
     UnregisterDrawCB = "view3d.slvs_unregister_draw_cb"
     WriteSelectionTexture = "view3d.slvs_write_selection_texture"
-
+    DriverMenu = "view3d.driver_menu"
+    SetDriver = "view3d.set_driver"
+    AddLocalDriverSource = "view3d.add_local_driver_source"
+    DeleteLocalDriverSource = "view3d.delete_local_driver_source"
 
 class Macros(str, Enum):
     DuplicateMove = "view3d.slvs_duplicate_move"
@@ -82,6 +85,7 @@ class Macros(str, Enum):
 
 class Menus(str, Enum):
     SelectedMenu = "VIEW3D_MT_selected_menu"
+    DriverMenu = "VIEW3D_MT_driver_menu"
 
 
 class Panels(str, Enum):
@@ -90,6 +94,7 @@ class Panels(str, Enum):
     SketcherTools = "VIEW3D_PT_sketcher_tools"
     SketcherConstraints = "VIEW3D_PT_sketcher_constraints"
     SketcherEntities = "VIEW3D_PT_sketcher_entities"
+    SketcherDrivers = "VIEW3D_PT_sketcher_drivers"
 
 
 class VisibilityTypes(str, Enum):

--- a/fork-ecosky.md
+++ b/fork-ecosky.md
@@ -1,0 +1,45 @@
+This fork includes the following improvements:
+
+**Driver Usability Features to improve parametric design workflow**
+
+While CAD Sketcher already had support for using Blender drivers to centralize the data used to specify values on constraints, it can be
+cumbersome when there are lots of data to manage. The previous workflow involved finding a property somewhere, context menu on it to
+Copy as New Driver, then going back to the constraint and pasting it. Since the data are typically stored in custom properties, this also means
+relying on Blender's custom property interfaces which don't offer many organizational features. 
+
+This fork aims to improve some of these issues with the following:
+
+* Added buttons to the constraint panel that displays a context menu
+which allow the user to select a suitable constraint target from a user
+defined set of objects. 
+* Added a new panel that allows the user to select any number of
+objects for use by the new driver selection context menu.
+
+
+When the driver selection menu appears, it will sort all the candidates
+alphabetically and for each one, list all the int and float custom
+properties that are suitable for use as drivers. Choosing one will
+cause any existing driver to be destroyed, and creates a new one using
+the selected property.
+
+These features make selecting sources for constraints very efficient
+because each sketch can specify which set of source objects to pull data from,
+which provides the option to organize dimensional data many useful ways.
+
+I have done only a small amount of testing and while it seems to be
+working for me, it may not work for you. 
+
+Possible future enhancements include:
+* A global list of driver sources that are shared with all sketches.
+* An option to "add" the driver to the existing driver, to facilitate the creation of expressions that use data from multiple driver sources.
+* Copy/Paste driver sources between sketches
+* Informative tooltips
+* Drag & drop the list of driver sources for organizational purposes
+
+
+
+
+![image](https://github.com/ecosky/CAD_Sketcher/assets/8033250/e4c11c37-7508-40c6-925c-2f70b931d2c5)
+![image](https://github.com/ecosky/CAD_Sketcher/assets/8033250/6b6da429-9c67-41ad-808c-1567873c5adf)
+
+

--- a/model/group_sketcher.py
+++ b/model/group_sketcher.py
@@ -13,6 +13,7 @@ from .base_entity import SlvsGenericEntity
 from .group_entities import SlvsEntities
 from .group_constraints import SlvsConstraints
 from ..utilities.view import update_cb
+from ..model.sketch import SourceDriverGroup
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +45,8 @@ class SketcherProps(PropertyGroup):
 
     # This is needed for the sketches ui list
     ui_active_sketch: IntProperty()
+
+    driver_sources: bpy.props.CollectionProperty(name="driver_sources", type=SourceDriverGroup)
 
     @property
     def all(self) -> Generator[Union[SlvsGenericEntity, SlvsConstraints], None, None]:

--- a/model/sketch.py
+++ b/model/sketch.py
@@ -20,6 +20,8 @@ convert_items = [
     ("MESH", "Mesh", "", 3),
 ]
 
+class SourceDriverGroup(bpy.types.PropertyGroup):
+    source : bpy.props.PointerProperty(name="source", type=bpy.types.Object)
 
 # TODO: draw sketches and allow selecting
 class SlvsSketch(SlvsGenericEntity, PropertyGroup):
@@ -60,6 +62,7 @@ class SlvsSketch(SlvsGenericEntity, PropertyGroup):
     curve_resolution: IntProperty(
         name="Mesh Curve Resolution", default=12, min=1, soft_max=25
     )
+    driver_sources: bpy.props.CollectionProperty(name="driver_sources", type=SourceDriverGroup)
 
     def dependencies(self) -> List[SlvsGenericEntity]:
         return [
@@ -111,4 +114,4 @@ class SlvsSketch(SlvsGenericEntity, PropertyGroup):
 slvs_entity_pointer(SlvsSketch, "wp")
 SlvsSketch.__setattr__ = unique_attribute_setter
 
-register, unregister = register_classes_factory((SlvsSketch,))
+register, unregister = register_classes_factory((SourceDriverGroup, SlvsSketch))

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -9,6 +9,8 @@ from ..utilities import preferences
 from .panels.tools import VIEW3D_PT_sketcher_tools
 from .panels.constraints_list import VIEW3D_PT_sketcher_constraints
 from .panels.debug import VIEW3D_PT_sketcher_debug
+from .panels.driver_menu import VIEW3D_MT_driver_menu, DriverMenuOperator, SetDriverOperator
+from .panels.driver_sources import VIEW3D_PT_sketcher_drivers, AddLocalDriverSourceOperator, DeleteLocalDriverSourceOperator
 from .panels.entities_list import VIEW3D_PT_sketcher_entities
 from .panels.sketch_select import VIEW3D_PT_sketcher
 from .sketches_list import VIEW3D_UL_sketches
@@ -43,7 +45,13 @@ classes = [
     VIEW3D_PT_sketcher_entities,
     VIEW3D_PT_sketcher_constraints,
     VIEW3D_PT_sketcher_debug,
+    VIEW3D_PT_sketcher_drivers,
     VIEW3D_MT_selected_menu,
+    VIEW3D_MT_driver_menu,
+    DriverMenuOperator,
+    SetDriverOperator,
+    AddLocalDriverSourceOperator,
+    DeleteLocalDriverSourceOperator
 ]
 
 

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -10,7 +10,7 @@ from .panels.tools import VIEW3D_PT_sketcher_tools
 from .panels.constraints_list import VIEW3D_PT_sketcher_constraints
 from .panels.debug import VIEW3D_PT_sketcher_debug
 from .panels.driver_menu import VIEW3D_MT_driver_menu, DriverMenuOperator, SetDriverOperator
-from .panels.driver_sources import VIEW3D_PT_sketcher_drivers, AddLocalDriverSourceOperator, DeleteLocalDriverSourceOperator
+from .panels.driver_sources import VIEW3D_PT_sketcher_drivers, VIEW3D_PT_sketcher_local_drivers, AddDriverSourceOperator, AddLocalDriverSourceOperator, DeleteDriverSourceOperator, DeleteLocalDriverSourceOperator
 from .panels.entities_list import VIEW3D_PT_sketcher_entities
 from .panels.sketch_select import VIEW3D_PT_sketcher
 from .sketches_list import VIEW3D_UL_sketches
@@ -46,11 +46,14 @@ classes = [
     VIEW3D_PT_sketcher_constraints,
     VIEW3D_PT_sketcher_debug,
     VIEW3D_PT_sketcher_drivers,
+    VIEW3D_PT_sketcher_local_drivers,
     VIEW3D_MT_selected_menu,
     VIEW3D_MT_driver_menu,
     DriverMenuOperator,
     SetDriverOperator,
+    AddDriverSourceOperator,
     AddLocalDriverSourceOperator,
+    DeleteDriverSourceOperator,
     DeleteLocalDriverSourceOperator
 ]
 

--- a/ui/panels/constraints_list.py
+++ b/ui/panels/constraints_list.py
@@ -6,7 +6,7 @@ from . import VIEW3D_PT_sketcher_base
 
 
 def draw_constraint_listitem(
-    context: Context, layout: UILayout, constraint: types.GenericConstraint
+    context: Context, layout: UILayout, constraint: types.GenericConstraint, drivers_available = False
 ):
     """
     Creates a single row inside the ``layout`` describing
@@ -40,8 +40,8 @@ def draw_constraint_listitem(
         middle_sub.prop(constraint, constraint_prop, text="")
 
         # Assign Driver, shows list of candidate driver sources
-        if(isinstance(constraint, types.DimensionalConstraint)):
-            
+        if(drivers_available and isinstance(constraint, types.DimensionalConstraint)):
+
             props = middle_sub.operator(
                 declarations.Operators.DriverMenu,
                 text="",
@@ -104,10 +104,15 @@ class VIEW3D_PT_sketcher_constraints(VIEW3D_PT_sketcher_base):
         col.scale_y = 0.8
 
         sketch = context.scene.sketcher.active_sketch
+        drivers_available = (
+            (context.scene.sketcher.driver_sources and any(driver.source is not None for driver in context.scene.sketcher.driver_sources))
+            or 
+            (sketch.driver_sources is not None and any(driver.source is not None for driver in sketch.driver_sources))
+        )
         for c in context.scene.sketcher.constraints.dimensional:
             if not c.is_active(sketch):
                 continue
-            draw_constraint_listitem(context, col, c)
+            draw_constraint_listitem(context, col, c, drivers_available=drivers_available)
 
         # Geometric Constraints
         layout.label(text="Geometric:")

--- a/ui/panels/constraints_list.py
+++ b/ui/panels/constraints_list.py
@@ -39,6 +39,18 @@ def draw_constraint_listitem(
     for constraint_prop in constraint.props:
         middle_sub.prop(constraint, constraint_prop, text="")
 
+        # Assign Driver, shows list of candidate driver sources
+        if(isinstance(constraint, types.DimensionalConstraint)):
+            
+            props = middle_sub.operator(
+                declarations.Operators.DriverMenu,
+                text="",
+                icon="DRIVER",
+                emboss=False,
+            )
+            props.type = constraint.type
+            props.index = index
+      
     # Context menu, shows constraint name
     props = row.operator(
         declarations.Operators.ContextMenu,

--- a/ui/panels/driver_menu.py
+++ b/ui/panels/driver_menu.py
@@ -1,0 +1,130 @@
+
+import bpy
+from bpy.types import Operator, Menu
+from bpy.props import StringProperty, IntProperty
+
+from ...declarations import Operators, Menus
+
+
+# Define the operator class
+class DriverMenuOperator(Operator):
+    bl_label = "Driver Menu Operator"
+    bl_idname = Operators.DriverMenu # "object.driver_menu"
+    type: StringProperty(name="Type", options={"SKIP_SAVE"})
+    index: IntProperty(name="Index", default=-1, options={"SKIP_SAVE"})
+
+    def invoke(self, context, event):
+        VIEW3D_MT_driver_menu.index = self.index
+        VIEW3D_MT_driver_menu.type = self.type
+        bpy.ops.wm.call_menu(name=VIEW3D_MT_driver_menu.bl_idname)
+        return {'FINISHED'}
+
+# Define the operator class
+class SetDriverOperator(Operator):
+    bl_label = "Set Driver Operator"
+    bl_idname = Operators.SetDriver # "object.set_driver"
+
+    type: StringProperty(name="Type", options={"SKIP_SAVE"})
+    index: IntProperty(name="Index", default=-1, options={"SKIP_SAVE"})
+    sourceobject: StringProperty(name="sourceobject", options={"SKIP_SAVE"})
+    sourceproperty: StringProperty(name="sourceproperty", options={"SKIP_SAVE"})
+
+   
+    # https://blender.stackexchange.com/questions/262012/how-to-set-up-driver-via-python-script-between-custom-properties-of-objects
+    @staticmethod
+    def add_driver(source, target, prop, dataPath):
+        
+
+        # add the new driver
+        d = source.driver_add( prop ).driver
+        v = d.variables.new()
+        v.name                 = prop
+        v.targets[0].id        = target
+        v.targets[0].data_path = dataPath
+        d.expression = v.name
+
+
+    def execute(self, context):
+        constraints = context.scene.sketcher.constraints
+        constraint = constraints.get_from_type_index(self.type, self.index)
+
+        # Remove any existing drivers
+        # It might be useful to add another button to enable adding multiple drivers to the constraint,
+        # which would make it easier to assemble collections of drivers for a complex experssion.
+        while constraint.driver_remove("value", 0):
+            pass
+
+        if(self.sourceobject == ""):
+            return {'FINISHED'}
+
+        src = bpy.data.objects[self.sourceobject]
+        print(src)
+        self.add_driver(constraint, src, "value", f'["'+self.sourceproperty+'"]')
+        return {'FINISHED'}
+    
+    def invoke(self, context, event):
+        return self.execute(context)
+
+
+
+# Define the menu class
+class VIEW3D_MT_driver_menu(Menu):
+    bl_label = "Select Driver"
+    bl_idname = Menus.DriverMenu
+    
+    type = ""
+    index = -1
+
+    def draw(self, context):
+        layout = self.layout
+
+        props = layout.operator(
+            Operators.SetDriver,
+            text="None",
+            icon="TRASH"
+        )
+        props.type = self.type
+        props.index = self.index
+        props.sourceobject = ""
+        props.sourceproperty = ""
+
+        r = layout
+
+        sketch = bpy.context.scene.sketcher.active_sketch
+        if sketch is None:
+            return 
+        
+        sources = []
+        for group in sketch.driver_sources:
+            if not group is None:
+                source = group.source
+                if not source is None:
+                    sources.append(source)
+
+        sources.sort(key=lambda s: s.name)
+
+        for source in sources:
+            drewSource = False
+            for i, k in enumerate(source.keys()):
+                v = source[k]
+                if isinstance(v, int) or isinstance(v, float): 
+
+                    if not drewSource:
+                        drewSource = True
+                        r.separator()
+                        r.label(text=source.name, icon="OBJECT_DATA")
+
+                    props = r.operator(
+                        Operators.SetDriver,
+                        text= k + " " + str(v),
+                        icon="DRIVER"
+                    )
+                    props.type = self.type
+                    props.index = self.index
+                    props.sourceobject = source.name
+                    props.sourceproperty = k
+
+
+
+
+

--- a/ui/panels/driver_menu.py
+++ b/ui/panels/driver_menu.py
@@ -5,6 +5,7 @@ from bpy.props import StringProperty, IntProperty
 
 from ...declarations import Operators, Menus
 
+from .driver_util import GetDriverSources
 
 # Define the operator class
 class DriverMenuOperator(Operator):
@@ -33,8 +34,6 @@ class SetDriverOperator(Operator):
     # https://blender.stackexchange.com/questions/262012/how-to-set-up-driver-via-python-script-between-custom-properties-of-objects
     @staticmethod
     def add_driver(source, target, prop, dataPath):
-        
-
         # add the new driver
         d = source.driver_add( prop ).driver
         v = d.variables.new()
@@ -94,14 +93,7 @@ class VIEW3D_MT_driver_menu(Menu):
         if sketch is None:
             return 
         
-        sources = []
-        for group in sketch.driver_sources:
-            if not group is None:
-                source = group.source
-                if not source is None:
-                    sources.append(source)
-
-        sources.sort(key=lambda s: s.name)
+        sources = GetDriverSources(context, sketch)
 
         for source in sources:
             drewSource = False

--- a/ui/panels/driver_sources.py
+++ b/ui/panels/driver_sources.py
@@ -8,17 +8,43 @@ from . import VIEW3D_PT_sketcher_base
 
 from ...declarations import Operators
 
+class AddDriverSourceOperator(Operator):
+    bl_label = "Add Driver Source Operator"
+    bl_idname = Operators.AddDriverSource
+
+    def execute(self, context):
+        sketch = context.scene.sketcher.driver_sources.add()
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        return self.execute(context)
+
+
+class DeleteDriverSourceOperator(Operator):
+    bl_label = "Delete Local Driver Source Operator"
+    bl_idname = Operators.DeleteDriverSource 
+
+    index: IntProperty(default=-1)
+
+    def execute(self, context):
+        context.scene.sketcher.driver_sources.remove(self.index)
+        return {'FINISHED'}
+
+    def invoke(self, context, event):
+        return self.execute(context)
+
 
 class AddLocalDriverSourceOperator(Operator):
     bl_label = "Add Local Driver Source Operator"
     bl_idname = Operators.AddLocalDriverSource
 
-    def invoke(self, context, event):
-        sketch = context.scene.sketcher.active_sketch
-        #print("Add local driver")
-        #print("Adding source. Current count: " + str(len(sketch.driver_sources)))
-        driverGroup = sketch.driver_sources.add()
+    def execute(self, context):
+        driverGroup = context.scene.sketcher.active_sketch.driver_sources.add()
         return {'FINISHED'}
+
+    def invoke(self, context, event):
+        return self.execute(context)
+
 
 class DeleteLocalDriverSourceOperator(Operator):
     bl_label = "Delete Local Driver Source Operator"
@@ -27,18 +53,14 @@ class DeleteLocalDriverSourceOperator(Operator):
     index: IntProperty(default=-1)
 
     def execute(self, context):
-        print("Delete local driver")
-        sketch = context.scene.sketcher.active_sketch
+        context.scene.sketcher.active_sketch.driver_sources.remove(self.index)
         return {'FINISHED'}
     
     def invoke(self, context, event):
-        print("Delete local driver")
-        sketch = context.scene.sketcher.active_sketch
-        sketch.driver_sources.remove(self.index)
-        return {'FINISHED'}
+        return self.execute(context)
 
 
-def draw_driver_listitem(context: Context, layout: UILayout, source, index):
+def draw_driver_listitem(context: Context, layout: UILayout, source, index, op):
     """
     Creates a single row inside the ``layout`` describing
     the driver ``source``.
@@ -49,12 +71,21 @@ def draw_driver_listitem(context: Context, layout: UILayout, source, index):
     middle_sub = row.row()
 
     props = row.operator(
-        declarations.Operators.DeleteLocalDriverSource,
+        op, 
         text="",
         icon="X",
         emboss=False,
     )
     props.index = index
+
+def draw_drivers(context: Context, layout, driver_sources, op_add, op_delete):
+    col = layout.column(align=True)
+    col.operator(op_add, text="Add", icon="ADD")
+    box = layout.box()
+    col = box.column(align=True)
+    if not driver_sources is None:
+        for index, source in enumerate(driver_sources):
+            draw_driver_listitem(context, col, source, index, op_delete)
 
 class VIEW3D_PT_sketcher_drivers(VIEW3D_PT_sketcher_base):
     """
@@ -62,24 +93,30 @@ class VIEW3D_PT_sketcher_drivers(VIEW3D_PT_sketcher_base):
     Interactive
     """
 
-    bl_label = "Driver Menu"
+    bl_label = "Global Drivers"
     bl_idname = declarations.Panels.SketcherDrivers
     bl_options = {"DEFAULT_CLOSED"}
 
     def draw(self, context: Context):
         layout = self.layout
-        col = layout.column(align=True)
+
+        draw_drivers(context, layout, bpy.context.scene.sketcher.driver_sources, declarations.Operators.AddDriverSource, declarations.Operators.DeleteDriverSource)
+
+
+class VIEW3D_PT_sketcher_local_drivers(VIEW3D_PT_sketcher_base):
+    """
+    Driver Menu: Display list of suitable driver sources for selection
+    Interactive
+    """
+
+    bl_label = "Local Drivers"
+    bl_idname = declarations.Panels.SketcherLocalDrivers
+    bl_options = {"DEFAULT_CLOSED"}
+
+    def draw(self, context: Context):
+        layout = self.layout
 
         sketch = bpy.context.scene.sketcher.active_sketch
         if not sketch is None:
-            col.label(text = "Sketch specific driver menu sources")
-            col.operator(declarations.Operators.AddLocalDriverSource, text="Add", icon="ADD")
-            box = layout.box()
-            col = box.column(align=True)
-
-            if hasattr(sketch, "driver_sources"):
-                sources = sketch.driver_sources
-                if not sources is None:
-                    for index, source in enumerate(sources):
-                        draw_driver_listitem(context, col, source, index)
+            draw_drivers(context, layout, sketch.driver_sources, declarations.Operators.AddLocalDriverSource, declarations.Operators.DeleteLocalDriverSource)
 

--- a/ui/panels/driver_sources.py
+++ b/ui/panels/driver_sources.py
@@ -1,0 +1,85 @@
+import bpy
+from bpy.types import Object, Context, UILayout, Operator
+from bpy.props import IntProperty, PointerProperty, CollectionProperty
+
+from .. import declarations
+from .. import types
+from . import VIEW3D_PT_sketcher_base
+
+from ...declarations import Operators
+
+
+class AddLocalDriverSourceOperator(Operator):
+    bl_label = "Add Local Driver Source Operator"
+    bl_idname = Operators.AddLocalDriverSource
+
+    def invoke(self, context, event):
+        sketch = context.scene.sketcher.active_sketch
+        #print("Add local driver")
+        #print("Adding source. Current count: " + str(len(sketch.driver_sources)))
+        driverGroup = sketch.driver_sources.add()
+        return {'FINISHED'}
+
+class DeleteLocalDriverSourceOperator(Operator):
+    bl_label = "Delete Local Driver Source Operator"
+    bl_idname = Operators.DeleteLocalDriverSource 
+
+    index: IntProperty(default=-1)
+
+    def execute(self, context):
+        print("Delete local driver")
+        sketch = context.scene.sketcher.active_sketch
+        return {'FINISHED'}
+    
+    def invoke(self, context, event):
+        print("Delete local driver")
+        sketch = context.scene.sketcher.active_sketch
+        sketch.driver_sources.remove(self.index)
+        return {'FINISHED'}
+
+
+def draw_driver_listitem(context: Context, layout: UILayout, source, index):
+    """
+    Creates a single row inside the ``layout`` describing
+    the driver ``source``.
+    """
+    row = layout.row()
+    row.prop(source, "source", text="")
+
+    middle_sub = row.row()
+
+    props = row.operator(
+        declarations.Operators.DeleteLocalDriverSource,
+        text="",
+        icon="X",
+        emboss=False,
+    )
+    props.index = index
+
+class VIEW3D_PT_sketcher_drivers(VIEW3D_PT_sketcher_base):
+    """
+    Driver Menu: Display list of suitable driver sources for selection
+    Interactive
+    """
+
+    bl_label = "Driver Menu"
+    bl_idname = declarations.Panels.SketcherDrivers
+    bl_options = {"DEFAULT_CLOSED"}
+
+    def draw(self, context: Context):
+        layout = self.layout
+        col = layout.column(align=True)
+
+        sketch = bpy.context.scene.sketcher.active_sketch
+        if not sketch is None:
+            col.label(text = "Sketch specific driver menu sources")
+            col.operator(declarations.Operators.AddLocalDriverSource, text="Add", icon="ADD")
+            box = layout.box()
+            col = box.column(align=True)
+
+            if hasattr(sketch, "driver_sources"):
+                sources = sketch.driver_sources
+                if not sources is None:
+                    for index, source in enumerate(sources):
+                        draw_driver_listitem(context, col, source, index)
+

--- a/ui/panels/driver_util.py
+++ b/ui/panels/driver_util.py
@@ -1,0 +1,19 @@
+
+def AddSources(sources, driver_sources):
+    if driver_sources is None:
+        return
+    for group in driver_sources:
+        if not group is None:
+            source = group.source
+            if not source is None:
+                sources.append(source)
+
+    
+def GetDriverSources(context, sketch):
+    sources = []
+    if not sketch is None:
+        AddSources(sources, sketch.driver_sources)
+
+    AddSources(sources, context.scene.sketcher.driver_sources)
+    sources.sort(key=lambda s: s.name)
+    return sources


### PR DESCRIPTION
While CAD Sketcher already had support for using Blender drivers to
centralize the data used to specify values on constraints, it can be
cumbersome when there are lots of data to manage. The previous workflow
involved finding a property somewhere, context menu on it to
Copy as New Driver, then going back to the constraint and pasting it.
Since the data are typically stored in custom properties, this also
means relying on Blender's custom property interfaces which don't offer
many organizational features.

This PR aims to improve some of these issues with the following:

* Added buttons to the constraint panel that displays a context menu
which allow the user to select a suitable constraint target from a user
defined set of objects.
* Added a new panel that allows the user to select any number of
objects for use by the new driver selection context menu.

When the driver selection menu appears, it will sort all the candidates
alphabetically and for each one, list all the int and float custom
properties that are suitable for use as drivers. Choosing one will
cause any existing driver to be destroyed, and creates a new one using
the selected property.

These features make selecting sources for constraints very efficient
because each sketch can specify which set of source objects to pull data from,
which provides the option to organize dimensional data many useful ways.

I have done only a small amount of testing and while it seems to be
working for me, it may not work for you.

Possible future enhancements include:
* A global list of driver sources that are shared with all sketches.
* An option to "add" the driver to the existing driver, to facilitate
  the creation of expressions that use data from multiple driver sources
* Copy/Paste driver sources between sketches
* Informative tooltips
* Drag & drop the list of driver sources for organizational purposes

I have done only a small amount of testing and while it seems to be
working for me, it may not work for you. 


I don't do PRs very often so I'm not sure how exactly to manage the extra file and change I made to the README.md as part of a pull, I am assuming those two commits shouldn't be included but I haven't yet figured out how to submit a PR for just the one feature commit.