### PR TITLE
Add REGION3D availability checks in animation blender 4.5.4

### DIFF
--- a/operators/align_view.py
+++ b/operators/align_view.py
@@ -19,6 +19,12 @@ TARGET_MATRIX = None
 
 
 def animate_viewport():
+    global REGION3D
+    
+    # Check if REGION3D is still available
+    if REGION3D is None:
+        return None  # Stop animation
+    
     # Calculate the elapsed time
     elapsed_time = time.time() - START_TIME
     t = min(elapsed_time / DURATION, 1.0)  # Normalize time to [0, 1]
@@ -49,6 +55,11 @@ class View3D_OT_slvs_align_view(bpy.types.Operator):
 
         REGION3D = context.region_data
         DURATION = self.duration
+
+        # Check if region_data is available
+        if REGION3D is None:
+            self.report({'WARNING'}, "No 3D viewport available for alignment")
+            return {'CANCELLED'}
 
         # Store the current location and rotation
         START_LOCATION = REGION3D.view_location.copy()


### PR DESCRIPTION

<img width="1183" height="766" alt="Screenshot From 2025-11-01 21-29-27" src="https://github.com/user-attachments/assets/f0f3aab7-a705-4db8-8666-9617e8b367ab" />
Fix problem. Added checks for REGION3D availability in animate_viewport function.