### PR TITLE
Fix initialization constraint value from old versions of files

### DIFF
--- a/model/group_sketcher.py
+++ b/model/group_sketcher.py
@@ -78,6 +78,8 @@ class SketcherProps(PropertyGroup):
                 and constraint.is_property_set("value_store")
             ):
                 init_value = float(constraint.value_store)
+            elif hasattr(constraint, "value") and constraint.is_property_set("value"):
+                init_value = float(constraint.value)
             else:
                 init_value = 0.0
 


### PR DESCRIPTION
There was a bug in the previous PR for UUID use in constraints. Some older file are using the the attribute "value" to hold the constraint value instead of "value_store". 
Added a condition to check for "value" attribute before defaultign to 0.0 to capture those cases.

This fixes https://github.com/hlorus/CAD_Sketcher/issues/561

Cheers!
