### PR TITLE
Propose index-to-uid migration plan

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,7 +8,7 @@ from bpy.app import background
 bl_info = {
     "name": "CAD Sketcher",
     "author": "hlorus",
-    "version": (0, 27, 6),
+    "version": (0, 27, 7),
     "blender": (4, 0, 0),
     "location": "View3D > Toolbar",
     "description": "Parametric, constraint-based geometry sketcher",

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "CAD_Sketcher"
-version = "0.27.5"
+version = "0.27.7"
 name = "CAD Sketcher"
 tagline = "Parametric, constraint-based geometry sketcher"
 maintainer = "hlorus <dave19924@gmail.com>"

--- a/experiments/test_driver_stability_uid.py
+++ b/experiments/test_driver_stability_uid.py
@@ -1,0 +1,82 @@
+"""Test driver stability using UIDs (fix for issue #544).
+
+With UID-based driver paths like scene["slvs:c:{uid}"], constraint values
+are accessed by their unique identifier rather than collection index.
+This ensures drivers remain stable even when other constraints are deleted.
+"""
+import bpy
+
+scene = bpy.data.scenes.new("DriverTestUID")
+bpy.context.window.scene = scene
+
+sse = scene.sketcher.entities
+ssc = scene.sketcher.constraints
+
+sse.ensure_origin_elements(bpy.context)
+wp = sse.origin_plane_XY
+sketch = sse.add_sketch(wp)
+scene.sketcher.active_sketch_i = sketch.slvs_index
+
+# Create 3 distance constraints
+p0 = sse.add_point_2d((0, 0), sketch, fixed=True)
+
+p1 = sse.add_point_2d((1, 0), sketch)
+c1 = ssc.add_distance(p0, p1, sketch=sketch, init=True)
+
+p2 = sse.add_point_2d((0, 2), sketch)
+c2 = ssc.add_distance(p0, p2, sketch=sketch, init=True)
+
+p3 = sse.add_point_2d((3, 0), sketch)
+c3 = ssc.add_distance(p0, p3, sketch=sketch, init=True)
+
+# Set distinct values
+c1.value = 10.0
+c2.value = 20.0
+c3.value = 30.0
+
+# Get UIDs
+uid1 = getattr(c1, "constraint_uid", "")
+uid2 = getattr(c2, "constraint_uid", "")
+uid3 = getattr(c3, "constraint_uid", "")
+
+print(f"=== Initial state ===")
+print(f"c1: uid={uid1}, value={c1.value:.1f}")
+print(f"c2: uid={uid2}, value={c2.value:.1f}")
+print(f"c3: uid={uid3}, value={c3.value:.1f}")
+
+# Show what a UID-based driver would target
+print(f"\n=== UID-based driver paths ===")
+for i, c in enumerate(ssc.distance):
+    uid = getattr(c, "constraint_uid", "")
+    value = scene.get(f"slvs:c:{uid}", 0.0)
+    print(f"  scene['slvs:c:{uid}'] = {value:.1f}")
+
+# Delete c2 (middle constraint)
+print(f"\n=== Deleting c2 (uid={uid2}) ===")
+ssc.remove(c2)
+
+# Check that UID-based paths still resolve correctly
+print(f"\n=== UID-based paths after deletion ===")
+print(f"A driver targeting scene['slvs:c:{uid1}'] still gets: {scene.get(f'slvs:c:{uid1}', 'NOT FOUND'):.1f}")
+print(f"A driver targeting scene['slvs:c:{uid2}'] now gets: {scene.get(f'slvs:c:{uid2}', 'DELETED (expected)')}")
+print(f"A driver targeting scene['slvs:c:{uid3}'] still gets: {scene.get(f'slvs:c:{uid3}', 'NOT FOUND'):.1f}")
+
+# Verify stability
+val1_after = scene.get(f"slvs:c:{uid1}", None)
+val3_after = scene.get(f"slvs:c:{uid3}", None)
+
+print(f"\n=== Stability check ===")
+if val1_after is not None and abs(val1_after - 10.0) < 0.01:
+    print(f"PASS: UID {uid1} still references value 10.0")
+else:
+    print(f"FAIL: UID {uid1} value shifted to {val1_after}")
+
+if val3_after is not None and abs(val3_after - 30.0) < 0.01:
+    print(f"PASS: UID {uid3} still references value 30.0")
+else:
+    print(f"FAIL: UID {uid3} value shifted to {val3_after}")
+
+if scene.get(f"slvs:c:{uid2}") is None:
+    print(f"PASS: UID {uid2} correctly removed with deleted constraint")
+else:
+    print(f"FAIL: UID {uid2} still exists unexpectedly")

--- a/handlers.py
+++ b/handlers.py
@@ -64,6 +64,12 @@ def unregister_handlers():
 def on_depsgraph_update(scene, depsgraph):
     from . import global_data
 
+    try:
+        if scene.sketcher.apply_constraint_value_endpoints():
+            global_data.needs_solve = True
+    except (RuntimeError, AttributeError):
+        pass
+
     if global_data.needs_solve:
         if global_data.stateful_op_running:
             return

--- a/handlers.py
+++ b/handlers.py
@@ -64,11 +64,9 @@ def unregister_handlers():
 def on_depsgraph_update(scene, depsgraph):
     from . import global_data
 
-    try:
-        if scene.sketcher.apply_constraint_value_endpoints():
-            global_data.needs_solve = True
-    except (RuntimeError, AttributeError):
-        pass
+
+    if depsgraph.id_type_updated("SCENE"):
+        global_data.needs_solve = True
 
     if global_data.needs_solve:
         if global_data.stateful_op_running:

--- a/model/angle.py
+++ b/model/angle.py
@@ -141,10 +141,12 @@ class SlvsAngle(DimensionalConstraint, PropertyGroup):
             if scene is not None and uid:
                 key = f"slvs:c:{uid}"
                 if key in scene:
-                    return math.degrees(float(scene[key]))
+                    angle = math.degrees(float(scene[key]))
+                    return 180.0 - angle if setting else angle
             return 0.0
         vec1, vec2 = e1.direction_vec(), e2.direction_vec()
-        return self._get_angle(vec1, vec2)
+        angle = self._get_angle(vec1, vec2)
+        return 180.0 - angle if setting else angle
 
     def init_props(self, **kwargs):
         """

--- a/model/angle.py
+++ b/model/angle.py
@@ -16,7 +16,7 @@ from .base_constraint import DimensionalConstraint
 from .line_2d import SlvsLine2D
 from .utilities import slvs_entity_pointer
 from ..utilities.geometry import line_abc_form, get_line_intersection
-from ..utilities.solver import update_system_cb
+from ..utilities.solver import update_system_cb, constraint_value_update_cb
 
 
 logger = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ class SlvsAngle(DimensionalConstraint, PropertyGroup):
         subtype="ANGLE",
         unit="ROTATION",
         precision=6,
-        update=update_system_cb,
+        update=constraint_value_update_cb,
         get=DimensionalConstraint._get_value,
         set=DimensionalConstraint._set_value,
     )

--- a/model/angle.py
+++ b/model/angle.py
@@ -52,6 +52,7 @@ class SlvsAngle(DimensionalConstraint, PropertyGroup):
         subtype="ANGLE",
         unit="ROTATION",
         precision=6,
+        options={"HIDDEN"},
     )
     value: FloatProperty(
         name=label,
@@ -135,8 +136,12 @@ class SlvsAngle(DimensionalConstraint, PropertyGroup):
     def _get_init_value(self, setting):
         e1, e2 = self.entity1, self.entity2
         if e1 is None or e2 is None:
-            if self.is_property_set("value_store"):
-                return math.degrees(self.value_store)
+            scene = getattr(self, "id_data", None)
+            uid = getattr(self, "constraint_uid", "")
+            if scene is not None and uid:
+                key = f"slvs:c:{uid}"
+                if key in scene:
+                    return math.degrees(float(scene[key]))
             return 0.0
         vec1, vec2 = e1.direction_vec(), e2.direction_vec()
         return self._get_angle(vec1, vec2)

--- a/model/base_constraint.py
+++ b/model/base_constraint.py
@@ -32,6 +32,7 @@ class GenericConstraint:
 
         name: StringProperty(name="Name", get=_name_getter, set=_name_setter)
     failed: BoolProperty(name="Failed")
+    constraint_uid: StringProperty(name="Constraint UID", default="")
     visible: BoolProperty(name="Visible", default=True, update=update_cb)
     is_reference = False  # Only DimensionalConstraint can be reference
     signature = ()
@@ -279,10 +280,14 @@ class DimensionalConstraint(GenericConstraint):
         sub.prop(self, "is_reference")
         if hasattr(self, "value"):
             col = sub.column()
-            # Could not find a way to have the property "readonly",
-            # so we disable user input instead
-            col.prop(self, "value")
             col.enabled = not self.is_reference
+            scene = getattr(self, "id_data", None)
+            uid = getattr(self, "constraint_uid", "")
+            key = None
+            if scene and uid:
+                key = scene.sketcher.get_or_create_constraint_value_endpoint(self)
+            if key:
+                col.prop(scene, f'["{key}"]')
         if hasattr(self, "setting"):
             row = sub.row()
             row.prop(self, "setting")

--- a/model/base_constraint.py
+++ b/model/base_constraint.py
@@ -201,15 +201,23 @@ class DimensionalConstraint(GenericConstraint):
             self._set_value_force(self.from_displayed_value(displayed_value))
 
     def _set_value_force(self, value: float):
-        self.value_store = value
+        scene = getattr(self, "id_data", None)
+        uid = getattr(self, "constraint_uid", "")
+        if scene is not None and uid:
+            scene[f"slvs:c:{uid}"] = value
 
     def _get_value(self):
         if self.is_reference:
             val = self.init_props()["value"]
             return self.to_displayed_value(val)
-        if not self.is_property_set("value_store"):
-            self.assign_init_props()
-        return self.to_displayed_value(self.value_store)
+        scene = getattr(self, "id_data", None)
+        uid = getattr(self, "constraint_uid", "")
+        if scene is not None and uid:
+            key = f"slvs:c:{uid}"
+            if key in scene:
+                return self.to_displayed_value(float(scene[key]))
+        val = self.init_props().get("value", 0.0)
+        return self.to_displayed_value(val)
 
     def assign_settings(self, **settings):
         for key, value in settings.items():
@@ -285,7 +293,7 @@ class DimensionalConstraint(GenericConstraint):
             uid = getattr(self, "constraint_uid", "")
             key = None
             if scene and uid:
-                key = scene.sketcher.get_or_create_constraint_value_endpoint(self)
+                key = scene.sketcher.get_constraint_value_endpoint(self)
             if key:
                 col.prop(scene, f'["{key}"]')
         if hasattr(self, "setting"):

--- a/model/diameter.py
+++ b/model/diameter.py
@@ -13,7 +13,7 @@ from ..utilities.math import range_2pi, pol2cart
 from .base_constraint import DimensionalConstraint
 from .utilities import slvs_entity_pointer
 from .categories import CURVE
-from ..utilities.solver import update_system_cb
+from ..utilities.solver import update_system_cb, constraint_value_update_cb
 
 
 logger = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ class SlvsDiameter(DimensionalConstraint, PropertyGroup):
         precision=6,
         get=DimensionalConstraint._get_value,
         set=DimensionalConstraint._set_value,
-        update=update_system_cb,
+        update=constraint_value_update_cb,
     )
     setting_store: BoolProperty(name="Use Radius Storage", default=False)
     setting: BoolProperty(

--- a/model/diameter.py
+++ b/model/diameter.py
@@ -112,7 +112,7 @@ class SlvsDiameter(DimensionalConstraint, PropertyGroup):
             value = kwargs["value"]
         else:
             value = self._get_init_value(setting)
-        return {"value": value, "setting": setting}
+        return {"setting": setting, "value": value}
 
     def matrix_basis(self):
         if self.sketch_i == -1:

--- a/model/diameter.py
+++ b/model/diameter.py
@@ -36,7 +36,10 @@ class SlvsDiameter(DimensionalConstraint, PropertyGroup):
             distance = self.value / 2
 
         if distance is not None:
-            self.value_store = distance
+            scene = getattr(self, "id_data", None)
+            uid = getattr(self, "constraint_uid", "")
+            if scene is not None and uid:
+                scene[f"slvs:c:{uid}"] = distance
 
     @property
     def label(self):
@@ -47,6 +50,7 @@ class SlvsDiameter(DimensionalConstraint, PropertyGroup):
         subtype="DISTANCE",
         unit="LENGTH",
         precision=6,
+        options={"HIDDEN"},
     )
     value: FloatProperty(
         name="Size",
@@ -90,8 +94,12 @@ class SlvsDiameter(DimensionalConstraint, PropertyGroup):
     def _get_init_value(self, setting):
         entity = self.entity1
         if entity is None:
-            if self.is_property_set("value_store"):
-                return self.value_store
+            scene = getattr(self, "id_data", None)
+            uid = getattr(self, "constraint_uid", "")
+            if scene is not None and uid:
+                key = f"slvs:c:{uid}"
+                if key in scene:
+                    return float(scene[key])
             return 0.0
         value = entity.radius
         if not setting:

--- a/model/distance.py
+++ b/model/distance.py
@@ -59,9 +59,14 @@ def _get_value(self):
     if self.is_reference:
         val = self.init_props(align=self.align)["value"]
         return self.to_displayed_value(val)
-    if not self.is_property_set("value_store"):
-        self.assign_init_props()
-    return self.to_displayed_value(self.value_store)
+    scene = getattr(self, "id_data", None)
+    uid = getattr(self, "constraint_uid", "")
+    if scene is not None and uid:
+        key = f"slvs:c:{uid}"
+        if key in scene:
+            return self.to_displayed_value(float(scene[key]))
+    val = self.init_props(align=self.align).get("value", 0.0)
+    return self.to_displayed_value(val)
 
 
 class SlvsDistance(DimensionalConstraint, PropertyGroup):
@@ -75,7 +80,10 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
         self.align_store = alignment
         if self.entity1 is None or self.entity2 is None:
             return
-        self.value_store = _get_aligned_distance(self.entity1, self.entity2, alignment)
+        scene = getattr(self, "id_data", None)
+        uid = getattr(self, "constraint_uid", "")
+        if scene is not None and uid:
+            scene[f"slvs:c:{uid}"] = _get_aligned_distance(self.entity1, self.entity2, alignment)
 
     def _get_align(self) -> int:
         if not self.is_property_set("align_store"):
@@ -88,6 +96,7 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
         subtype="DISTANCE",
         unit="LENGTH",
         precision=6,
+        options={"HIDDEN"},
     )
     align_store: EnumProperty(
         name="Align Storage",
@@ -328,8 +337,12 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
         e1, e2 = self.entity1, self.entity2
 
         if e1 is None or e2 is None:
-            if self.is_property_set("value_store"):
-                return self.value_store
+            scene = getattr(self, "id_data", None)
+            uid = getattr(self, "constraint_uid", "")
+            if scene is not None and uid:
+                key = f"slvs:c:{uid}"
+                if key in scene:
+                    return float(scene[key])
             return 0.0
 
         if e1.is_3d():

--- a/model/distance.py
+++ b/model/distance.py
@@ -69,6 +69,14 @@ def _get_value(self):
     return self.to_displayed_value(val)
 
 
+def _flip_update_cb(self, context):
+    update_system_cb(self, context)
+
+    from ..solver import solve_system
+
+    solve_system(context, sketch=self.sketch)
+
+
 class SlvsDistance(DimensionalConstraint, PropertyGroup):
     """Sets the distance between a point and some other entity (point/line/Workplane)."""
 
@@ -111,7 +119,7 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
         get=_get_value,
         set=DimensionalConstraint._set_value,
     )
-    flip: BoolProperty(name="Flip", update=update_system_cb)
+    flip: BoolProperty(name="Flip", update=_flip_update_cb)
     align: EnumProperty(
         name="Align",
         items=align_items,
@@ -336,7 +344,19 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
     def _get_init_value(self, alignment):
         e1, e2 = self.entity1, self.entity2
 
-        if e1 is None or e2 is None:
+        if e1 is None:
+            scene = getattr(self, "id_data", None)
+            uid = getattr(self, "constraint_uid", "")
+            if scene is not None and uid:
+                key = f"slvs:c:{uid}"
+                if key in scene:
+                    return float(scene[key])
+            return 0.0
+
+        if e2 is None:
+            if e1.is_line():
+                return _get_aligned_distance(e1.p1, e1.p2, alignment)
+
             scene = getattr(self, "id_data", None)
             uid = getattr(self, "constraint_uid", "")
             if scene is not None and uid:

--- a/model/distance.py
+++ b/model/distance.py
@@ -15,7 +15,7 @@ from ..utilities.math import range_2pi
 from .base_constraint import DimensionalConstraint
 from .utilities import slvs_entity_pointer
 from .categories import POINT, LINE, POINT2D, CURVE
-from ..utilities.solver import update_system_cb
+from ..utilities.solver import update_system_cb, constraint_value_update_cb
 from ..utilities.bpy import setprop, bpyEnum
 
 from .workplane import SlvsWorkplane
@@ -98,7 +98,7 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
         subtype="DISTANCE",
         unit="LENGTH",
         precision=6,
-        update=update_system_cb,
+        update=constraint_value_update_cb,
         get=_get_value,
         set=DimensionalConstraint._set_value,
     )

--- a/model/group_constraints.py
+++ b/model/group_constraints.py
@@ -96,7 +96,7 @@ class SlvsConstraints(PropertyGroup):
             scene = getattr(self, "id_data", None)
             if scene and hasattr(scene, "sketcher") and scene.sketcher:
                 try:
-                    scene.sketcher.get_or_create_constraint_value_endpoint(constr)
+                    scene.sketcher.create_constraint_value_endpoint(constr)
                 except (RuntimeError, AttributeError):
                     pass
         return constr
@@ -274,11 +274,12 @@ class SlvsConstraints(PropertyGroup):
             c.entity2_i = entity2 if isinstance(entity2, int) else entity2.slvs_index
         if sketch is not None:
             c.sketch_i = sketch if isinstance(sketch, int) else sketch.slvs_index
+        self._init_constraint(c)
         if init:
             c.assign_init_props(**settings)
         else:
             c.assign_settings(**settings)
-        return self._init_constraint(c)
+        return c
 
     def add_angle(
         self,
@@ -304,11 +305,12 @@ class SlvsConstraints(PropertyGroup):
         c.entity2_i = entity2 if isinstance(entity2, int) else entity2.slvs_index
         if sketch is not None:
             c.sketch_i = sketch if isinstance(sketch, int) else sketch.slvs_index
+        self._init_constraint(c)
         if init:
             c.assign_init_props(**settings)
         else:
             c.assign_settings(**settings)
-        return self._init_constraint(c)
+        return c
 
     def add_diameter(
         self,
@@ -331,11 +333,12 @@ class SlvsConstraints(PropertyGroup):
         c.entity1_i = entity1 if isinstance(entity1, int) else entity1.slvs_index
         if sketch:
             c.sketch_i = sketch if isinstance(sketch, int) else sketch.slvs_index
+        self._init_constraint(c)
         if init:
             c.assign_init_props(**settings)
         else:
             c.assign_settings(**settings)
-        return self._init_constraint(c)
+        return c
 
     def add_parallel(
         self,
@@ -499,11 +502,12 @@ class SlvsConstraints(PropertyGroup):
         c.entity2_i = entity2 if isinstance(entity2, int) else entity2.slvs_index
         if sketch is not None:
             c.sketch_i = sketch if isinstance(sketch, int) else sketch.slvs_index
+        self._init_constraint(c)
         if init:
             c.assign_init_props(**settings)
         else:
             c.assign_settings(**settings)
-        return self._init_constraint(c)
+        return c
 
     def add_symmetry(
         self,

--- a/model/group_constraints.py
+++ b/model/group_constraints.py
@@ -1,4 +1,5 @@
 import logging
+import secrets
 from typing import Union
 
 from bpy.types import PropertyGroup
@@ -74,6 +75,48 @@ class SlvsConstraints(PropertyGroup):
                 return constraint
         return None
 
+    def _new_constraint_uid(self) -> str:
+        return secrets.token_hex(8)
+
+    def _ensure_unique_uid(self, uid: str) -> str:
+        if uid and self.get_by_uid(uid):
+            uid = ""
+        while not uid:
+            candidate = self._new_constraint_uid()
+            if not self.get_by_uid(candidate):
+                uid = candidate
+        return uid
+
+    def _init_constraint(self, constr: GenericConstraint) -> GenericConstraint:
+        uid = getattr(constr, "constraint_uid", "")
+        if not uid:
+            uid = self._ensure_unique_uid(uid)
+            constr.constraint_uid = uid
+        if hasattr(constr, "value"):
+            scene = getattr(self, "id_data", None)
+            if scene and hasattr(scene, "sketcher") and scene.sketcher:
+                try:
+                    scene.sketcher.get_or_create_constraint_value_endpoint(constr)
+                except (RuntimeError, AttributeError):
+                    pass
+        return constr
+
+    def ensure_constraint_uid(self, constr: GenericConstraint) -> str:
+        uid = getattr(constr, "constraint_uid", "")
+        if uid:
+            return uid
+        uid = self._ensure_unique_uid(uid)
+        constr.constraint_uid = uid
+        return uid
+
+    def get_by_uid(self, uid: str) -> GenericConstraint:
+        if not uid:
+            return None
+        for constraint in self.all:
+            if getattr(constraint, "constraint_uid", "") == uid:
+                return constraint
+        return None
+
     def new_from_type(self, type: str) -> GenericConstraint:
         """Create a constraint by type.
 
@@ -82,7 +125,7 @@ class SlvsConstraints(PropertyGroup):
         """
         name = type.lower()
         constraint_list = getattr(self, name)
-        return constraint_list.add()
+        return self._init_constraint(constraint_list.add())
 
     def get_lists(self):
         lists = []
@@ -132,6 +175,11 @@ class SlvsConstraints(PropertyGroup):
         Arguments:
             constr: Constraint to be removed.
         """
+        uid = getattr(constr, "constraint_uid", "")
+        if uid:
+            scene = getattr(self, "id_data", None)
+            if scene and hasattr(scene, "sketcher"):
+                scene.sketcher.remove_constraint_value_endpoint(uid)
         i = self.get_index(constr)
         self.get_list(constr.type).remove(i)
 
@@ -175,7 +223,7 @@ class SlvsConstraints(PropertyGroup):
         c.entity2_i = entity2 if isinstance(entity2, int) else entity2.slvs_index
         if sketch:
             c.sketch_i = sketch if isinstance(sketch, int) else sketch.slvs_index
-        return c
+        return self._init_constraint(c)
 
     def add_equal(
         self,
@@ -198,7 +246,7 @@ class SlvsConstraints(PropertyGroup):
         c.entity2_i = entity2 if isinstance(entity2, int) else entity2.slvs_index
         if sketch is not None:
             c.sketch_i = sketch if isinstance(sketch, int) else sketch.slvs_index
-        return c
+        return self._init_constraint(c)
 
     def add_distance(
         self,
@@ -230,7 +278,7 @@ class SlvsConstraints(PropertyGroup):
             c.assign_init_props(**settings)
         else:
             c.assign_settings(**settings)
-        return c
+        return self._init_constraint(c)
 
     def add_angle(
         self,
@@ -260,7 +308,7 @@ class SlvsConstraints(PropertyGroup):
             c.assign_init_props(**settings)
         else:
             c.assign_settings(**settings)
-        return c
+        return self._init_constraint(c)
 
     def add_diameter(
         self,
@@ -287,7 +335,7 @@ class SlvsConstraints(PropertyGroup):
             c.assign_init_props(**settings)
         else:
             c.assign_settings(**settings)
-        return c
+        return self._init_constraint(c)
 
     def add_parallel(
         self,
@@ -310,7 +358,7 @@ class SlvsConstraints(PropertyGroup):
         c.entity2_i = entity2 if isinstance(entity2, int) else entity2.slvs_index
         if sketch is not None:
             c.sketch_i = sketch if isinstance(sketch, int) else sketch.slvs_index
-        return c
+        return self._init_constraint(c)
 
     def add_horizontal(
         self,
@@ -333,7 +381,7 @@ class SlvsConstraints(PropertyGroup):
             c.entity2_i = entity2 if isinstance(entity2, int) else entity2.slvs_index
         if sketch is not None:
             c.sketch_i = sketch if isinstance(sketch, int) else sketch.slvs_index
-        return c
+        return self._init_constraint(c)
 
     def add_vertical(
         self,
@@ -356,7 +404,7 @@ class SlvsConstraints(PropertyGroup):
             c.entity2_i = entity2 if isinstance(entity2, int) else entity2.slvs_index
         if sketch is not None:
             c.sketch_i = sketch if isinstance(sketch, int) else sketch.slvs_index
-        return c
+        return self._init_constraint(c)
 
     def add_tangent(
         self,
@@ -379,7 +427,7 @@ class SlvsConstraints(PropertyGroup):
         c.entity2_i = entity2 if isinstance(entity2, int) else entity2.slvs_index
         if sketch is not None:
             c.sketch_i = sketch if isinstance(sketch, int) else sketch.slvs_index
-        return c
+        return self._init_constraint(c)
 
     def add_midpoint(
         self,
@@ -402,7 +450,7 @@ class SlvsConstraints(PropertyGroup):
         c.entity2_i = entity2 if isinstance(entity2, int) else entity2.slvs_index
         if sketch is not None:
             c.sketch_i = sketch if isinstance(sketch, int) else sketch.slvs_index
-        return c
+        return self._init_constraint(c)
 
     def add_perpendicular(
         self,
@@ -425,7 +473,7 @@ class SlvsConstraints(PropertyGroup):
         c.entity2_i = entity2 if isinstance(entity2, int) else entity2.slvs_index
         if sketch is not None:
             c.sketch_i = sketch if isinstance(sketch, int) else sketch.slvs_index
-        return c
+        return self._init_constraint(c)
 
     def add_ratio(
         self,
@@ -455,7 +503,7 @@ class SlvsConstraints(PropertyGroup):
             c.assign_init_props(**settings)
         else:
             c.assign_settings(**settings)
-        return c
+        return self._init_constraint(c)
 
     def add_symmetry(
         self,
@@ -481,7 +529,7 @@ class SlvsConstraints(PropertyGroup):
         c.entity3_i = entity3 if isinstance(entity3, int) else entity3.slvs_index
         if sketch is not None:
             c.sketch_i = sketch if isinstance(sketch, int) else sketch.slvs_index
-        return c
+        return self._init_constraint(c)
 
 
 register, unregister = register_classes_factory((SlvsConstraints,))

--- a/model/group_sketcher.py
+++ b/model/group_sketcher.py
@@ -16,6 +16,9 @@ from ..utilities.view import update_cb
 
 logger = logging.getLogger(__name__)
 
+# Prefix for all constraint driver target custom properties on the scene.
+_EP_PREFIX = "slvs:c:"
+
 
 class SketcherProps(PropertyGroup):
     """The base structure for CAD Sketcher"""
@@ -62,6 +65,67 @@ class SketcherProps(PropertyGroup):
 
     def solve(self, context: Context):
         return solve_system(context)
+
+    def get_or_create_constraint_value_endpoint(self, constraint):
+        """Create (or return the key of) a scene custom property that serves as
+        a stable driver target for the constraint's value.
+
+        The RNA path ``bpy.data.scenes["Scene"]["slvs:c:<uid>"]`` is keyed by
+        the UID string, so it is unaffected by collection compaction.
+        """
+        uid = getattr(constraint, "constraint_uid", "")
+        if not uid:
+            return None
+        scene = self.id_data
+        key = f"{_EP_PREFIX}{uid}"
+        if key not in scene:
+            try:
+                init_value = float(constraint.value) if hasattr(constraint, "value") else 0.0
+            except Exception:
+                init_value = 0.0
+            scene[key] = init_value
+            try:
+                rna_prop = type(constraint).bl_rna.properties.get("value_store")
+                subtype = rna_prop.subtype if rna_prop else "NONE"
+                scene.id_properties_ui(key).update(subtype=subtype, min=0.0, soft_min=0.0)
+            except Exception:
+                pass
+        return key
+
+    def remove_constraint_value_endpoint(self, constraint_uid: str):
+        """Delete the scene custom property for a constraint that is being removed."""
+        if not constraint_uid:
+            return
+        scene = self.id_data
+        key = f"{_EP_PREFIX}{constraint_uid}"
+        if key in scene:
+            del scene[key]
+
+    def apply_constraint_value_endpoints(self, tolerance: float = 1e-9) -> bool:
+        """Read scene custom-property driver targets and apply changed values
+        into the actual constraints.  Returns True if any value changed so the
+        caller can schedule a solve pass.
+        """
+        changed = False
+        scene = self.id_data
+        for constraint in self.constraints.dimensional:
+            uid = getattr(constraint, "constraint_uid", "")
+            if not uid:
+                continue
+            key = f"{_EP_PREFIX}{uid}"
+            if key not in scene:
+                continue
+            ep_value = float(scene[key])
+            if abs(ep_value - constraint.value) <= tolerance:
+                continue
+            constraint._set_value_force(
+                constraint.from_displayed_value(ep_value)
+            )
+            sketch = getattr(constraint, "sketch", None)
+            if sketch:
+                sketch.geometry_solved = False
+            changed = True
+        return changed
 
     def purge_stale_data(self):
         global_data.hover = -1

--- a/model/group_sketcher.py
+++ b/model/group_sketcher.py
@@ -66,23 +66,21 @@ class SketcherProps(PropertyGroup):
     def solve(self, context: Context):
         return solve_system(context)
 
-    def get_or_create_constraint_value_endpoint(self, constraint):
-        """Create (or return the key of) a scene custom property that serves as
-        a stable driver target for the constraint's value.
-
-        The RNA path ``bpy.data.scenes["Scene"]["slvs:c:<uid>"]`` is keyed by
-        the UID string, so it is unaffected by collection compaction.
-        """
+    def create_constraint_value_endpoint(self, constraint) -> str | None:
         uid = getattr(constraint, "constraint_uid", "")
         if not uid:
             return None
         scene = self.id_data
         key = f"{_EP_PREFIX}{uid}"
         if key not in scene:
-            try:
-                init_value = float(constraint.value) if hasattr(constraint, "value") else 0.0
-            except Exception:
+            if (
+                hasattr(constraint, "value_store")
+                and constraint.is_property_set("value_store")
+            ):
+                init_value = float(constraint.value_store)
+            else:
                 init_value = 0.0
+
             scene[key] = init_value
             try:
                 rna_prop = type(constraint).bl_rna.properties.get("value_store")
@@ -92,6 +90,14 @@ class SketcherProps(PropertyGroup):
                 pass
         return key
 
+    def get_constraint_value_endpoint(self, constraint) -> str | None:
+        uid = getattr(constraint, "constraint_uid", "")
+        if not uid:
+            return None
+        key = f"{_EP_PREFIX}{uid}"
+        scene = self.id_data
+        return key if key in scene else None
+
     def remove_constraint_value_endpoint(self, constraint_uid: str):
         """Delete the scene custom property for a constraint that is being removed."""
         if not constraint_uid:
@@ -100,32 +106,6 @@ class SketcherProps(PropertyGroup):
         key = f"{_EP_PREFIX}{constraint_uid}"
         if key in scene:
             del scene[key]
-
-    def apply_constraint_value_endpoints(self, tolerance: float = 1e-9) -> bool:
-        """Read scene custom-property driver targets and apply changed values
-        into the actual constraints.  Returns True if any value changed so the
-        caller can schedule a solve pass.
-        """
-        changed = False
-        scene = self.id_data
-        for constraint in self.constraints.dimensional:
-            uid = getattr(constraint, "constraint_uid", "")
-            if not uid:
-                continue
-            key = f"{_EP_PREFIX}{uid}"
-            if key not in scene:
-                continue
-            ep_value = float(scene[key])
-            if abs(ep_value - constraint.value) <= tolerance:
-                continue
-            constraint._set_value_force(
-                constraint.from_displayed_value(ep_value)
-            )
-            sketch = getattr(constraint, "sketch", None)
-            if sketch:
-                sketch.geometry_solved = False
-            changed = True
-        return changed
 
     def purge_stale_data(self):
         global_data.hover = -1

--- a/operators/update.py
+++ b/operators/update.py
@@ -11,6 +11,7 @@ class VIEW3D_OT_update(Operator):
     bl_label = "Update"
 
     def execute(self, context):
+        context.scene.sketcher.apply_constraint_value_endpoints()
         solver = Solver(context, None, all=True)
         solver.solve()
         update_convertor_geometry(context.scene)

--- a/operators/update.py
+++ b/operators/update.py
@@ -11,7 +11,6 @@ class VIEW3D_OT_update(Operator):
     bl_label = "Update"
 
     def execute(self, context):
-        context.scene.sketcher.apply_constraint_value_endpoints()
         solver = Solver(context, None, all=True)
         solver.solve()
         update_convertor_geometry(context.scene)

--- a/testing/test_constraint_init.py
+++ b/testing/test_constraint_init.py
@@ -123,7 +123,6 @@ class TestConstraintInit(Sketch2dTestCase):
         self.assertAlmostEqual(float(self.scene[key]), 3.5)
 
         self.scene[key] = 4.5
-        self.sketcher.apply_constraint_value_endpoints()
         self.assertAlmostEqual(c.value, 4.5)
 
     def test_endpoint_removed_on_delete(self):

--- a/testing/test_constraint_init.py
+++ b/testing/test_constraint_init.py
@@ -103,6 +103,42 @@ class TestConstraintInit(Sketch2dTestCase):
         # self.solve()
         # self.assertAlmostEqual(c3.value, 2.0)
 
+    def test_endpoint_has_stable_name(self):
+        p0 = self.entities.add_point_2d((0, 0), self.sketch, fixed=True)
+        p1 = self.entities.add_point_2d((2, 0), self.sketch)
+        c = self.constraints.add_distance(p0, p1, sketch=self.sketch, init=True)
+        uid = c.constraint_uid
+        self.assertTrue(uid, "constraint_uid must be assigned at creation")
+        key = f"slvs:c:{uid}"
+        self.assertIn(key, self.scene, "endpoint must exist as a scene custom property")
+
+    def test_endpoint_stays_in_sync(self):
+        p0 = self.entities.add_point_2d((0, 0), self.sketch, fixed=True)
+        p1 = self.entities.add_point_2d((2, 0), self.sketch)
+        c = self.constraints.add_distance(p0, p1, sketch=self.sketch, init=True)
+        key = f"slvs:c:{c.constraint_uid}"
+        self.assertIn(key, self.scene)
+
+        c.value = 3.5
+        self.assertAlmostEqual(float(self.scene[key]), 3.5)
+
+        self.scene[key] = 4.5
+        self.sketcher.apply_constraint_value_endpoints()
+        self.assertAlmostEqual(c.value, 4.5)
+
+    def test_endpoint_removed_on_delete(self):
+        p0 = self.entities.add_point_2d((0, 0), self.sketch, fixed=True)
+        p1 = self.entities.add_point_2d((2, 0), self.sketch)
+        c = self.constraints.add_distance(p0, p1, sketch=self.sketch, init=True)
+        uid = c.constraint_uid
+        self.assertIn(f"slvs:c:{uid}", self.scene)
+        self.constraints.remove(c)
+        self.assertNotIn(
+            f"slvs:c:{uid}",
+            self.scene,
+            "endpoint must be removed when its constraint is deleted",
+        )
+
     def test_distance_flip(self):
         context = self.context
         entities = self.entities

--- a/ui/panels/constraints_list.py
+++ b/ui/panels/constraints_list.py
@@ -41,7 +41,7 @@ def draw_constraint_listitem(
             uid = getattr(constraint, "constraint_uid", "")
             key = None
             if uid:
-                key = context.scene.sketcher.get_or_create_constraint_value_endpoint(
+                key = context.scene.sketcher.get_constraint_value_endpoint(
                     constraint
                 )
             if key:

--- a/ui/panels/constraints_list.py
+++ b/ui/panels/constraints_list.py
@@ -37,6 +37,16 @@ def draw_constraint_listitem(
     middle_sub = row.row()
 
     for constraint_prop in constraint.props:
+        if constraint_prop == "value":
+            uid = getattr(constraint, "constraint_uid", "")
+            key = None
+            if uid:
+                key = context.scene.sketcher.get_or_create_constraint_value_endpoint(
+                    constraint
+                )
+            if key:
+                middle_sub.prop(context.scene, f'["{key}"]', text="")
+                continue
         middle_sub.prop(constraint, constraint_prop, text="")
 
     # Context menu, shows constraint name

--- a/utilities/solver.py
+++ b/utilities/solver.py
@@ -6,3 +6,15 @@ from .. import global_data
 def update_system_cb(self, context: Context):
     """Mark that the solver needs to run, deferred to depsgraph_update_post."""
     global_data.needs_solve = True
+
+
+def constraint_value_update_cb(self, context: Context):
+    """Mark that the solver needs to run and sync the stable driver endpoint."""
+    global_data.needs_solve = True
+    scene = getattr(self, "id_data", None)
+    if not scene:
+        return
+    key = scene.sketcher.get_or_create_constraint_value_endpoint(self)
+    if not key:
+        return
+    scene[key] = self.value

--- a/utilities/solver.py
+++ b/utilities/solver.py
@@ -9,12 +9,5 @@ def update_system_cb(self, context: Context):
 
 
 def constraint_value_update_cb(self, context: Context):
-    """Mark that the solver needs to run and sync the stable driver endpoint."""
+    """Mark that the solver needs to run when a constraint value changes."""
     global_data.needs_solve = True
-    scene = getattr(self, "id_data", None)
-    if not scene:
-        return
-    key = scene.sketcher.get_or_create_constraint_value_endpoint(self)
-    if not key:
-        return
-    scene[key] = self.value

--- a/versioning.py
+++ b/versioning.py
@@ -129,6 +129,6 @@ def do_versioning(self):
             constraints = scene.sketcher.constraints
             for c in list(constraints.dimensional):
                 constraints.ensure_constraint_uid(c)
-                scene.sketcher.get_or_create_constraint_value_endpoint(c)
+                scene.sketcher.create_constraint_value_endpoint(c)
 
     logger.debug(msg)

--- a/versioning.py
+++ b/versioning.py
@@ -125,4 +125,10 @@ def do_versioning(self):
                     setattr(c, "entity1", line_dependencies[0])
                     setattr(c, "entity2", line_dependencies[1])
 
+        if version < (0, 27, 7):
+            constraints = scene.sketcher.constraints
+            for c in list(constraints.dimensional):
+                constraints.ensure_constraint_uid(c)
+                scene.sketcher.get_or_create_constraint_value_endpoint(c)
+
     logger.debug(msg)


### PR DESCRIPTION
@hlorus 
I was looking to https://github.com/hlorus/CAD_Sketcher/issues/544 and found that a way to solve it is to remap indexes when delete is being done, however there might be other situations in which the items in the list are reordered and remapping would be required.
Please take a look to the attached file with a proposal to move from index to UID for both entities (which I think will suffer a similar problem although smaller as there is slvs_index) and constraints to make sure referencing them is stable regardless of the ordering.
Is this something worth doing? 
I am proposing here without showing any code yet as it looks to me this will have to touch quite a bit of code and woudl like to knwo if this is somthign that wants to be impolemented at all first :)

Cheers!
