### PR TITLE
Vulkan support

### DIFF
--- a/model/arc.py
+++ b/model/arc.py
@@ -11,9 +11,9 @@ from mathutils.geometry import intersect_line_sphere_2d, intersect_sphere_sphere
 from bpy.utils import register_classes_factory
 
 from ..solver import Solver
-from .base_entity import SlvsGenericEntity
+from .base_entity import SlvsGenericEntity, tag_update
 from .base_entity import Entity2D
-from .utilities import slvs_entity_pointer, tag_update
+from .utilities import slvs_entity_pointer
 from .constants import CURVE_RESOLUTION
 from ..utilities.constants import HALF_TURN, FULL_TURN, QUARTER_TURN
 from ..utilities.math import range_2pi, pol2cart

--- a/model/circle.py
+++ b/model/circle.py
@@ -12,9 +12,9 @@ from bpy.utils import register_classes_factory
 
 from ..solver import Solver
 from ..utilities.math import range_2pi, pol2cart
-from .base_entity import SlvsGenericEntity
+from .base_entity import SlvsGenericEntity, tag_update
 from .base_entity import Entity2D
-from .utilities import slvs_entity_pointer, tag_update
+from .utilities import slvs_entity_pointer
 from .constants import CURVE_RESOLUTION
 from ..utilities.constants import HALF_TURN, FULL_TURN
 from ..utilities.draw import coords_arc_2d

--- a/model/normal_3d.py
+++ b/model/normal_3d.py
@@ -6,7 +6,7 @@ from bpy.utils import register_classes_factory
 from mathutils import Euler
 
 from ..solver import Solver
-from .base_entity import SlvsGenericEntity
+from .base_entity import SlvsGenericEntity, tag_update
 
 
 logger = logging.getLogger(__name__)
@@ -50,7 +50,7 @@ class SlvsNormal3D(Normal3D, PropertyGroup):
         description="Quaternion which describes the orientation of the normal",
         subtype="QUATERNION",
         size=4,
-        update=SlvsGenericEntity.tag_update,
+        update=tag_update,
     )
 
     ui_orientation: FloatVectorProperty(
@@ -60,7 +60,7 @@ class SlvsNormal3D(Normal3D, PropertyGroup):
         get=get_orientation,
         set=set_orientation,
         options={"SKIP_SAVE"},
-        update=SlvsGenericEntity.tag_update,
+        update=tag_update,
     )
     props = ("ui_orientation",)
 

--- a/model/point_2d.py
+++ b/model/point_2d.py
@@ -10,10 +10,10 @@ from bpy.utils import register_classes_factory
 
 from ..utilities.draw import draw_rect_2d
 from ..solver import Solver
-from .base_entity import SlvsGenericEntity
-from .base_entity import Entity2D
+from .base_entity import SlvsGenericEntity, Entity2D, tag_update
 from .utilities import slvs_entity_pointer, make_coincident
 from .line_2d import SlvsLine2D
+from ..utilities.constants import HALF_TURN
 
 logger = logging.getLogger(__name__)
 
@@ -79,8 +79,9 @@ class SlvsPoint2D(Point2D, PropertyGroup):
         subtype="XYZ",
         size=2,
         unit="LENGTH",
-        update=SlvsGenericEntity.tag_update,
+        update=tag_update,
     )
+    props = ("co",)
 
     def dependencies(self) -> List[SlvsGenericEntity]:
         return [

--- a/model/point_3d.py
+++ b/model/point_3d.py
@@ -9,6 +9,7 @@ from bpy.utils import register_classes_factory
 from ..utilities.draw import draw_cube_3d
 from ..solver import Solver
 from .base_entity import SlvsGenericEntity
+from .base_entity import tag_update
 
 
 logger = logging.getLogger(__name__)
@@ -60,7 +61,7 @@ class SlvsPoint3D(Point3D, PropertyGroup):
         description="The location of the point",
         subtype="XYZ",
         unit="LENGTH",
-        update=SlvsGenericEntity.tag_update,
+        update=tag_update,
     )
     props = ("location",)
 

--- a/operators/update.py
+++ b/operators/update.py
@@ -1,23 +1,22 @@
-from bpy.types import Operator, Context
+import bpy
+from bpy.types import Operator
 from bpy.utils import register_classes_factory
 
