### PR TITLE
Fix interactive solving and constraint stability

### DIFF
--- a/global_data.py
+++ b/global_data.py
@@ -25,6 +25,7 @@ highlight_entities = []
 
 needs_solve = False
 needs_redraw = False
+stateful_op_running = False
 
 Z_AXIS = Vector((0, 0, 1))
 

--- a/handlers.py
+++ b/handlers.py
@@ -65,6 +65,9 @@ def on_depsgraph_update(scene, depsgraph):
     from . import global_data
 
     if global_data.needs_solve:
+        if global_data.stateful_op_running:
+            return
+
         global_data.needs_solve = False
         from .solver import solve_system
 

--- a/model/angle.py
+++ b/model/angle.py
@@ -31,9 +31,12 @@ class SlvsAngle(DimensionalConstraint, PropertyGroup):
     def assign_init_props(self, context: Context = None, **kwargs):
         # Updating self.setting will create recursion loop
 
-        super().assign_init_props(context)
+        super().assign_init_props(context, **kwargs)
 
         line1, line2 = self.entity1, self.entity2
+        if line1 is None or line2 is None:
+            return
+
         origin = get_line_intersection(
             *line_abc_form(line1.p1.co, line1.p2.co),
             *line_abc_form(line2.p1.co, line2.p2.co),
@@ -130,7 +133,12 @@ class SlvsAngle(DimensionalConstraint, PropertyGroup):
         return math.degrees(math.acos(x))
 
     def _get_init_value(self, setting):
-        vec1, vec2 = self.entity1.direction_vec(), self.entity2.direction_vec()
+        e1, e2 = self.entity1, self.entity2
+        if e1 is None or e2 is None:
+            if self.is_property_set("value_store"):
+                return math.degrees(self.value_store)
+            return 0.0
+        vec1, vec2 = e1.direction_vec(), e2.direction_vec()
         return self._get_angle(vec1, vec2)
 
     def init_props(self, **kwargs):
@@ -141,7 +149,10 @@ class SlvsAngle(DimensionalConstraint, PropertyGroup):
         """
 
         setting = kwargs.get("setting", self.setting)
-        angle = kwargs.get("value", self._get_init_value(setting))
+        if "value" in kwargs:
+            angle = kwargs["value"]
+        else:
+            angle = self._get_init_value(setting)
 
         return {
             "value": math.radians(angle),

--- a/model/base_constraint.py
+++ b/model/base_constraint.py
@@ -215,6 +215,23 @@ class DimensionalConstraint(GenericConstraint):
             if value is None:
                 continue
 
+            # "value" has a custom RNA getter that may call assign_init_props,
+            # so never read it back — just write unconditionally.
+            if key == "value":
+                setprop(self, key, value)
+                continue
+
+            # For all other keys (e.g. "setting", "flip", "align") skip the
+            # write when the value is unchanged so we don't fire update
+            # callbacks that would re-enter assign_init_props and recurse.
+            try:
+                current = getattr(self, key)
+            except Exception:
+                current = object()
+
+            if current == value:
+                continue
+
             setprop(self, key, value)
 
     def assign_init_props(self, context: Context = None, **kwargs):

--- a/model/diameter.py
+++ b/model/diameter.py
@@ -88,14 +88,22 @@ class SlvsDiameter(DimensionalConstraint, PropertyGroup):
         return solvesys.diameter(group, self.entity1.py_data, self.diameter)
 
     def _get_init_value(self, setting):
-        value = self.entity1.radius
+        entity = self.entity1
+        if entity is None:
+            if self.is_property_set("value_store"):
+                return self.value_store
+            return 0.0
+        value = entity.radius
         if not setting:
             return value * 2
         return value
 
     def init_props(self, **kwargs):
         setting = kwargs.get("setting", self.setting)
-        value = kwargs.get("value", self._get_init_value(setting))
+        if "value" in kwargs:
+            value = kwargs["value"]
+        else:
+            value = self._get_init_value(setting)
         return {"value": value, "setting": setting}
 
     def matrix_basis(self):

--- a/model/distance.py
+++ b/model/distance.py
@@ -39,6 +39,8 @@ def get_side_of_line(line_start, line_end, point):
 
 
 def _get_aligned_distance(p_1, p_2, alignment):
+    if p_1 is None or p_2 is None:
+        return 0.0
     if alignment == "HORIZONTAL":
         return abs(p_2.co.x - p_1.co.x)
     if alignment == "VERTICAL":
@@ -70,9 +72,10 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
 
     def _set_align(self, value: int):
         alignment = bpyEnum(align_items, value).identifier
-        distance = _get_aligned_distance(self.entity1, self.entity2, alignment)
         self.align_store = alignment
-        self.value_store = distance
+        if self.entity1 is None or self.entity2 is None:
+            return
+        self.value_store = _get_aligned_distance(self.entity1, self.entity2, alignment)
 
     def _get_align(self) -> int:
         if not self.is_property_set("align_store"):
@@ -133,15 +136,21 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
 
     def use_flipping(self):
         # Only use flipping for constraint between point and line/workplane
-        if self.entity1.is_curve():
+        e1, e2 = self.entity1, self.entity2
+        if e1 is None or e2 is None:
             return False
-        return type(self.entity2) in (*LINE, SlvsWorkplane)
+        if e1.is_curve():
+            return False
+        return type(e2) in (*LINE, SlvsWorkplane)
 
     def use_align(self):
         """Returns True if constraint's entities allow distance to be aligned"""
-        if type(self.entity2) in (*LINE, SlvsWorkplane):
+        e1, e2 = self.entity1, self.entity2
+        if e1 is None or e2 is None:
             return False
-        if self.entity1.is_curve():
+        if type(e2) in (*LINE, SlvsWorkplane):
+            return False
+        if e1.is_curve():
             return False
         return True
 
@@ -318,6 +327,11 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
     def _get_init_value(self, alignment):
         e1, e2 = self.entity1, self.entity2
 
+        if e1 is None or e2 is None:
+            if self.is_property_set("value_store"):
+                return self.value_store
+            return 0.0
+
         if e1.is_3d():
             return (e1.location - e2.location).length
 
@@ -359,7 +373,10 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
         alignment = kwargs.get("align")
         retval = {}
 
-        value = kwargs.get("value", self._get_init_value(alignment))
+        if "value" in kwargs:
+            value = kwargs["value"]
+        else:
+            value = self._get_init_value(alignment)
 
         if self.use_flipping() and value < 0:
             value = abs(value)

--- a/model/group_sketcher.py
+++ b/model/group_sketcher.py
@@ -30,6 +30,13 @@ class SketcherProps(PropertyGroup):
         options={"SKIP_SAVE"},
         update=update_cb,
     )
