### PR TITLE
Fix solver.py for slvs 3.2rc1+ API change

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -204,11 +204,15 @@ class Solver:
         for sketch in sketches:
             g = self._get_group(sketch)
 
-            fails = []
-            if report:
-                retval, fails = self.solvesys.solve_sketch(g, report)
+            result = self.solvesys.solve_sketch(g, report)
+
+            # Handle API: result is always a dict, not a tuple
+            if isinstance(result, dict):
+                retval = result
+                fails = []  # New API doesn't return fails separately
             else:
-                retval = self.solvesys.solve_sketch(g, report)
+                # Fallback for old API (tuple unpacking)
+                retval, fails, *_ = result
 
             if retval['result'] > 4:
                 logger.debug("Solver returned undocumented value: {}".format(retval))


### PR DESCRIPTION
The slvs API changed between 3.2.0.dev66 and 3.2rc1. The `solve_sketch()` method now returns only a dict instead of a tuple when `report=True`.

Previous API (3.2.0.dev66):
```python
  retval, fails = solve_sketch(g, report=True)
```

Current API (3.2rc1+):
```python
  result = solve_sketch(g, report=True)  # returns dict only
```

This change adds backwards-compatible handling for both API versions by checking if the result is a dict (new API) or tuple (old API).