### PR TITLE
Dedicated operator for merging points and allow coincident points constraints

### DIFF
--- a/declarations.py
+++ b/declarations.py
@@ -52,6 +52,7 @@ class Operators(str, Enum):
     DeleteConstraint = "view3d.slvs_delete_constraint"
     DeleteEntity = "view3d.slvs_delete_entity"
     InstallPackage = "view3d.slvs_install_package"
+    MergePoints = "view3d.slvs_merge_points"
     Paste = "view3d.slvs_paste"
     Move = "view3d.slvs_move"
     Offset = "view3d.slvs_offset"

--- a/keymaps.py
+++ b/keymaps.py
@@ -14,6 +14,11 @@ constraint_access = (
         },
     ),
     (
+        Operators.MergePoints,
+        {"type": "M", "value": "PRESS", "alt": True},
+        None,
+    ),
+    (
         Operators.AddVertical,
         {"type": "V", "value": "PRESS", "shift": True},
         {

--- a/model/group_constraints.py
+++ b/model/group_constraints.py
@@ -170,10 +170,6 @@ class SlvsConstraints(PropertyGroup):
             SlvsCoincident: The created constraint.
         """
 
-        if all([e.is_point() for e in (entity1, entity2)]):
-            # TODO: Implicitly merge points
-            return
-
         c = self.coincident.add()
         c.entity1_i = entity1 if isinstance(entity1, int) else entity1.slvs_index
         c.entity2_i = entity2 if isinstance(entity2, int) else entity2.slvs_index

--- a/operators/add_geometric_constraints.py
+++ b/operators/add_geometric_constraints.py
@@ -7,6 +7,9 @@ from ..solver import solve_system
 from ..declarations import Operators
 from ..stateful_operator.utilities.register import register_stateops_factory
 from .base_constraint import GenericConstraintOp
+from ..utilities.select import deselect_all
+from ..utilities.view import refresh
+from ..utilities.merge import delete_collapsed_lines, merge_point_indices
 
 from ..model.coincident import SlvsCoincident
 from ..model.equal import SlvsEqual
@@ -53,6 +56,84 @@ class VIEW3D_OT_slvs_add_coincident(Operator, GenericConstraintOp):
                 sketch=self.sketch,
             )
         return super().main(context)
+
+
+class VIEW3D_OT_slvs_merge_points(Operator):
+    """Merge selected points"""
+
+    bl_idname = Operators.MergePoints
+    bl_label = "Merge Points"
+    bl_options = {"UNDO", "REGISTER"}
+
+    @classmethod
+    def poll(cls, context: Context):
+        return context.scene.sketcher.active_sketch_i != -1
+
+    def _selected_points(self, context: Context):
+        entities = context.scene.sketcher.entities
+        return [entity for entity in entities.selected if entity.is_point()]
+
+    def _resolve_target(self, points):
+        origin_points = [point for point in points if point.origin]
+        fixed_points = [point for point in points if point.fixed and not point.origin]
+
+        if len(origin_points) > 1:
+            return None, "Multiple origin points selected"
+
+        if origin_points:
+            if fixed_points:
+                return None, "Cannot merge with origin and fixed points selected"
+            return origin_points[0], None
+
+        if len(fixed_points) > 1:
+            return None, "Cannot merge multiple fixed points"
+
+        if fixed_points:
+            return fixed_points[0], None
+
+        return points[-1], None
+
+    def execute(self, context: Context):
+        points = self._selected_points(context)
+        if len(points) < 2:
+            self.report({"WARNING"}, "Select at least two points to merge")
+            return {"CANCELLED"}
+
+        target, error = self._resolve_target(points)
+        if error:
+            level = {"WARNING"} if error == "Cannot merge multiple fixed points" else {"ERROR"}
+            self.report(level, error)
+            return {"CANCELLED"}
+
+        duplicates = list(points)
+        duplicates.remove(target)
+        duplicate_indices = sorted(
+            (point.slvs_index for point in duplicates),
+            reverse=True,
+        )
+        target_index = target.slvs_index
+        target_index = merge_point_indices(context, target_index, duplicate_indices)
+
+        target = context.scene.sketcher.entities.get(target_index)
+        if target is None:
+            self.report({"ERROR"}, "Merge target became invalid")
+            return {"CANCELLED"}
+
+        deselect_all(context)
+        target.selected = True
+
+        deleted_lines = delete_collapsed_lines(context, point_indices={target_index})
+
+        solve_system(context, context.scene.sketcher.active_sketch)
+        refresh(context)
+        if deleted_lines:
+            self.report(
+                {"INFO"},
+                f"Merged {len(duplicates)} point(s) and deleted {deleted_lines} collapsed line(s)",
+            )
+        else:
+            self.report({"INFO"}, f"Merged {len(duplicates)} point(s)")
+        return {"FINISHED"}
 
 
 class VIEW3D_OT_slvs_add_equal(Operator, GenericConstraintOp):
@@ -248,6 +329,7 @@ class VIEW3D_OT_slvs_add_symmetry(Operator, GenericConstraintOp):
 
 constraint_operators = (
     VIEW3D_OT_slvs_add_coincident,
+    VIEW3D_OT_slvs_merge_points,
     VIEW3D_OT_slvs_add_equal,
     VIEW3D_OT_slvs_add_vertical,
     VIEW3D_OT_slvs_add_horizontal,

--- a/operators/add_geometric_constraints.py
+++ b/operators/add_geometric_constraints.py
@@ -3,14 +3,10 @@ import logging
 from bpy.types import Operator, Context
 from bpy.props import FloatProperty
 
-from ..model.utilities import update_pointers
 from ..solver import solve_system
 from ..declarations import Operators
 from ..stateful_operator.utilities.register import register_stateops_factory
 from .base_constraint import GenericConstraintOp
-from ..utilities.select import deselect_all
-from ..utilities.view import refresh
-from ..solver import solve_system
 
 from ..model.coincident import SlvsCoincident
 from ..model.equal import SlvsEqual
@@ -25,11 +21,6 @@ from ..model.ratio import SlvsRatio
 logger = logging.getLogger(__name__)
 
 
-def merge_points(context, duplicate, target):
-    update_pointers(context.scene, duplicate.slvs_index, target.slvs_index)
-    context.scene.sketcher.entities.remove(duplicate.slvs_index)
-
-
 class VIEW3D_OT_slvs_add_coincident(Operator, GenericConstraintOp):
     """Add a coincident constraint"""
 
@@ -39,27 +30,21 @@ class VIEW3D_OT_slvs_add_coincident(Operator, GenericConstraintOp):
 
     type = "COINCIDENT"
 
-    def handle_merge(self, context):
+    def _is_restricted_point_pair(self):
         points = self.entity1, self.entity2
 
-        if not all([e.is_point() for e in points]):
+        if not all(point.is_point() for point in points):
             return False
 
-        for p1, p2 in (points, reversed(points)):
-            if p1.origin:
-                continue
-            if p1.fixed:
-                continue
-
-            merge_points(context, p1, p2)
-            solve_system(context, context.scene.sketcher.active_sketch)
-            break
-        return True
+        return all(point.fixed for point in points)
 
     def main(self, context: Context):
-        # Implicitly merge points
-        if self.handle_merge(context):
-            return True
+        if self._is_restricted_point_pair():
+            self.report(
+                {"WARNING"},
+                "Cannot add coincident between two fixed points",
+            )
+            return False
 
         if not self.exists(context, SlvsCoincident):
             self.target = context.scene.sketcher.constraints.add_coincident(

--- a/operators/add_geometric_constraints.py
+++ b/operators/add_geometric_constraints.py
@@ -124,6 +124,9 @@ class VIEW3D_OT_slvs_merge_points(Operator):
 
         deleted_lines = delete_collapsed_lines(context, point_indices={target_index})
 
+        active_sketch = context.scene.sketcher.active_sketch
+        if active_sketch:
+            active_sketch.geometry_solved = False
         solve_system(context, context.scene.sketcher.active_sketch)
         refresh(context)
         if deleted_lines:

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -18,6 +18,8 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
     def draw(self, context: Context):
         layout = self.layout
 
+        layout.operator(declarations.Operators.MergePoints)
+
         # Constraints
         layout.label(text="Constraints:")
         col = layout.column(align=True)

--- a/utilities/merge.py
+++ b/utilities/merge.py
@@ -1,0 +1,81 @@
+from ..model.utilities import update_pointers
+
+
+def collect_collapsed_line_indices(context, point_indices=None):
+    entities = context.scene.sketcher.entities
+    point_index_set = set(point_indices) if point_indices is not None else None
+    return [
+        entity.slvs_index
+        for entity in entities.all
+        if entity.is_line()
+        and (p1 := getattr(entity, "p1_i", None)) is not None
+        and p1 == getattr(entity, "p2_i", None)
+        and (point_index_set is None or p1 in point_index_set)
+    ]
+
+
+def _delete_constraints_for_lines(context, collapsed_lines):
+    if not collapsed_lines:
+        return
+
+    constraints = context.scene.sketcher.constraints
+    collapsed_set = set(collapsed_lines)
+    constraints_to_delete = []
+
+    for constraint in constraints.all:
+        try:
+            deps = constraint.dependencies()
+        except Exception:
+            deps = []
+
+        if any(getattr(dep, "slvs_index", None) in collapsed_set for dep in deps):
+            constraints_to_delete.append(constraint)
+
+    constraints_to_delete.sort(
+        key=lambda constraint: (constraint.type, constraint.index()), reverse=True
+    )
+    for constraint in constraints_to_delete:
+        constraints.remove(constraint)
+
+
+def delete_collapsed_lines(context, point_indices=None):
+    entities = context.scene.sketcher.entities
+    collapsed = collect_collapsed_line_indices(context, point_indices=point_indices)
+    if not collapsed:
+        return 0
+
+    _delete_constraints_for_lines(context, collapsed)
+
+    deleted = 0
+    for line_index in sorted(collapsed, reverse=True):
+        line = entities.get(line_index)
+        if line is None:
+            continue
+        entities.remove(line_index)
+        deleted += 1
+
+    return deleted
+
+
+def merge_point_indices(context, target_index, duplicate_indices):
+    entities = context.scene.sketcher.entities
+
+    for duplicate_index in duplicate_indices:
+        collection_name = entities.collection_name_from_index(duplicate_index)
+        last_index_before_remove = (
+            getattr(entities, collection_name)[-1].slvs_index if collection_name else None
+        )
+
+        update_pointers(context.scene, duplicate_index, target_index)
+        entities.remove(duplicate_index)
+
+        # SlvsEntities.remove swaps the last item into the removed slot.
+        # If the merge target was that last item, its new index becomes duplicate_index.
+        if (
+            last_index_before_remove is not None
+            and target_index == last_index_before_remove
+            and duplicate_index != last_index_before_remove
+        ):
+            target_index = duplicate_index
+
+    return target_index


### PR DESCRIPTION
This is a proposal to allow both to merge points and also coincident constraint them.
Currently adding a coincident constraint to points is merging them which is a destructive process. 

There are sitiuations in which coincident constraining points is required. 
For exmaple in AEC one would like to draw high level structures (like several lines that form a slab, wall run, covering, etc.) that are logically touching each other by means of point coincident constraint. Currently, since this is merging the points, this breaks the independenc of such constructs which is nice should one want to change that constraint in the future for example during a design cycle.

Three commits are provided:

- Let slvs_add_coincident() add constraint for two points (as long as they are not both fixed)
    - Removes the old point-point coincident block in constraints handling and lets coincident be created for point pairs.
    - Adds a guard in operator flow so fixed+fixed point pairs are rejected with a warning instead of creating an invalid constraint.
 

-  Add merge points operator and integrate into UI and keymaps
    - Introduces Merge Points operator with target resolution rules and merge execution.
    - Integrates merge action into declarations, tools UI, and keymaps.
    - Adds merge utility module for pointer rewiring and collapsed-line cleanup.

- Reset geometry solved status when merging points in active sketch just in case solver fails
    - Sets geometry_solved to False before solve. This makes state safer and more consistent if solve is skipped/aborts.
   
Cheers!