-from ..declarations import Operators
 from ..solver import Solver
 from ..converters import update_convertor_geometry
 
 
-class View3D_OT_update(Operator):
-    """Solve all sketches and update converted geometry"""
+class VIEW3D_OT_update(Operator):
+    bl_idname = "view3d.slvs_update"
+    bl_label = "Update"
 
-    bl_idname = Operators.Update
-    bl_label = "Force Update"
-
-    def execute(self, context: Context):
-        solver = Solver(context, None, all=True)
-        solver.solve()
-
-        update_convertor_geometry(context.scene)
-        return {"FINISHED"}
+    def execute(self, context):
+        update_convertor_geometry()
+        solvesys = Solver()
+        solvesys.solve()
+        return {'FINISHED'}
 
 
-register, unregister = register_classes_factory((View3D_OT_update,))
+register, unregister = register_classes_factory((
+    VIEW3D_OT_update,
+))

--- a/shaders.py
+++ b/shaders.py
@@ -57,6 +57,17 @@ class Shaders:
         }
     """
 
+    base_vertex_shader_2d = """
+        void main() {
+           gl_Position = ModelViewProjectionMatrix * vec4(pos.xy, 0.0, 1.0f);
+        }
+    """
+    base_fragment_shader_2d = """
+        void main() {
+            fragColor = color;
+        }
+    """
+
     @classmethod
     def get_base_shader_3d_info(cls):
 
@@ -82,12 +93,39 @@ class Shaders:
 
         return shader_info
 
+    @classmethod
+    def get_base_shader_2d_info(cls):
+
+        shader_info = GPUShaderCreateInfo()
+        shader_info.push_constant("MAT4", "ModelViewProjectionMatrix")
+        shader_info.push_constant("VEC4", "color")
+        shader_info.push_constant("FLOAT", "lineWidth")
+        shader_info.vertex_in(0, "VEC2", "pos")
+        shader_info.fragment_out(0, "VEC4", "fragColor")
+
+        shader_info.vertex_source(cls.base_vertex_shader_2d)
+        shader_info.fragment_source(cls.base_fragment_shader_2d)
+
+        return shader_info
+
     @staticmethod
     @cache
     def uniform_color_3d():
         if app.version < (3, 5):
             return gpu.shader.from_builtin("3D_UNIFORM_COLOR")
         return gpu.shader.from_builtin("UNIFORM_COLOR")
+
+    @staticmethod
+    @cache
+    def point_color_3d():
+        """Get uniform color shader for points. Compatible with all GPU backends."""
+        return gpu.shader.from_builtin("UNIFORM_COLOR")
+
+    @staticmethod
+    @cache
+    def polyline_color_3d():
+        """Get polyline shader for thick lines on Vulkan/Metal backends."""
+        return gpu.shader.from_builtin("POLYLINE_UNIFORM_COLOR")
 
     @classmethod
     @cache
@@ -173,7 +211,7 @@ class Shaders:
             }
         """
         )
-        
+
         shader = create_from_info(shader_info)
         del shader_info
         return shader
@@ -210,3 +248,11 @@ class Shaders:
             }
         """
         return GPUShader(vertex_shader, fragment_shader)
+
+    @classmethod
+    @cache
+    def uniform_color_line_2d(cls):
+        shader_info = cls.get_base_shader_2d_info()
+        shader = create_from_info(shader_info)
+        del shader_info
+        return shader

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -32,8 +32,9 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
         layout.prop(context.scene.sketcher, "use_construction")
 
         # Node modifier operators
-        layout.label(text="Node Tools:")
-        col = layout.column(align=True)
-        # col.operator(declarations.Operators.NodeFill)
-        col.operator(declarations.Operators.NodeExtrude)
-        col.operator(declarations.Operators.NodeArrayLinear)
+        if is_experimental():
+            layout.label(text="Node Tools:")
+            col = layout.column(align=True)
+            #col.operator(declarations.Operators.NodeFill)
+            col.operator(declarations.Operators.NodeExtrude)
+            col.operator(declarations.Operators.NodeArrayLinear)


### PR DESCRIPTION
This splits out the minimal required changes from #519 to better support the vulkan backend. The main differences are:
- Use the new point_* and polyline_* shader variants for both backends
- Fallback to the old uniform_color_line_3d shader for dashed lines, custom thickness is currently not supported