+    auto_axis_constraints: BoolProperty(
+        name="Auto Constraints",
+        description="Automatically add inferred constraints (for example auto axis alignment and auto coincident)",
+        default=True,
+        options={"SKIP_SAVE"},
+        update=update_cb,
+    )
     selectable_constraints: BoolProperty(
         name="Constraints Selectability",
         default=True,

--- a/operators/add_line_2d.py
+++ b/operators/add_line_2d.py
@@ -28,6 +28,7 @@ class View3D_OT_slvs_add_line2d(Operator, Operator2d):
     l2d_state2_doc = ("Endpoint", "Pick or place line's ending Point.")
 
     continuous_draw: BoolProperty(name="Continuous Draw", default=True)
+    _skip_auto_axis_this_segment = False
 
     states = (
         state_from_args(
@@ -45,6 +46,21 @@ class View3D_OT_slvs_add_line2d(Operator, Operator2d):
         ),
     )
 
+    def init(self, context, event):
+        self._skip_auto_axis_this_segment = False
+        return super().init(context, event)
+
+    def check_event(self, event):
+        if self.state_index == 1 and event.shift:
+            self._skip_auto_axis_this_segment = True
+
+        is_confirm = event.type in ("LEFTMOUSE", "RET", "NUMPAD_ENTER")
+        if is_confirm and event.value == "PRESS":
+            self._skip_auto_axis_this_segment = (
+                self._skip_auto_axis_this_segment or bool(event.shift)
+            )
+        return super().check_event(event)
+
     def main(self, context: Context):
         wp = self.sketch.wp
         p1, p2 = self.get_point(context, 0), self.get_point(context, 1)
@@ -53,20 +69,26 @@ class View3D_OT_slvs_add_line2d(Operator, Operator2d):
         if context.scene.sketcher.use_construction:
             self.target.construction = True
 
-        # auto vertical/horizontal constraint
         self.has_alignment = False
-        constraints = context.scene.sketcher.constraints
-        vec_dir = self.target.direction_vec()
-        if vec_dir.length:
-            angle = vec_dir.angle(Vector((1, 0)))
+        use_auto_axis = (
+            context.scene.sketcher.auto_axis_constraints
+            and not self._skip_auto_axis_this_segment
+        )
+        if use_auto_axis:
+            constraints = context.scene.sketcher.constraints
+            vec_dir = self.target.direction_vec()
+            if vec_dir.length:
+                angle = vec_dir.angle(Vector((1, 0)))
 
-            threshold = 0.1
-            if angle < threshold or angle > HALF_TURN - threshold:
-                constraints.add_horizontal(self.target, sketch=self.sketch)
-                self.has_alignment = True
-            elif (QUARTER_TURN - threshold) < angle < (QUARTER_TURN + threshold):
-                constraints.add_vertical(self.target, sketch=self.sketch)
-                self.has_alignment = True
+                threshold = 0.1
+                if angle < threshold or angle > HALF_TURN - threshold:
+                    constraints.add_horizontal(self.target, sketch=self.sketch)
+                    self.has_alignment = True
+                elif (QUARTER_TURN - threshold) < angle < (QUARTER_TURN + threshold):
+                    constraints.add_vertical(self.target, sketch=self.sketch)
+                    self.has_alignment = True
+
+        self._skip_auto_axis_this_segment = False
 
         ignore_hover(self.target)
         return True

--- a/operators/base_stateful.py
+++ b/operators/base_stateful.py
@@ -15,7 +15,17 @@ class GenericEntityOp(StatefulOperator):
     """Extend StatefulOperator with extension specific types"""
 
     def check_event(self, event):
+        if event.shift:
+            self.state_data["skip_auto_constraints"] = True
         return super().check_event(event)
+
+    def use_auto_constraints(self, context: Context, state_data=None) -> bool:
+        if state_data is None:
+            state_data = self.state_data
+        return (
+            context.scene.sketcher.auto_axis_constraints
+            and not state_data.get("skip_auto_constraints", False)
+        )
 
     def pick_element(self, context, coords):
         retval = super().pick_element(context, coords)
@@ -41,6 +51,9 @@ class GenericEntityOp(StatefulOperator):
         return hovered.slvs_index if hovered else None
 
     def add_coincident(self, context: Context, point, state, state_data):
+        if not self.use_auto_constraints(context, state_data):
+            return
+
         index = state_data.get("hovered", -1)
         if index != -1:
             hovered = context.scene.sketcher.entities.get(index)

--- a/stateful_operator/logic.py
+++ b/stateful_operator/logic.py
@@ -3,6 +3,7 @@ from bpy.props import IntProperty, BoolProperty
 from bpy.types import Context, Event
 from mathutils import Vector
 
+from .. import global_data
 from .state_machine import _StateMachineMixin
 from .utilities.generic import to_list
 from .utilities.description import state_desc, stateful_op_desc
@@ -258,6 +259,7 @@ class StatefulOperatorLogic(_StateMachineMixin):
         return False
 
     def invoke(self, context: Context, event: Event):
+        global_data.stateful_op_running = True
         self._state_data.clear()
         self._numeric = NumericInput()
         self._state_snapshot = self.create_snapshot(context)
@@ -296,6 +298,7 @@ class StatefulOperatorLogic(_StateMachineMixin):
         return self._end(context, succeede)
 
     def execute(self, context: Context):
+        global_data.stateful_op_running = True
         self._numeric = NumericInput()
         self.redo_states(context)
         ok = self.main(context)
@@ -496,12 +499,15 @@ class StatefulOperatorLogic(_StateMachineMixin):
                     )
                     self.set_state_pointer(to_list(ret_values), index=i, implicit=True)
 
