### PR TITLE
Dev-env-with-vscode

### DIFF
--- a/.vscode/debugpy_port.py
+++ b/.vscode/debugpy_port.py
@@ -1,19 +1,42 @@
 import debugpy
+import os
+import sys
 
-try:
-    from colorama import Fore
 
-    YELLOW, GREEN, RED, RESET = Fore.YELLOW, Fore.GREEN, Fore.RED, Fore.RESET
-except ImportError:
-    YELLOW, GREEN, RED, RESET = [""] * 4
+def _kill_process_on_port(port):
+    my_pid = os.getpid()
+    if sys.platform in ("linux", "darwin"):
+        import subprocess, signal
 
-# https://code.visualstudio.com/docs/python/debugging#_debugging-by-attaching-over-a-network-connection
+        if sys.platform == "linux":
+            result = subprocess.run(
+                ["fuser", f"{port}/tcp"], capture_output=True, text=True
+            )
+        else:
+            result = subprocess.run(
+                ["lsof", "-ti", f"tcp:{port}"], capture_output=True, text=True
+            )
+        for pid in [int(p) for p in result.stdout.split() if p.strip().isdigit()]:
+            if pid != my_pid:
+                try:
+                    os.kill(pid, signal.SIGTERM)
+                except ProcessLookupError:
+                    pass
+    elif sys.platform == "win32":
+        import subprocess
 
-# 5678 is the default attach port in the VS Code debug configurations. Unless a host and port are specified, host defaults to 127.0.0.1
+        result = subprocess.run(["netstat", "-ano"], capture_output=True, text=True)
+        for line in result.stdout.splitlines():
+            if f":{port}" in line and "LISTENING" in line:
+                try:
+                    pid = int(line.split()[-1])
+                    if pid != my_pid:
+                        subprocess.run(
+                            ["taskkill", "/PID", str(pid), "/F"], capture_output=True
+                        )
+                except Exception:
+                    pass
+
+
+_kill_process_on_port(5678)
 debugpy.listen(5678)
-print(f"{YELLOW}Waiting for debugger attach{RESET}")
-debugpy.wait_for_client()
-if debugpy.is_client_connected():
-    print(f"{GREEN}Debugger attached to client{RESET}")
-else:
-    print(f"{RED}Failed to connect to client{RESET}")

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,7 +27,6 @@
                 "host": "localhost",
                 "port": 5678
             },
