### PR TITLE
Snapping to 3d geometry

### DIFF
--- a/operators/add_arc.py
+++ b/operators/add_arc.py
@@ -8,11 +8,12 @@ from ..declarations import Operators
 from ..stateful_operator.utilities.register import register_stateops_factory
 from ..stateful_operator.state import state_from_args
 from ..solver import solve_system
+from ..utilities.geometry import intersect_line_sphere_2d
 from ..utilities.math import pol2cart
 from .base_2d import Operator2d
 from .constants import types_point_2d
 from .utilities import ignore_hover
-from ..utilities.view import get_pos_2d
+from ..utilities.view import get_blender_snap_info, get_pos_2d
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,10 @@ class View3D_OT_slvs_add_arc2d(Operator, Operator2d):
     )
 
     def get_endpoint_pos(self, context: Context, coords):
-        mouse_pos = get_pos_2d(context, self.sketch.wp, coords)
+        snap_data = get_blender_snap_info(context, coords)
+        mouse_pos = get_pos_2d(
+            context, self.sketch.wp, coords, respect_snapping=True
+        )
         if mouse_pos is None:
             return None
 
@@ -65,6 +69,32 @@ class View3D_OT_slvs_add_arc2d(Operator, Operator2d):
         # Get radius from distance ct - p1
         p1 = self.get_point(context, 1).co
         radius = (p1 - ct).length
+
+        if snap_data and snap_data["type"] in {"EDGE", "EDGE_MIDPOINT"}:
+            world_edge = snap_data.get("world_edge")
+            if world_edge:
+                edge_points = [
+                    Vector((self.sketch.wp.matrix_basis.inverted() @ point)[:-1])
+                    for point in world_edge
+                ]
+                intersections = intersect_line_sphere_2d(
+                    edge_points[0], edge_points[1], ct, radius
+                )
+                if intersections:
+                    return min(
+                        intersections,
+                        key=lambda point: (Vector(point) - mouse_pos).length,
+                    )
+
+        if snap_data and snap_data["type"] == "VERTEX":
+            vertex_pos = Vector(
+                (
+                    self.sketch.wp.matrix_basis.inverted() @ snap_data["world_point"]
+                )[:-1]
+            )
+            if abs((vertex_pos - ct).length - radius) < 1e-5:
+                return vertex_pos
+
         pos = pol2cart(radius, angle) + ct
         return pos
 

--- a/operators/add_circle.py
+++ b/operators/add_circle.py
@@ -3,12 +3,13 @@ import logging
 from bpy.types import Operator, Context
 from bpy.props import FloatProperty
 from mathutils import Vector
+from mathutils.geometry import intersect_point_line
 
 from ..declarations import Operators
 from ..stateful_operator.utilities.register import register_stateops_factory
 from ..stateful_operator.state import state_from_args
 from ..solver import solve_system
-from ..utilities.view import get_pos_2d
+from ..utilities.view import get_blender_snap_info, get_pos_2d
 from .base_2d import Operator2d
 from .constants import types_point_2d
 from .utilities import ignore_hover
@@ -53,7 +54,21 @@ class View3D_OT_slvs_add_circle2d(Operator, Operator2d):
 
     def get_radius(self, context: Context, coords):
         wp = self.sketch.wp
-        pos = get_pos_2d(context, wp, coords)
+        snap_data = get_blender_snap_info(context, coords)
+        pos = get_pos_2d(context, wp, coords, respect_snapping=True)
+        if snap_data and snap_data["type"] in {"EDGE", "EDGE_MIDPOINT"}:
+            world_edge = snap_data.get("world_edge")
+            if world_edge:
+                edge_start, edge_end = [
+                    Vector((wp.matrix_basis.inverted() @ point)[:-1])
+                    for point in world_edge
+                ]
+                pos, factor = intersect_point_line(self.ct.co, edge_start, edge_end)
+                factor = min(max(factor, 0.0), 1.0)
+                pos = edge_start.lerp(edge_end, factor)
+        elif snap_data and snap_data["type"] == "VERTEX":
+            pos = Vector((wp.matrix_basis.inverted() @ snap_data["world_point"])[:-1])
+
         delta = Vector(pos) - self.ct.co
         radius = delta.length
         return radius

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -25,7 +25,7 @@ class Operator2d(GenericEntityOp):
     def state_func(self, context: Context, coords):
         state = self.state
         wp = self.sketch.wp
