### PR TITLE
Fix enum int/string handling in setprop (Blender 5.0) and _get_align callback

### DIFF
--- a/model/distance.py
+++ b/model/distance.py
@@ -71,7 +71,7 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
     def _set_align(self, value: int):
         alignment = bpyEnum(align_items, value).identifier
         distance = _get_aligned_distance(self.entity1, self.entity2, alignment)
-        self.align_store = value
+        self.align_store = alignment
         self.value_store = distance
 
     def _get_align(self) -> int:

--- a/model/distance.py
+++ b/model/distance.py
@@ -52,6 +52,7 @@ align_items = [
     ("VERTICAL", "Vertical", "", 2),
 ]
 
+
 def _get_value(self):
     if self.is_reference:
         val = self.init_props(align=self.align)["value"]
@@ -76,7 +77,7 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
     def _get_align(self) -> int:
         if not self.is_property_set("align_store"):
             return 0
-        return self.align_store
+        return bpyEnum(align_items, identifier=self.align_store).index
 
     label = "Distance"
     value_store: FloatProperty(
@@ -199,18 +200,12 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
 
                 p = solvesys.add_point_2d(group, *coords, wp)
 
-                handles.append(
-                    solvesys.horizontal(group, p, wp, entityB=e2.py_data)
-                )
-                handles.append(
-                    solvesys.vertical(group, p, wp, entityB=e1.py_data)
-                )
+                handles.append(solvesys.horizontal(group, p, wp, entityB=e2.py_data))
+                handles.append(solvesys.vertical(group, p, wp, entityB=e1.py_data))
 
                 base_point = e1 if alignment == "VERTICAL" else e2
                 handles.append(
-                    solvesys.distance(
-                        group, p, base_point.py_data, value, wp
-                    )
+                    solvesys.distance(group, p, base_point.py_data, value, wp)
                 )
                 return handles
             else:
@@ -286,7 +281,7 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
 
             if v_rotation.length != 0:
                 angle = v_rotation.angle_signed(x_axis)
-                
+
             mat_rot = Matrix.Rotation(angle, 2, "Z")
             v_translation = (p2 + p1) / 2
 
@@ -304,7 +299,7 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
                     )
                 if v_rotation.length != 0:
                     angle = v_rotation.angle_signed(x_axis)
-                
+
                 mat_rot = Matrix.Rotation(angle, 2, "Z")
                 v_translation = (p2 + p1) / 2
             else:

--- a/utilities/bpy.py
+++ b/utilities/bpy.py
@@ -119,12 +119,13 @@ def add_new_empty(context: Context, location: Vector, name="") -> Object:
 
 
 def setprop(data, key, value):
-    """Set a property value, handling enum index conversion."""
+    """Set an RNA property. For enums, integer values are treated as
+    indices into `enum_items` and converted to the enum identifier (the string Blender expects when assigning).
+    """
     prop = data.rna_type.properties[key]
 
-    # Handle Enums which have to be set by the item's id rather than identifier
-    if prop.type == "ENUM":
-        value = prop.enum_items[value].value
+    if prop.type == "ENUM" and isinstance(value, int):
+        value = prop.enum_items[value].identifier
 
     setattr(data, key, value)
 


### PR DESCRIPTION
Blender's enum properties:
- RNA assignment via setattr expects string identifiers, 
- get/set property callbacks must return/receive integers.

bpy.py — setprop() (Blender 5.0 compat):
Blender 5.0 no longer accepts integers when assigning enum properties via setattr. Changed from `prop.enum_items[value].value (integer)` to `prop.enum_items[value].identifier (string)`. Added an `isinstance(value, int)` guard so string values pass through unchanged.

distance.py — SlvsDistance._get_align() (latent bug):
The get callback for the align EnumProperty was returning self.align_store directly — a string identifier — which Blender cannot interpret as an integer, causing:
`TypeError: 'str' object cannot be interpreted as an integer`
Fixed by converting the stored identifier back to its integer index via `bpyEnum(align_items, identifier=self.align_store).index`.

Cheers!