-            "preLaunchTask": "Run Blender interactively",
             "pathMappings": [
                 {
                     "localRoot": "${config:cadSketcher.localRoot}",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,7 @@
 
         {
             "name": "Pytest+debugger",
-            "type": "python",
+            "type": "debugpy",
             "request": "attach",
             "connect": {
                 "host": "localhost",
@@ -13,15 +13,15 @@
             "preLaunchTask": "Run Blender+testing",
             "pathMappings": [
                 {
-                    "localRoot": "${workspaceFolder}",
-                    "remoteRoot": "."
+                    "localRoot": "${config:cadSketcher.localRoot}",
+                    "remoteRoot": "${config:cadSketcher.remoteRoot}"
                 }
             ],
-            "justMyCode": true
+            "justMyCode": false
         },
         {
             "name": "Interactive+debugger",
-            "type": "python",
+            "type": "debugpy",
             "request": "attach",
             "connect": {
                 "host": "localhost",
@@ -30,11 +30,11 @@
             "preLaunchTask": "Run Blender interactively",
             "pathMappings": [
                 {
-                    "localRoot": "${workspaceFolder}",
-                    "remoteRoot": "."
+                    "localRoot": "${config:cadSketcher.localRoot}",
+                    "remoteRoot": "${config:cadSketcher.remoteRoot}"
                 }
             ],
-            "justMyCode": true
+            "justMyCode": false
         }
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cadSketcher.localRoot": "/home/falken10vdl/cadSketcherDevel/CAD_Sketcher",
+  "cadSketcher.remoteRoot": "/home/falken10vdl/.config/blender/5.0/extensions/user_default/CAD_Sketcher",
+  "cadSketcher.blenderPath": "/home/falken10vdl/.local/share/applications/blender-5.0.1-linux-x64"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,10 +2,20 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "Configure CAD_Sketcher/vscode development environment",
+            "type": "shell",
+            "command": "blender",
+            "args": [
+                "--background",
+                "--python", "${workspaceFolder}/scripts/dev_environment_vscode_config.py"
+            ],
+            "problemMatcher": []
+        },
+        {
             "label": "Run Blender+testing",
             "detail": "Runs testfiles using Blender in the background + opens debugpy port and waits for connection",
             "command": "blender",
-            "args": ["--background", "--addons", "CAD_Sketcher","--python","./.vscode/debugpy_port.py","--python","./testing/__init__.py", "--", "--log_level=DEBUG"],
+            "args": ["--background", "--addons", "bl_ext.user_default.CAD_Sketcher","--python","./.vscode/debugpy_port.py","--python","./testing/__init__.py", "--", "--log_level=DEBUG"],
             "type": "shell",
             "isBackground": true,
             "problemMatcher": {
@@ -35,7 +45,7 @@
             "label": "Run Blender interactively",
             "detail": "Starts remote debugpy session and Blender gui with solely this addon activated",
             "command": "blender",
-            "args": ["--addons", "CAD_Sketcher", "--python","./.vscode/debugpy_port.py", "--", "--log_level=DEBUG", "--interactive"],
+            "args": ["--addons", "bl_ext.user_default.CAD_Sketcher", "--python","./.vscode/debugpy_port.py", "--", "--log_level=DEBUG", "--interactive"],
             "type": "shell",
             "isBackground": true,
             "problemMatcher": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,64 +12,46 @@
             "problemMatcher": []
         },
         {
-            "label": "Run Blender+testing",
-            "detail": "Runs testfiles using Blender in the background + opens debugpy port and waits for connection",
-            "command": "blender",
-            "args": ["--background", "--addons", "bl_ext.user_default.CAD_Sketcher","--python","./.vscode/debugpy_port.py","--python","./testing/__init__.py", "--", "--log_level=DEBUG"],
+            "label": "Launch Blender interactively",
+            "detail": "Start Blender with debugpy listening on port 5678. Then attach with 'Interactive+debugger'.",
             "type": "shell",
+            "command": "blender",
+            "args": [
+                "--python", ".vscode/debugpy_port.py",
+                "--", "--log_level=DEBUG", "--interactive"
+            ],
             "isBackground": true,
-            "problemMatcher": {
-                "owner": "python",
-                "source": "python",
-                "fileLocation": ["relative", "${workspaceFolder}"],
-                "pattern": {
-                    // Example error that we want to regex-catch
-                    //   File "/abs/path/to/CAD_Sketcher/class_defines.py", line 3467, in register
-                    //     bpy.utils.register_class(cls)
-                    //   ValueError: bpy_struct "SlvsPoint3D" registration error: 'slvs_index' PointerProperty could not register (see previous error)
-                    "regexp": "^ *File \"([\/\\w.]+)\", line (\\d+), in (\\w+)\n *(.*)\\n(\\w+: .*)$",
-                    "file": 1,
-                    "line": 2,
-                    // "message": 3, // The function name
-                    "code": 4,
-                    "message": 5
-                },
-                "background": {
-                    "activeOnStart": true,
-                    "beginsPattern": "^Blender.*$",
-                    "endsPattern": "Waiting for debugger attach", // See debugpy_port.py
-                }
-            }
+            "problemMatcher": []
         },
         {
-            "label": "Run Blender interactively",
-            "detail": "Starts remote debugpy session and Blender gui with solely this addon activated",
-            "command": "blender",
-            "args": ["--addons", "bl_ext.user_default.CAD_Sketcher", "--python","./.vscode/debugpy_port.py", "--", "--log_level=DEBUG", "--interactive"],
+            "label": "Run Blender+testing",
+            "detail": "Runs testfiles using Blender in the background + opens debugpy port on 5678",
             "type": "shell",
+            "command": "blender",
+            "args": [
+                "--background",
+                "--python", ".vscode/debugpy_port.py",
+                "--python", "./testing/__init__.py",
+                "--", "--log_level=DEBUG"
+            ],
             "isBackground": true,
             "problemMatcher": {
                 "owner": "python",
                 "source": "python",
                 "fileLocation": ["relative", "${workspaceFolder}"],
                 "pattern": {
-                    // Example error that we want to regex-catch
-                    //   File "/abs/path/to/CAD_Sketcher/class_defines.py", line 3467, in register
-                    //     bpy.utils.register_class(cls)
-                    //   ValueError: bpy_struct "SlvsPoint3D" registration error: 'slvs_index' PointerProperty could not register (see previous error)
                     "regexp": "^ *File \"([\/\\w.]+)\", line (\\d+), in (\\w+)\n *(.*)\\n(\\w+: .*)$",
                     "file": 1,
                     "line": 2,
-                    // "message": 3, // The function name
                     "code": 4,
                     "message": 5
                 },
                 "background": {
                     "activeOnStart": true,
                     "beginsPattern": "^Blender.*$",
-                    "endsPattern": "Waiting for debugger attach", // See debugpy_port.py
+                    "endsPattern": "^Blender quit$"
                 }
             }
-        },
+        }
     ]
 }

--- a/scripts/dev_environment_vscode_config.py
+++ b/scripts/dev_environment_vscode_config.py
@@ -1,0 +1,75 @@
+"""Setup CAD_Sketcher development environment and configure VS Code.
+
+This script:
+  1. Replaces the installed Blender extension copy with a symlink to this repo.
+  2. Writes .vscode/settings.json with path mappings for the VS Code debugger.
+
+Run it once via the VS Code task "Configure CAD_Sketcher/vscode development environment",
+or directly:
+
+    blender --background --python scripts/dev_environment_vscode_config.py
+"""
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import bpy
+
+# Repo root is two levels up from this script (scripts/dev_environment_vscode_config.py).
+repo_path = Path(__file__).resolve().parent.parent
+
+# Derive the Blender user config path from the running Blender version.
+major, minor, _ = bpy.app.version
+blender_version = f"{major}.{minor}"
+
+if sys.platform == "win32":
+    blender_config = (
+        Path.home() / f"AppData/Roaming/Blender Foundation/Blender/{blender_version}"
+    )
+elif sys.platform == "darwin":
+    blender_config = (
+        Path.home() / f"Library/Application Support/Blender/{blender_version}"
+    )
+else:
+    blender_config = Path.home() / f".config/blender/{blender_version}"
+
+install_path = blender_config / "extensions/user_default/CAD_Sketcher"
+
+assert install_path.exists() or install_path.is_symlink(), (
+    f"CAD_Sketcher not found at expected path: {install_path}\n"
+    "Make sure the addon is installed in Blender before running this script."
+)
+
+# Create / update the symlink so Blender loads directly from the repo.
+if install_path.is_symlink():
+    current_target = install_path.resolve()
+    if current_target == repo_path:
+        print(f"Symlink already correct: {install_path} -> {repo_path}")
+    else:
+        print(f"Relinking: {install_path} -> {repo_path}  (was -> {current_target})")
+        install_path.unlink()
+        install_path.symlink_to(repo_path, target_is_directory=True)
+else:
+    print(f"Replacing installed copy with symlink: {install_path} -> {repo_path}")
+    shutil.rmtree(install_path)
+    install_path.symlink_to(repo_path, target_is_directory=True)
+
+# Write .vscode/settings.json consumed by launch.json path mappings.
+settings_path = repo_path / ".vscode" / "settings.json"
+settings_path.parent.mkdir(parents=True, exist_ok=True)
+
+settings = json.loads(settings_path.read_text()) if settings_path.exists() else {}
+settings.update(
+    {
+        "cadSketcher.localRoot": repo_path.as_posix(),
+        "cadSketcher.remoteRoot": install_path.as_posix(),
+        "cadSketcher.blenderPath": Path(bpy.app.binary_path).parent.as_posix(),
+    }
+)
+settings_path.write_text(json.dumps(settings, indent=2))
+
+print("\n\nCAD_Sketcher/VSCode development environment configured successfully!\n\n")
+print(f"  localRoot  : {repo_path}")
+print(f"  remoteRoot : {install_path}")

--- a/scripts/dev_environment_vscode_config.py
+++ b/scripts/dev_environment_vscode_config.py
@@ -1,13 +1,25 @@
 """Setup CAD_Sketcher development environment and configure VS Code.
 
-This script:
-  1. Replaces the installed Blender extension copy with a symlink to this repo.
-  2. Writes .vscode/settings.json with path mappings for the VS Code debugger.
+One-off setup (run once):
+  1. Install the CAD_Sketcher extension in Blender.
+  2. Run this script via the VS Code task "Configure CAD_Sketcher/vscode development environment",
+     or directly:
 
-Run it once via the VS Code task "Configure CAD_Sketcher/vscode development environment",
-or directly:
+         blender --background --python scripts/dev_environment_vscode_config.py
 
-    blender --background --python scripts/dev_environment_vscode_config.py
+     This replaces the installed extension copy with a symlink to this repo and
+     writes .vscode/settings.json with path mappings for the VS Code debugger.
+
+Per-session workflow:
+  1. Run the VS Code task "Launch Blender interactively" to start Blender with
+     debugpy listening on port 5678.
+  2. Run the "Interactive+debugger" launch configuration (F5) to attach the debugger.
+  3. To restart Blender from within Blender, one can use bonsai's operator (F3 -> bim.restart_blender).
+     Then re-run F5 to re-attach the debugger.
+
+For automated testing:
+  - Run the VS Code task "Run Blender+testing" to run the test suite headlessly.
+    The "Pytest+debugger" launch configuration (F5) can be used to attach mid-test if needed.
 """
 
 import json
@@ -17,10 +29,8 @@ from pathlib import Path
 
 import bpy
 
-# Repo root is two levels up from this script (scripts/dev_environment_vscode_config.py).
 repo_path = Path(__file__).resolve().parent.parent
 
-# Derive the Blender user config path from the running Blender version.
 major, minor, _ = bpy.app.version
 blender_version = f"{major}.{minor}"
 
@@ -42,7 +52,6 @@ assert install_path.exists() or install_path.is_symlink(), (
     "Make sure the addon is installed in Blender before running this script."
 )
 
-# Create / update the symlink so Blender loads directly from the repo.
 if install_path.is_symlink():
     current_target = install_path.resolve()
     if current_target == repo_path:
@@ -56,7 +65,6 @@ else:
     shutil.rmtree(install_path)
     install_path.symlink_to(repo_path, target_is_directory=True)
 
-# Write .vscode/settings.json consumed by launch.json path mappings.
 settings_path = repo_path / ".vscode" / "settings.json"
 settings_path.parent.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Hi there!
This si a proposal for a test environment using vscode and folowing Bonsai BIM's approach to link the source code for easy development.

VS Code Development Environment
Prerequisites
- Blender (4.2 or later) installed and available on PATH
- CAD_Sketcher extension already installed inside Blender once (via Edit → Preferences → Get Extensions)
- debugpy available in Blender's Python (pip install debugpy into Blender's Python if needed)
- Bonsai BIM extension (if you want to do bim.restart_blender)