-        pos = get_pos_2d(context, wp, coords)
+        pos = get_pos_2d(context, wp, coords, respect_snapping=True)
 
         # Handle implicit properties based on state.types
         if SlvsPoint2D in state.types:

--- a/operators/tweak.py
+++ b/operators/tweak.py
@@ -5,7 +5,7 @@ from mathutils.geometry import intersect_line_plane
 from .. import global_data
 from ..declarations import Operators
 from ..solver import Solver
-from ..utilities.view import get_picking_origin_dir
+from ..utilities.view import get_picking_origin_dir, get_pos_2d
 
 
 class View3D_OT_slvs_tweak(Operator):
@@ -14,6 +14,13 @@ class View3D_OT_slvs_tweak(Operator):
     bl_idname = Operators.Tweak
     bl_label = "Tweak Solvespace Entities"
     bl_options = {"UNDO"}
+
+    def _get_tweak_pos(self, context: Context, entity, coords):
+        wp = entity.wp
+        pos_2d = get_pos_2d(context, wp, coords, respect_snapping=True)
+        if pos_2d is None:
+            return None
+        return wp.matrix_basis @ pos_2d.to_3d()
 
     def invoke(self, context: Context, event):
         index = global_data.hover
@@ -34,13 +41,8 @@ class View3D_OT_slvs_tweak(Operator):
                 )
                 return {"CANCELLED"}
 
-            # For 2D entities it should be enough precise to get picking point from
-            # intersection with workplane
-            wp = entity.sketch.wp
             coords = (event.mouse_region_x, event.mouse_region_y)
-            origin, dir = get_picking_origin_dir(context, coords)
-            end_point = dir * context.space_data.clip_end + origin
-            pos = intersect_line_plane(origin, end_point, wp.p1.location, wp.normal)
+            pos = self._get_tweak_pos(context, entity, coords)
         else:
             pos = entity.closest_picking_point(origin, view_vector)
 
@@ -65,9 +67,7 @@ class View3D_OT_slvs_tweak(Operator):
             origin, dir = get_picking_origin_dir(context, coords)
 
             if hasattr(entity, "sketch"):
-                wp = entity.wp
-                end_point = dir * context.space_data.clip_end + origin
-                pos = intersect_line_plane(origin, end_point, wp.p1.location, wp.normal)
+                pos = self._get_tweak_pos(context, entity, coords)
             else:
                 pos = dir * self.depth + origin
 

--- a/utilities/view.py
+++ b/utilities/view.py
@@ -235,7 +235,7 @@ def get_blender_snap_info(context: Context, coords: Vector) -> Optional[dict]:
 
     objects = []
     hit_object = ob.evaluated_get(depsgraph) if result and ob is not None and ob.type == "MESH" else None
-    if result and ob is not None and ob.type == "MESH":
+    if hit_object is not None and not _snap_show_xray(context):
         objects.append(hit_object)
     else:
         for visible in context.visible_objects:

