### PR TITLE
Fixed issue #426

### DIFF
--- a/operators/add_workplane.py
+++ b/operators/add_workplane.py
@@ -137,7 +137,7 @@ class View3D_OT_slvs_add_workplane_face(Operator, Operator3d):
 
         self.target = sse.add_workplane(origin, nm)
         ignore_hover(self.target)
-        [a.tag_redraw() for a in bpy.context.screen.areas] # Force re-draw of UI (Blender doesn't update after tool usage)
+        context.area.tag_redraw() # Force re-draw of UI (Blender doesn't update after tool usage)
         return True
 
 

--- a/operators/add_workplane.py
+++ b/operators/add_workplane.py
@@ -137,6 +137,7 @@ class View3D_OT_slvs_add_workplane_face(Operator, Operator3d):
 
         self.target = sse.add_workplane(origin, nm)
         ignore_hover(self.target)
+        [a.tag_redraw() for a in bpy.context.screen.areas] # Force re-draw of UI (Blender doesn't update after tool usage)
         return True
 
 


### PR DESCRIPTION
This might be a patch for the problem, but it works.
I noticed that Blender doesn't update the UI after creating a new workplane.

# Before
![blender_vjybzlzsDG](https://github.com/user-attachments/assets/c622d924-f080-4d71-acd7-9aebb4312e5d)
I noticed that it creates the new workplanes, but doesn't update the changes.

# After
![blender_iYdK64yN76](https://github.com/user-attachments/assets/673ca104-5235-4602-b259-eb4ff197e3ba)
This is when I force the update after the workplane creation

Windows
Blender 4.0
CAD_Sketcher: latest
(I don't want the bounty. Too much for such a small change)

Edit: Hmm, I just thought about it. It might cause some performance problems for bigger projects. But at least I found the problem.

With that said, I'm not sure if it's avoidable to not re-draw.