### PR TITLE
Fix sketch mesh creation sometimes creating degenerate faces, or faces with reversed normals

### DIFF
--- a/converters.py
+++ b/converters.py
@@ -5,6 +5,7 @@ from typing import Union
 import bpy
 import bmesh
 from bpy.types import Mesh, Scene, Object
+from mathutils import Vector
 
 from .utilities.bezier import set_handles
 from .utilities.walker import EntityWalker
@@ -84,6 +85,22 @@ def mesh_from_temporary(mesh: Mesh, name: str, existing_mesh: Union[bool, None] 
     bmesh.ops.dissolve_limit(
         bm, angle_limit=math.radians(0.1), verts=bm.verts, edges=bm.edges
     )
+
+    # Clean up degenerate faces with invalid normal vectors
+    zero_normal_faces = [f for f in bm.faces if f.normal.length < 1e-6]
+    if zero_normal_faces:
+        try:
+            bmesh.ops.dissolve_faces(bm, faces=zero_normal_faces)
+        except Exception as e:               
+            pass # Could not dissolve faces
+
+    # Find the most common normal direction, and use that to fix faces that are reversed
+    normals = [f.normal.copy() for f in bm.faces if f.normal.length > 1e-6]
+    if normals:
+        avg_normal = sum(normals, Vector((0,0,0))) / len(normals)
+        wrong_way = [f for f in bm.faces if f.normal.dot(avg_normal) < 0]
+        if wrong_way:
+            bmesh.ops.reverse_faces(bm, faces=wrong_way)
 
     if existing_mesh:
         existing_mesh.clear_geometry()


### PR DESCRIPTION
This fixes a couple of issues with mesh creation when exiting a sketch I have run into.

1. Fixes certain geometry creating faces that result in a normal vector of {0,0,0}, leading to solidify extruding incorrectly. Solution for this was dissolving the things with this incalculable normal vector result.

2. Fixes certain geometry creating faces that have vertexes spun in the wrong order, leading to a reversed normal vector compared to the rest. The solution for this was a bit more odd, checking the average normal of the faces, and then flipping ones opposite of that average direction.

Fixes #373
Fixes #447
Fixes #489

I used Claude AI to help me with all of this. I don't really write python, and certainly had no idea how blender plugins work or where in the repo the related code was for the meshing step. Fortunately there's not a lot of changed lines, so hopefully it is pretty understandable.

I tested these changes on the blend file from issue 447, the process from 373, the process from 489, and on my own blend file where I originally encountered the problem. It worked to fix all of them at least for using solidify.

Before:
<img width="833" height="353" alt="image" src="https://github.com/user-attachments/assets/61bb2cfa-8559-4995-a8e3-ee01d235eb99" />

After:
<img width="727" height="305" alt="image" src="https://github.com/user-attachments/assets/099a4342-03ed-425f-b7c0-4ae2b0c06254" />