--- a/utilities/view.py
+++ b/utilities/view.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Optional, Tuple
 
 from bpy.types import Context, RegionView3D
 from bpy_extras.view3d_utils import (
@@ -8,7 +8,7 @@ from bpy_extras.view3d_utils import (
     region_2d_to_vector_3d,
 )
 from mathutils import Vector
-from mathutils.geometry import intersect_line_plane
+from mathutils.geometry import intersect_line_plane, intersect_point_line, intersect_line_line
 
 
 def get_picking_origin_dir(context: Context, coords: Vector) -> Tuple[Vector, Vector]:
@@ -45,9 +45,254 @@ def get_placement_pos(context: Context, coords: Vector) -> Vector:
     return region_2d_to_location_3d(region, rv3d, coords, view_vector)
 
 
-def get_pos_2d(context: Context, wp, coords: Vector) -> Vector:
+def _snap_elements(tool_settings) -> set[str]:
+    elements = set()
+    for attr in ("snap_elements", "snap_elements_base"):
+        value = getattr(tool_settings, attr, None)
+        if not value:
+            continue
+        if isinstance(value, str):
+            elements.add(value)
+        else:
+            elements.update(value)
+
+    if "EDGE_PERPENDICULAR" in elements:
+        elements.add("EDGE")
+
+    return elements
+
+
+def _closest_segment_point_world(
+    screen_point: Vector, world_start: Vector, world_end: Vector, region, rv3d
+) -> Optional[Vector]:
+    ray_origin = region_2d_to_origin_3d(region, rv3d, screen_point)
+    ray_dir = region_2d_to_vector_3d(region, rv3d, screen_point)
+
+    seg = world_end - world_start
+    seg_len_sq = seg.length_squared
+    if seg_len_sq < 1e-10:
+        return world_start.copy()
+
+    ray_point, seg_point = intersect_line_line(
+        ray_origin, ray_origin + ray_dir,
+        world_start, world_end
+    )
+
+    if seg_point is None:
+        seg_norm = seg.normalized()
+        t_seg = (ray_origin - world_start).dot(seg_norm) / seg.length
+        t_seg = max(0.0, min(1.0, t_seg))
+        return world_start.lerp(world_end, t_seg)
+
+    t_seg = (seg_point - world_start).dot(seg) / seg_len_sq
+    t_seg = max(0.0, min(1.0, t_seg))
+    return world_start.lerp(world_end, t_seg)
+
+
+def _snap_screen_threshold(context: Context) -> float:
+    inputs = context.preferences.inputs
+    return max(inputs.drag_threshold, inputs.drag_threshold_mouse)
+
+
+def _snap_show_xray(context: Context) -> bool:
+    space_data = context.space_data
+    if not space_data or space_data.type != "VIEW_3D":
+        return False
+
+    shading = getattr(space_data, "shading", None)
+    if not shading:
+        return False
+
+    return getattr(shading, "show_xray", False)
+
+
+def _screen_snap_candidates(
+    context: Context,
+    coords: Vector,
+    obj_eval,
+    elements,
+    face_index: Optional[int] = None,
+):
+    me = getattr(obj_eval, "data", None)
+    if me is None:
+        return []
+
+    threshold = _snap_screen_threshold(context)
+    region = context.region
+    rv3d = context.region_data
+    matrix = obj_eval.matrix_world
+    candidates = []
+    vertex_screen = {}
+    face_vertex_indices = None
+    face_edge_keys = None
+
+    if face_index is not None and 0 <= face_index < len(me.polygons):
+        polygon = me.polygons[face_index]
+        face_vertex_indices = tuple(polygon.vertices)
+        face_edge_keys = tuple(polygon.edge_keys)
+
+    def get_vertex_screen(index: int):
+        if index not in vertex_screen:
+            world = matrix @ me.vertices[index].co
+            vertex_screen[index] = location_3d_to_region_2d(region, rv3d, world)
+        return vertex_screen[index]
+
+    def add_candidate(priority: int, region_point: Vector, snap_data: dict):
+        if region_point is None:
+            return
+
+        distance = (coords - region_point).length
+        if distance > threshold:
+            return
+
+        candidates.append((priority, distance, region_point, snap_data))
+
+    if "VERTEX" in elements:
+        vertex_indices = (
+            face_vertex_indices if face_vertex_indices is not None else range(len(me.vertices))
+        )
+        for vertex_index in vertex_indices:
+            vertex = me.vertices[vertex_index]
+            add_candidate(
+                0,
+                get_vertex_screen(vertex.index),
+                {
+                    "type": "VERTEX",
+                    "world_point": matrix @ vertex.co,
+                },
+            )
+
+    if "EDGE" in elements or "EDGE_MIDPOINT" in elements:
+        if face_edge_keys is not None:
+            face_edge_map = {edge_key: me.edges[i] for i, edge_key in enumerate(me.edge_keys)}
+            edges = [face_edge_map[edge_key] for edge_key in face_edge_keys]
+        else:
+            edges = me.edges
+
+        for edge in edges:
+            v1, v2 = edge.vertices
+            start = get_vertex_screen(v1)
+            end = get_vertex_screen(v2)
+            if start is None or end is None:
+                continue
+
+            midpoint = (start + end) / 2
+            world_start = matrix @ me.vertices[v1].co
+            world_end = matrix @ me.vertices[v2].co
+
+            if "EDGE_MIDPOINT" in elements:
+                add_candidate(
+                    1,
+                    midpoint,
+                    {
+                        "type": "EDGE_MIDPOINT",
+                        "world_point": (world_start + world_end) / 2,
+                        "world_edge": (world_start, world_end),
+                    },
+                )
+
+            if "EDGE" in elements:
+                world_closest = _closest_segment_point_world(coords, world_start, world_end, region, rv3d)
+                if world_closest is None:
+                    continue
+                region_point = location_3d_to_region_2d(region, rv3d, world_closest)
+                if region_point is None:
+                    continue
+                     
+                add_candidate(
+                    2,
+                    region_point,
+                    {
+                        "type": "EDGE",
+                        "world_point": world_closest,
+                        "world_edge": (world_start, world_end),
+                    },
+                )
+
+    return candidates
+
+
+def get_blender_snap_info(context: Context, coords: Vector) -> Optional[dict]:
+    tool_settings = context.scene.tool_settings
+    if not getattr(tool_settings, "use_snap", False):
+        return None
+
+    coords = Vector(coords)
+    elements = _snap_elements(tool_settings)
+    if not elements.intersection(
+        {"VERTEX", "EDGE", "EDGE_MIDPOINT"}
+    ):
+        return None
+
+    origin, view_vector = get_picking_origin_dir(context, coords)
+    depsgraph = context.evaluated_depsgraph_get()
+
+    result, location, _normal, face_index, ob, _matrix = context.scene.ray_cast(
+        depsgraph, origin, view_vector
+    )
+    snap_target = getattr(tool_settings, "snap_target", "CLOSEST")
+    candidates = []
+
+    objects = []
+    hit_object = ob.evaluated_get(depsgraph) if result and ob is not None and ob.type == "MESH" else None
+    if result and ob is not None and ob.type == "MESH":
+        objects.append(hit_object)
+    else:
+        for visible in context.visible_objects:
+            if visible.type != "MESH":
+                continue
+            objects.append(visible.evaluated_get(depsgraph))
+
+    for obj_eval in objects:
+        candidate_face_index = None
+        if (
+            not _snap_show_xray(context)
+            and hit_object is not None
+            and obj_eval.original == hit_object.original
+        ):
+            candidate_face_index = face_index
+        candidates.extend(
+            _screen_snap_candidates(
+                context,
+                coords,
+                obj_eval,
+                elements,
+                face_index=candidate_face_index,
+            )
+        )
+
+    if not candidates:
+        return None
+
+    _priority, _distance, region_point, snap_data = min(
+        candidates, key=lambda item: (item[0], item[1])
+    )
+    snap_data["region_point"] = region_point
+    return snap_data
+
+
+def get_pos_2d(
+    context: Context,
+    wp,
+    coords: Vector,
+    respect_snapping: bool = False,
+) -> Vector:
     """Returns the coordinates on the workplane the mouse points at"""
     origin, end_point = get_picking_origin_end(context, coords)
+
+    if respect_snapping:
+        snap_info = get_blender_snap_info(context, coords)
+        if snap_info and "world_point" in snap_info:
+            snap_world_point = snap_info["world_point"]
+            pos = intersect_line_plane(origin, end_point, wp.p1.location, wp.normal)
+            if pos is None:
+                return None
+            closest_point = intersect_line_plane(snap_world_point, origin, wp.p1.location, wp.normal)
+            if closest_point is None:
+                return None
+            pos = wp.matrix_basis.inverted() @ closest_point
+            return Vector(pos[:-1])
+
     pos = intersect_line_plane(origin, end_point, wp.p1.location, wp.normal)
     if pos is None:
         return None


### PR DESCRIPTION
All of the code in this PR was done by codex AI, and tested in Blender by me.

This feature allows you to snap sketch geometry to existing 3d geometry in the scene. It doesn't cause any constraints to be made, or link anything to make it more parametric unfortunately. It snaps to a projection of 3d geometry onto the workplane. Ideally you would be doing this in an orthographic view normal to the sketch plane, but you don't have to be. If you are not, you can still snap accurately to things that are in the same plane as the workplane, which of course covers the face you made the workplane on.

I believe this covers #12.

This implementation enables:
- Snap to vertexes, edges, edge midpoints (when any of such snap target is enabled, and the "Snap during transforms" blender toggle is on) of visible geometry
- Snap to any if x-ray is enabled, otherwise just front geometry
- Circles can snap tangent to edges, or coincident with vertexes (not constrained though)
- Works with moving points, not just drawing them
- Applies to any drawable thing that makes a point, so lines, start of circle, arcs, points

<img width="1098" height="820" alt="CAD Sketcher Snapping Feature Demo" src="https://github.com/user-attachments/assets/c1b57ba7-b31a-42be-b09a-2a9878d22a47" />

Ideally it would show the little icons you get when blender does the snapping itself, but I wasn't able to figure out how to get that without having to implement new rendering just for the plugin which would basically duplicate whatever that existing code is.