### PR TITLE
Removed check for running solver only on coincident constraints

### DIFF
--- a/operators/add_line_2d.py
+++ b/operators/add_line_2d.py
@@ -83,8 +83,7 @@ class View3D_OT_slvs_add_line2d(Operator, Operator2d):
             logger.debug("Add: {}".format(self.target))
 
         if succeede:
-            if self.has_coincident():
-                solve_system(context, sketch=self.sketch)
+            solve_system(context, sketch=self.sketch)
 
 
 register, unregister = register_stateops_factory((View3D_OT_slvs_add_line2d,))


### PR DESCRIPTION
New behavior will run the solver every time after a line segment has been created.  
[BUG] CAD Sketcher shows horizontal and vertical constraints on slanting lines. #429