### PR TITLE
Fix DOF stale-status messaging

### DIFF
--- a/model/sketch.py
+++ b/model/sketch.py
@@ -50,7 +50,12 @@ class SlvsSketch(SlvsGenericEntity, PropertyGroup):
     solver_state: EnumProperty(
         name="Solver Status", items=global_data.solver_state_items
     )
-    dof: IntProperty(name="Degrees of Freedom", max=6)
+    dof: IntProperty(name="Degrees of Freedom")
+    geometry_solved: BoolProperty(
+        name="Geometry Solved",
+        description="Whether the sketch geometry has been solved after the last edit",
+        default=True,
+    )
     target_curve: PointerProperty(type=bpy.types.Curve)
     target_curve_object: PointerProperty(type=bpy.types.Object)
     target_mesh: PointerProperty(type=bpy.types.Mesh)

--- a/operators/add_arc.py
+++ b/operators/add_arc.py
@@ -98,7 +98,10 @@ class View3D_OT_slvs_add_arc2d(Operator, Operator2d):
     def fini(self, context: Context, succeede: bool):
         if hasattr(self, "target"):
             logger.debug("Add: {}".format(self.target))
-            self.solve_state(context, self.sketch)
+        if succeede:
+            if self.has_coincident():
+                self.solve_state(context, self.sketch)
+            self.sketch.geometry_solved = False
 
 
 register, unregister = register_stateops_factory((View3D_OT_slvs_add_arc2d,))

--- a/operators/add_circle.py
+++ b/operators/add_circle.py
@@ -76,6 +76,7 @@ class View3D_OT_slvs_add_circle2d(Operator, Operator2d):
         if succeede:
             if self.has_coincident():
                 solve_system(context, sketch=self.sketch)
+            self.sketch.geometry_solved = False
 
 
 register, unregister = register_stateops_factory((View3D_OT_slvs_add_circle2d,))

--- a/operators/add_line_2d.py
+++ b/operators/add_line_2d.py
@@ -88,6 +88,7 @@ class View3D_OT_slvs_add_line2d(Operator, Operator2d):
         if succeede:
             if self.has_coincident() or self.has_alignment:
                 solve_system(context, sketch=self.sketch)
+            self.sketch.geometry_solved = False
 
 
 register, unregister = register_stateops_factory((View3D_OT_slvs_add_line2d,))

--- a/operators/add_point_2d.py
+++ b/operators/add_point_2d.py
@@ -56,6 +56,7 @@ class View3D_OT_slvs_add_point2d(Operator, Operator2d):
         if succeede:
             if self.has_coincident():
                 solve_system(context, sketch=self.sketch)
+            self.sketch.geometry_solved = False
 
 
 register, unregister = register_stateops_factory((View3D_OT_slvs_add_point2d,))

--- a/operators/add_rectangle.py
+++ b/operators/add_rectangle.py
@@ -99,6 +99,7 @@ class View3D_OT_slvs_add_rectangle(Operator, Operator2d):
         if succeede:
             if self.has_coincident():
                 solve_system(context, sketch=self.sketch)
+            self.sketch.geometry_solved = False
 
     def create_point(self, context: Context, values, state, state_data):
         value = values[0]

--- a/operators/bevel.py
+++ b/operators/bevel.py
@@ -153,7 +153,10 @@ class View3D_OT_slvs_bevel(Operator, Operator2d):
                         target.invert_direction = True
 
         refresh(context)
-        solve_system(context)
+        sketch = context.scene.sketcher.active_sketch
+        if sketch:
+            sketch.geometry_solved = False
+        solve_system(context, sketch)
 
 
 register, unregister = register_stateops_factory((View3D_OT_slvs_bevel,))

--- a/operators/delete_constraint.py
+++ b/operators/delete_constraint.py
@@ -43,6 +43,8 @@ class View3D_OT_slvs_delete_constraint(Operator, HighlightElement):
         constraints.remove(constr)
 
         sketch = context.scene.sketcher.active_sketch
+        if sketch:
+            sketch.geometry_solved = False
         solve_system(context, sketch=sketch)
         refresh(context)
         return {"FINISHED"}

--- a/operators/delete_entity.py
+++ b/operators/delete_entity.py
@@ -114,7 +114,10 @@ class View3D_OT_slvs_delete_entity(Operator, HighlightElement):
                     continue
                 self.delete(e, context)
 
-        solve_system(context, context.scene.sketcher.active_sketch)
+        sketch = context.scene.sketcher.active_sketch
+        if sketch:
+            sketch.geometry_solved = False
+        solve_system(context, sketch)
         refresh(context)
         return {"FINISHED"}
 

--- a/operators/move.py
+++ b/operators/move.py
@@ -94,6 +94,8 @@ class View3D_OT_slvs_move(Operator, Operator2d):
 
     def fini(self, context: Context, succeede: bool):
         if succeede:
+            if self.sketch:
+                self.sketch.geometry_solved = False
             solve_system(context, sketch=self.sketch)
 
 

--- a/operators/offset.py
+++ b/operators/offset.py
@@ -168,6 +168,9 @@ class View3D_OT_slvs_add_offset(Operator, Operator2d):
         if not succeede:
             return
 
+        if self.sketch:
+            self.sketch.geometry_solved = False
+
         constraints = context.scene.sketcher.constraints
 
         # Add parallel constraint

--- a/operators/trim.py
+++ b/operators/trim.py
@@ -85,6 +85,7 @@ class View3D_OT_slvs_trim(Operator, Operator2d):
             return
 
         trim.replace(context)
+        sketch.geometry_solved = False
         refresh(context)
 
 

--- a/operators/tweak.py
+++ b/operators/tweak.py
@@ -53,6 +53,9 @@ class View3D_OT_slvs_tweak(Operator):
     def modal(self, context: Context, event: Event):
         if event.type == "LEFTMOUSE" and event.value == "RELEASE":
             context.window.cursor_modal_restore()
+            sketch = context.scene.sketcher.active_sketch
+            if sketch:
+                sketch.geometry_solved = False
             return {"FINISHED"}
 
         context.window.cursor_modal_set("HAND")

--- a/solver.py
+++ b/solver.py
@@ -223,6 +223,7 @@ class Solver:
             if report and sketch:
                 sketch.solver_state = self.result.identifier
                 sketch.dof = retval['dof']
+                sketch.geometry_solved = True
 
             if retval['result'] != 0 and retval['result'] != 4:
                 self.ok = False

--- a/ui/panels/sketch_select.py
+++ b/ui/panels/sketch_select.py
@@ -27,6 +27,7 @@ def sketch_selector(
         ).index = -1
         row.active = True
 
+    row.alert = bool(active_sketch and not active_sketch.geometry_solved)
     row.operator(declarations.Operators.Update, icon="FILE_REFRESH", text="")
 
 


### PR DESCRIPTION
When adding new geometry the DOF info in the UI was missleading. I guess the reason to not  set needs_solve  when creating geomtry is due to performance reasons.

Threfore, I have added a geometry_solved flag to track stale solve state so there is an alert in bpy.ops.view3d.slvs_update() for the user to be warned.
Also removed some 6DOF cap which I guess it is fine for a single 3d rigid body but for the whole sketch system, the DOF can grow much higher.

Fianlly, add_arc has been changed to look exactly the same as the other equivalent files

Cheers!

