### PR TITLE
🐛 fix: improve exception for get_addon_version_tuple

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -27,8 +27,8 @@ def get_addon_version_tuple() -> tuple:
         import toml
         version_tuple = toml.load(manifest)["version"]
         return tuple(map(int, version_tuple.split(".")))
-    except Exception:
-        print("Error: Unable to retrieve addon version")
+    except Exception as e:
+        print(f"Error: Unable to retrieve addon version - {e}")
         return (0, 0, 0)
 
 


### PR DESCRIPTION
When I started Blender, I didn't have the version of the add-on, but no error message. So I did a mini fix of the exception. 

The problem was that I didn't have the toml python lib. Is there anything I can do to indicate the need or autoinstall it ?

It's my first time with python, be kind :smile: 