One-time setup
Run the VS Code task "Configure CAD_Sketcher/vscode development environment" (Terminal → Run Task), or directly from a terminal:


blender --background --python scripts/dev_environment_vscode_config.py
This does two things:

- Replaces the installed copy of the extension inside Blender's config directory with a symlink pointing to this repo, so Blender always loads your working tree.
- Writes settings.json with the path mappings the debugger needs to map Blender's runtime paths back to your local source files.

Re-run this script if you move the repo or upgrade Blender.

Interactive development (with live debugger)
- Run the VS Code task "Launch Blender interactively" — this opens Blender's GUI with debugpy listening on port 5678.
- In VS Code, run the "Interactive+debugger" launch configuration (F5) to attach the debugger. Breakpoints in your source files will now be hit.
- Edit code, then restart Blender from within Blender using the bim.restart_blender operator (F3 → type restart). Blender relaunches and re-opens the debugpy port automatically.
- Press F5 again to re-attach the debugger to the restarted Blender.
You do not need to rerun the launch task between restarts — the task stays running and Blender manages its own restart (you can do bim.restart_blender whenever code updates have been done and you want to see them in action)

Automated testing
Run the VS Code task "Run Blender+testing" to execute the test suite headlessly. The task completes when Blender prints Blender quit.

If you need to debug a test mid-run, use the "Pytest+debugger" launch configuration (F5) — it launches the test task automatically and attaches the debugger when the port becomes available.

