### PR TITLE
Mesh Extrude, Boolean Convert type

### DIFF
--- a/model/sketch.py
+++ b/model/sketch.py
@@ -3,7 +3,7 @@ from typing import List
 
 import bpy
 from bpy.types import PropertyGroup
-from bpy.props import EnumProperty, BoolProperty, IntProperty, PointerProperty
+from bpy.props import EnumProperty, BoolProperty, IntProperty, PointerProperty, FloatProperty, StringProperty
 from bpy.utils import register_classes_factory
 
 from .. import global_data
@@ -18,6 +18,7 @@ convert_items = [
     ("NONE", "None", "", 1),
     ("BEZIER", "Bezier", "", 2),
     ("MESH", "Mesh", "", 3),
+    ("BOOLEAN", "Boolean", "", 4),
 ]
 
 
@@ -38,6 +39,33 @@ class SlvsSketch(SlvsGenericEntity, PropertyGroup):
         if self.convert_type != "NONE":
             self.visible = False
 
+    boolean_base: StringProperty(
+        name="Base",
+        description="The base object you will be cutting",
+    )
+    boolean_type: EnumProperty(
+        name="Operation",
+        description="Boolean Operation to perform on the selected mesh",
+        items=(
+            ("INTERSECT", "Intersect", ""),
+            ("UNION", "Union", ""),
+            ("DIFFERENCE", "Difference", ""),
+        ),
+        default="DIFFERENCE"
+    )
+    extrude_depth: FloatProperty(
+        name="Depth",
+        description="Distance to extrude the mesh",
+        default=0,
+        min=0,
+    )
+    extrude_offset: FloatProperty(
+        name="Offset",
+        description="Direction to extrude the mesh (Positive, Negative, Both)",
+        min=-1,
+        max=1,
+        default=1,
+    )
     convert_type: EnumProperty(
         name="Convert Type",
         items=convert_items,

--- a/ui/panels/sketch_select.py
+++ b/ui/panels/sketch_select.py
@@ -1,4 +1,5 @@
 from bpy.types import Context, UILayout
+import bpy
 
 from .. import declarations
 from . import VIEW3D_PT_sketcher_base
@@ -75,10 +76,22 @@ class VIEW3D_PT_sketcher(VIEW3D_PT_sketcher_base):
             row.prop(sketch, "name")
             layout.prop(sketch, "convert_type")
 
-            if sketch.convert_type == "MESH":
+            if sketch.convert_type in ["MESH", "BOOLEAN"]:
                 layout.prop(sketch, "curve_resolution")
             if sketch.convert_type != "NONE":
                 layout.prop(sketch, "fill_shape")
+            if sketch.convert_type in ["MESH", "BOOLEAN"]:
+                box = layout.box()
+                column = box.column(align=True)
+                column.label(text="Extrude")
+                column.prop(sketch, "extrude_depth")
+                column.prop(sketch, "extrude_offset")
+            if sketch.convert_type == "BOOLEAN":
+                box = layout.box()
+                column = box.column(align=True)
+                column.label(text="Boolean")
+                column.prop_search(sketch, "boolean_base", bpy.data, "meshes")
+                column.prop(sketch, "boolean_type")
 
             layout.operator(
                 declarations.Operators.DeleteEntity,


### PR DESCRIPTION
## Mesh Extrude
![MeshExtrude](https://github.com/hlorus/CAD_Sketcher/assets/8839603/1955ac6d-2722-4718-b4cb-678f4bb5be9c)
Added an option to 'Extrude' a 3rd dimension to sketches when converting to meshes.  
This adds a Solidify modifier automatically and fills in the 'Depth' and 'Offset' from sketch properties `extrude_depth` and `extrude_offset` It first checks for and adjusts the existing 'Extrude Sketch' Solidify modifier, and creates one if it doesn't exist.

## Boolean Convert type
![BooleanConvert](https://github.com/hlorus/CAD_Sketcher/assets/8839603/a2f16f9e-bcc3-4926-8b53-d80bef003d4a)
Added a 4th conversion mode to the `update_convertor_geometry` function - `Boolean` 
This will convert to mesh, and allows for the new 'Extrude', but also sets the viewport display to 'Bounds' and allows you to specify the target object you wish to cut, automatically applying a Boolean modifier to the target, and selecting your current sketch as the cutter object.