### PR TITLE
Start dashes where line intersects the edge of the screen

### DIFF
--- a/shaders.py
+++ b/shaders.py
@@ -21,12 +21,24 @@ class Shaders:
            gl_Position = ModelViewProjectionMatrix * vec4(pos.xyz, 1.0f);
 
            vec2 ssPos = vec2(gl_Position.xy / gl_Position.w);
-           stipple_start = stipple_pos = ssPos;
+           segment_start = stipple_pos = ssPos;
         }
     """
     base_fragment_shader_3d = """
         void main() {
 
+            vec2 delta = stipple_pos - segment_start;
+            vec2 stipple_start;
+            if (abs(delta.x) > abs(delta.y)) {
+                stipple_start.x = 0;
+                float t = -segment_start.x / delta.x;
+                stipple_start.y = segment_start.y + t * delta.y;
+            }
+            else {
+                stipple_start.y = 0;
+                float t = -segment_start.y / delta.y;
+                stipple_start.x = segment_start.x + t * delta.x;
+            }
             float distance_along_line = distance(stipple_pos, stipple_start);
             float normalized_distance = fract(distance_along_line / dash_width);
 
@@ -50,7 +62,7 @@ class Shaders:
 
         vert_out = GPUStageInterfaceInfo("stipple_pos_interface")
         vert_out.no_perspective("VEC2", "stipple_pos")
-        vert_out.flat("VEC2", "stipple_start")
+        vert_out.flat("VEC2", "segment_start")
 
         # NOTE: How to set default values?
 


### PR DESCRIPTION
This improves on the problem where circles and other things made of lots of short lines become invisible, but the dash spacing still isn't brilliant. It helps #162, but I'm not sure I'd necessarily consider it fully fixed, so I'll leave it up to you whether you want to award the bounty.

Before:
![image](https://github.com/user-attachments/assets/e08213c9-9b21-47b6-9ad2-1cd9ad6ec205)

After:
![image](https://github.com/user-attachments/assets/6bdbf8c5-5be8-4d35-8dea-ee65301a332d)

Alternatively, as an imgsli: https://imgsli.com/MjgyOTMw

I did attempt a better solution (you can see it here https://github.com/AnyOldName3/CAD_Sketcher/tree/sad-overcomplicated-dashhes) but it didn't end up actually looking any better, and was more complicated. Apparently, screen-space line stippling that continues nicely along separate segments in the same line strip isn't something that's easy to do, with the typical solutions being to stick to OpenGL 2.1, which does it in hardware, to use a Vulkan extension that does it in hardware, or to give up.