### PR TITLE
Add Symmetry constraint

### DIFF
--- a/declarations.py
+++ b/declarations.py
@@ -37,6 +37,7 @@ class Operators(str, Enum):
     AddPoint3D = "view3d.slvs_add_point3d"
     AddPresetTheme = "bgs.theme_preset_add"
     AddRatio = "view3d.slvs_add_ratio"
+    AddSymmetry = "view3d.slvs_add_symmetry"
     AddRectangle = "view3d.slvs_add_rectangle"
     AddSketch = "view3d.slvs_add_sketch"
     AddTangent = "view3d.slvs_add_tangent"
@@ -127,4 +128,5 @@ ConstraintOperators = (
     Operators.AddTangent,
     Operators.AddMidPoint,
     Operators.AddRatio,
+    Operators.AddSymmetry,
 )

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -24,8 +24,7 @@ modules = [
     "midpoint",
     "perpendicular",
     "ratio",
-    # currently disabled because of a bug in the solver module
-    # "symmetry",
+    "symmetry",
     "group_constraints",
     "group_sketcher",
 ]

--- a/model/group_constraints.py
+++ b/model/group_constraints.py
@@ -21,6 +21,7 @@ from .perpendicular import SlvsPerpendicular
 from .tangent import SlvsTangent
 from .midpoint import SlvsMidpoint
 from .ratio import SlvsRatio
+from .symmetry import SlvsSymmetry
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,7 @@ class SlvsConstraints(PropertyGroup):
         SlvsMidpoint,
         SlvsPerpendicular,
         SlvsRatio,
+        SlvsSymmetry,
     )
 
     _constraints = (
@@ -58,6 +60,7 @@ class SlvsConstraints(PropertyGroup):
         SlvsMidpoint,
         SlvsPerpendicular,
         SlvsRatio,
+        SlvsSymmetry,
     )
 
     __annotations__ = {
@@ -456,6 +459,32 @@ class SlvsConstraints(PropertyGroup):
             c.assign_init_props(**settings)
         else:
             c.assign_settings(**settings)
+        return c
+
+    def add_symmetry(
+        self,
+        entity1: SlvsGenericEntity,
+        entity2: SlvsGenericEntity,
+        entity3: SlvsGenericEntity,
+        sketch: Union[SlvsSketch, None] = None,
+    ) -> SlvsSymmetry:
+        """Add a symmetry constraint.
+
+        Arguments:
+            entity1: First point entity
+            entity2: Second point entity
+            entity3: Line or workplane to be symmetric about
+            sketch: The sketch this constraint belongs to.
+
+        Returns:
+            SlvsSymmetry: The created constraint.
+        """
+        c = self.symmetry.add()
+        c["entity1_i"] = entity1 if isinstance(entity1, int) else entity1.slvs_index
+        c["entity2_i"] = entity2 if isinstance(entity2, int) else entity2.slvs_index
+        c["entity3_i"] = entity3 if isinstance(entity3, int) else entity3.slvs_index
+        if sketch is not None:
+            c["sketch_i"] = sketch if isinstance(sketch, int) else sketch.slvs_index
         return c
 
 

--- a/model/symmetry.py
+++ b/model/symmetry.py
@@ -16,7 +16,7 @@ from .line_2d import SlvsLine2D
 logger = logging.getLogger(__name__)
 
 
-class SlvsSymmetric(GenericConstraint, PropertyGroup):
+class SlvsSymmetry(GenericConstraint, PropertyGroup):
     """Forces two points to be symmetric about a plane.
 
     The symmetry plane may be a workplane when used in 3D. Or, the symmetry plane
@@ -25,8 +25,8 @@ class SlvsSymmetric(GenericConstraint, PropertyGroup):
 
     """
 
-    type = "SYMMETRIC"
-    label = "Symmetric"
+    type = "SYMMETRY"
+    label = "Symmetry"
 
     # TODO: not all combinations are possible!
     signature = (
@@ -43,32 +43,26 @@ class SlvsSymmetric(GenericConstraint, PropertyGroup):
     def create_slvs_data(self, solvesys, group=Solver.group_fixed):
         e1, e2, e3 = self.entity1, self.entity2, self.entity3
 
-        # NOTE: this doesn't seem to work correctly, acts like addSymmetricVertical
-        if isinstance(e3, SlvsLine2D):
-            return solvesys.addSymmetricLine(
-                e1.py_data,
-                e2.py_data,
-                e3.py_data,
-                self.get_workplane(),
-                group=group,
-            )
+        wp = self.get_workplane()
+        kwargs = {}
+        if wp:
+            kwargs['workplane'] = wp
 
-        elif isinstance(e3, SlvsWorkplane):
-            return solvesys.addSymmetric(
-                e1.py_data,
-                e2.py_data,
-                e3.py_data,
-                wrkpln=self.get_workplane(),
-                group=group,
-            )
+        return solvesys.symmetric(
+            group,
+            e1.py_data,
+            e2.py_data,
+            e3.py_data,
+            **kwargs,
+        )
 
     def placements(self):
         return (self.entity1, self.entity2, self.entity3)
 
 
-slvs_entity_pointer(SlvsSymmetric, "entity1")
-slvs_entity_pointer(SlvsSymmetric, "entity2")
-slvs_entity_pointer(SlvsSymmetric, "entity3")
-slvs_entity_pointer(SlvsSymmetric, "sketch")
+slvs_entity_pointer(SlvsSymmetry, "entity1")
+slvs_entity_pointer(SlvsSymmetry, "entity2")
+slvs_entity_pointer(SlvsSymmetry, "entity3")
+slvs_entity_pointer(SlvsSymmetry, "sketch")
 
-register, unregister = register_classes_factory((SlvsSymmetric,))
+register, unregister = register_classes_factory((SlvsSymmetry,))

--- a/operators/add_geometric_constraints.py
+++ b/operators/add_geometric_constraints.py
@@ -240,6 +240,27 @@ class VIEW3D_OT_slvs_add_ratio(Operator, GenericConstraintOp):
         return super().main(context)
 
 
+class VIEW3D_OT_slvs_add_symmetry(Operator, GenericConstraintOp):
+    """Add a symmetry constraint"""
+
+    bl_idname = Operators.AddSymmetry
+    bl_label = "Symmetry"
+    bl_options = {"UNDO", "REGISTER"}
+
+    type = "SYMMETRY"
+
+    def main(self, context):
+        if not self.exists(context, SlvsRatio):
+            self.target = context.scene.sketcher.constraints.add_symmetry(
+                self.entity1,
+                self.entity2,
+                self.entity3,
+                sketch=self.sketch,
+            )
+
+        return super().main(context)
+
+
 constraint_operators = (
     VIEW3D_OT_slvs_add_coincident,
     VIEW3D_OT_slvs_add_equal,
@@ -250,6 +271,7 @@ constraint_operators = (
     VIEW3D_OT_slvs_add_tangent,
     VIEW3D_OT_slvs_add_midpoint,
     VIEW3D_OT_slvs_add_ratio,
+    VIEW3D_OT_slvs_add_symmetry,
 )
 
 register, unregister = register_stateops_factory(constraint_operators)


### PR DESCRIPTION
With the official solver binding the solving of symmetry constraints also works. This PR adds the possibility to constrain two points to be symmetric over a line either in 3d or 2d.