-    def _end(self, context, succeede, skip_undo=False):
+    def _end(self, context, succeede, skip_undo=False, keep_stateful_running=False):
         context.window.cursor_modal_restore()
         if hasattr(self, "fini"):
             self.fini(context, succeede)
         self.on_before_redo_states(context)
         context.workspace.status_text_set(None)
+
+        if not keep_stateful_running:
+            global_data.stateful_op_running = False
 
         if not succeede and not skip_undo:
             if self._state_snapshot is not None:
@@ -549,7 +555,7 @@ class StatefulOperatorLogic(_StateMachineMixin):
         The last pointer of the finished segment (e.g. a line endpoint)
         becomes the first pointer of the new segment, creating a chain.
         """
-        self._end(context, True)
+        self._end(context, True, keep_stateful_running=True)
         bpy.ops.ed.undo_push(message=self.bl_label)
 
         # Save the endpoint before _reset_op wipes state

--- a/stateful_operator/logic.py
+++ b/stateful_operator/logic.py
@@ -260,49 +260,58 @@ class StatefulOperatorLogic(_StateMachineMixin):
 
     def invoke(self, context: Context, event: Event):
         global_data.stateful_op_running = True
+        entered_modal = False
         self._state_data.clear()
         self._numeric = NumericInput()
         self._state_snapshot = self.create_snapshot(context)
+        try:
+            if hasattr(self, "init"):
+                if not self.init(context, event):
+                    return self._end(context, False)
 
-        if hasattr(self, "init"):
-            if not self.init(context, event):
-                return self._end(context, False)
+            retval = {"RUNNING_MODAL"}
+            go_modal = True
 
-        retval = {"RUNNING_MODAL"}
-        go_modal = True
+            if is_numeric_input(event):
+                if self.init_numeric(True):
+                    self._numeric.evaluate_event(event)
+                    self.evaluate_state(context, event, False)
 
-        if is_numeric_input(event):
-            if self.init_numeric(True):
-                self._numeric.evaluate_event(event)
-                self.evaluate_state(context, event, False)
+            # wait_for_input=True: respect selection for prefill, but wait for LMB
+            elif self.wait_for_input:
+                retval = self.prefill_state_props(context)
+                if retval == {"FINISHED"}:
+                    go_modal = False
+                if not self.executed and self.check_props():
+                    self.run_op(context)
+                    self.executed = True
+                context.area.tag_redraw()
 
-        # wait_for_input=True: respect selection for prefill, but wait for LMB
-        elif self.wait_for_input:
-            retval = self.prefill_state_props(context)
-            if retval == {"FINISHED"}:
-                go_modal = False
-            if not self.executed and self.check_props():
-                self.run_op(context)
-                self.executed = True
-            context.area.tag_redraw()
+            self.set_status_text(context)
 
-        self.set_status_text(context)
+            if go_modal:
+                context.window.cursor_modal_set("CROSSHAIR")
+                context.window_manager.modal_handler_add(self)
+                entered_modal = True
+                return retval
 
-        if go_modal:
-            context.window.cursor_modal_set("CROSSHAIR")
-            context.window_manager.modal_handler_add(self)
-            return retval
-
-        succeede = retval == {"FINISHED"}
-        # NOTE: Pushing an undo step here causes duplicated constraints after redo.
-        return self._end(context, succeede)
+            succeede = retval == {"FINISHED"}
+            # NOTE: Pushing an undo step here causes duplicated constraints after redo.
+            return self._end(context, succeede)
+        finally:
+            if not entered_modal and global_data.stateful_op_running:
+                global_data.stateful_op_running = False
 
     def execute(self, context: Context):
         global_data.stateful_op_running = True
-        self._numeric = NumericInput()
-        self.redo_states(context)
-        ok = self.main(context)
-        return self._end(context, ok, skip_undo=True)
+        try:
+            self._numeric = NumericInput()
+            self.redo_states(context)
+            ok = self.main(context)
+            return self._end(context, ok, skip_undo=True)
+        finally:
+            if global_data.stateful_op_running:
+                global_data.stateful_op_running = False
 
     def _handle_pass_through(self, context: Context, event: Event):
         if event.type in {"MIDDLEMOUSE", "WHEELUPMOUSE", "WHEELDOWNMOUSE", "MOUSEMOVE"}:

--- a/workspacetools/add_arc2d.py
+++ b/workspacetools/add_arc2d.py
@@ -18,3 +18,6 @@ class VIEW3D_T_slvs_add_arc2d(GenericStateTool, WorkSpaceTool):
         *tool_generic,
         *operator_access(Operators.AddArc2D),
     )
+
+    def draw_settings(context, layout, tool):
+        layout.prop(context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints")

--- a/workspacetools/add_circle2d.py
+++ b/workspacetools/add_circle2d.py
@@ -18,3 +18,6 @@ class VIEW3D_T_slvs_add_circle2d(GenericStateTool, WorkSpaceTool):
         *tool_generic,
         *operator_access(Operators.AddCircle2D),
     )
+
+    def draw_settings(context, layout, tool):
+        layout.prop(context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints")

--- a/workspacetools/add_line2d.py
+++ b/workspacetools/add_line2d.py
@@ -22,3 +22,4 @@ class VIEW3D_T_slvs_add_line2d(GenericStateTool, WorkSpaceTool):
     def draw_settings(context, layout, tool):
         props = tool.operator_properties(Operators.AddLine2D)
         layout.prop(props, "continuous_draw")
+        layout.prop(context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints")

--- a/workspacetools/add_line3d.py
+++ b/workspacetools/add_line3d.py
@@ -22,3 +22,4 @@ class VIEW3D_T_slvs_add_line3d(GenericStateTool, WorkSpaceTool):
     def draw_settings(context, layout, tool):
         props = tool.operator_properties(Operators.AddLine3D)
         layout.prop(props, "continuous_draw")
+        layout.prop(context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints")

--- a/workspacetools/add_point2d.py
+++ b/workspacetools/add_point2d.py
@@ -19,3 +19,6 @@ class VIEW3D_T_slvs_add_point2d(GenericStateTool, WorkSpaceTool):
         *tool_generic,
         *operator_access(Operators.AddPoint2D),
     )
+
+    def draw_settings(context, layout, tool):
+        layout.prop(context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints")

--- a/workspacetools/add_point3d.py
+++ b/workspacetools/add_point3d.py
@@ -19,3 +19,6 @@ class VIEW3D_T_slvs_add_point3d(GenericStateTool, WorkSpaceTool):
         *tool_generic,
         *operator_access(Operators.AddPoint3D),
     )
+
+    def draw_settings(context, layout, tool):
+        layout.prop(context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints")

--- a/workspacetools/add_rectangle.py
+++ b/workspacetools/add_rectangle.py
@@ -18,3 +18,6 @@ class VIEW3D_T_slvs_add_rectangle(GenericStateTool, WorkSpaceTool):
         *tool_generic,
         *operator_access(Operators.AddRectangle),
     )
+
+    def draw_settings(context, layout, tool):
+        layout.prop(context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints")


### PR DESCRIPTION
This PR bundles a set of stability improvements around interactive sketch editing and inferred constraints.

This PR was prompted while investigating the behavior shown in issue https://github.com/hlorus/CAD_Sketcher/issues/545:


A  umber of errors where ocurrign apart from teh auto constraint beahviour commented:
 - Deferred solver execution while stateful interactive operators are running, so solving is not triggered mid-edit.
- Fixed recursion in dimensional constraint initialization/settings updates.
- Hardened dimensional constraints against temporarily unresolved entity pointers during reference/initialization transitions.
- Unified inferred auto-constraint behavior:
  - Added a global Auto Constraints toggle for inferred constraints.
  - Added temporary Shift bypass for inferred constraints during interactive placement.
  - Applied this rule where it makes sense for inferred constraints, while keeping structural tool constraints intact (for example rectangle’s defining constraints).

Cheers!
