### PR TITLE
Require Blender 5.0 minimum and add version-matrix CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,15 +5,44 @@ on:
     branches: [main]
 
 jobs:
+  versions:
+    # Derive the Blender versions to test from the manifest so the minimal
+    # supported version stays the single source of truth (no CI drift).
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.detect.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: detect
+        name: Detect Blender versions to test
+        run: |
+          # Minimal supported version, read from blender_manifest.toml.
+          # Strip the patch component: "4.3.0" -> "4.3" so setup-blender
+          # resolves it to the latest available 4.3.x.
+          min=$(grep -oP 'blender_version_min\s*=\s*"\K[0-9]+\.[0-9]+' blender_manifest.toml)
+          if [ -z "$min" ]; then
+            echo "::error::Could not parse blender_version_min from blender_manifest.toml" >&2
+            exit 1
+          fi
+          # Current stable release we actively develop against.
+          stable="4.5"
+          # De-duplicated JSON array (minimal version first).
+          if [ "$min" = "$stable" ]; then
+            matrix="[\"$min\"]"
+          else
+            matrix="[\"$min\", \"$stable\"]"
+          fi
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "Testing Blender versions: $matrix"
+
   test-extension:
+    needs: versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        # "4.3" is blender_version_min from blender_manifest.toml — the minimal
-        # supported version. "4.5" is the current stable release we develop
-        # against. Keep "4.3" in sync with blender_version_min.
-        blender-version: ["4.3", "4.5"]
+        blender-version: ${{ fromJSON(needs.versions.outputs.matrix) }}
     name: test-extension (blender ${{ matrix.blender-version }})
     steps:
       - uses: moguri/setup-blender@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,10 +7,18 @@ on:
 jobs:
   test-extension:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # "4.3" is blender_version_min from blender_manifest.toml — the minimal
+        # supported version. "4.5" is the current stable release we develop
+        # against. Keep "4.3" in sync with blender_version_min.
+        blender-version: ["4.3", "4.5"]
+    name: test-extension (blender ${{ matrix.blender-version }})
     steps:
       - uses: moguri/setup-blender@v1
         with:
-          blender-version: "4.5"
+          blender-version: ${{ matrix.blender-version }}
 
       - run: blender --version
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,22 +17,18 @@ jobs:
       - id: detect
         name: Detect Blender versions to test
         run: |
-          # Minimal supported version, read from blender_manifest.toml.
-          # Strip the patch component: "4.3.0" -> "4.3" so setup-blender
-          # resolves it to the latest available 4.3.x.
+          # Lower bound: minimal supported version, read from
+          # blender_manifest.toml. Strip the patch component ("4.3.0" -> "4.3")
+          # so setup-blender resolves it to the newest available 4.3.x.
           min=$(grep -oP 'blender_version_min\s*=\s*"\K[0-9]+\.[0-9]+' blender_manifest.toml)
           if [ -z "$min" ]; then
             echo "::error::Could not parse blender_version_min from blender_manifest.toml" >&2
             exit 1
           fi
-          # Current stable release we actively develop against.
-          stable="4.5"
-          # De-duplicated JSON array (minimal version first).
-          if [ "$min" = "$stable" ]; then
-            matrix="[\"$min\"]"
-          else
-            matrix="[\"$min\", \"$stable\"]"
-          fi
+          # Upper bound: the literal "latest", which setup-blender resolves to
+          # the newest non-beta release on the Blender mirror at install time.
+          # Nothing is hardcoded — min tracks the manifest, max tracks releases.
+          matrix="[\"$min\", \"latest\"]"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           echo "Testing Blender versions: $matrix"
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Constraint-based sketcher extension for [Blender](https://www.blender.org/) that
 
 > :warning: **Experimental extension:** This is still work in progress, don't use it on production files without a backup.
 
-Minimum version: Blender 4.2
+Minimum version: Blender 5.0
 
 ## More than just an extension learn more: [CADsketcher.com](http://cadsketcher.com/)
 

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -8,7 +8,7 @@ maintainer = "hlorus <dave19924@gmail.com>"
 type = "add-on"
 website = "https://www.cadsketcher.com/"
 tags = ["3D View", "Modeling", "Mesh", "Object"]
-blender_version_min = "4.3.0"
+blender_version_min = "5.0.0"
 license = ["SPDX:GPL-3.0-or-later"]
 
 wheels = [

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -46,11 +46,11 @@
 ## Dependency installation
 CAD Sketcher heavily depends on the [solvespace python module](https://pypi.org/project/slvs/) and won't be functional without it. When installed as an Extension the module ships bundled as a wheel, so there's usually nothing to do here.
 
-> **Python version compatibility:** the bundled solver provides wheels for Python **3.11, 3.12 and 3.13** — the versions embedded in official [blender.org](https://www.blender.org/download/) builds. If Blender reports something like *"This Python version (3.14) isn't compatible with (3.11)"* on install, it's running a **newer system Python** (common with distribution-packaged Blender on rolling distros such as Arch/CachyOS). Fix it by using an official build from [blender.org](https://www.blender.org/download/) — the **4.5 LTS** is a safe choice — instead of your distribution's package. Python 3.14 is not yet supported (waiting on an upstream `slvs` release).
+> **Python version compatibility:** the bundled solver provides wheels for Python **3.11, 3.12 and 3.13** — the versions embedded in official [blender.org](https://www.blender.org/download/) builds. If Blender reports something like *"This Python version (3.14) isn't compatible with (3.11)"* on install, it's running a **newer system Python** (common with distribution-packaged Blender on rolling distros such as Arch/CachyOS). Fix it by using an official build from [blender.org](https://www.blender.org/download/) — the **5.2 LTS** is a safe choice — instead of your distribution's package. Python 3.14 is not yet supported (waiting on an upstream `slvs` release).
 
 Once the 3D View CAD Sketcher plugin is installed check its preferences for the "Solver Module" tab to see if the module is already available, otherwise follow one of the guides below.
 
-=== "Blender 4.2 Extension"
+=== "Blender 5.0 Extension"
     - If you install CAD Sketcher as a Blender Extension you can skip this step
 
 === "Install from PIP"


### PR DESCRIPTION
## What

Raises the **minimum supported Blender version to 5.0**, and converts the `test-extension` job into a matrix that runs against the minimal supported version *and* the newest release — with neither version hardcoded in the workflow.

## Why the bump is needed

The 0.3.0 native-curves refactor (#559) makes Blender's new `Curves` object the source of truth for sketch geometry. Building that geometry uses `Curves` Python API that **does not exist before Blender 5.0** — in particular `Curves.set_types()` (plus editable Bezier curves/handles on the new Curves object). On 4.x the sketch geometry fails to build at all:

```
File "model/curve_ref.py", line 518, in create
AttributeError: 'Curves' object has no attribute 'set_types'
```

So on Blender &lt; 5 **no solid is ever generated** — exactly the behaviour reported in #564.

The manifest previously declared `blender_version_min = "4.3.0"`, a value carried over *inside* the #559 refactor commit that was never valid for the new data model (the README even still advertised 4.2). This PR sets it to `5.0.0` so unsupported versions get a clean install-time block instead of a silently broken sketch, and updates the README / installation docs to match.

## CI matrix

- A `versions` job derives the test matrix:
  - **Lower bound** — `blender_version_min` parsed from `blender_manifest.toml` (single source of truth; now `5.0`).
  - **Upper bound** — the literal `"latest"`, which `moguri/setup-blender` resolves to the newest non-beta Blender release at install time.
- `fail-fast: false` so a failure on one version doesn't cancel the other; each version appears as its own check.

Bumping the manifest moves the low end; a new Blender release moves the high end — no workflow edits needed either way.

> **Note:** a separate Blender 5.2 change to Geometry-Nodes modifier-input access (`mod["Input_2"] = …` → `TypeError: id properties not supported for this type`) previously failed the `latest` job. That fix landed on `main` independently — inputs are now set via `mod.properties.inputs.<id>.value` on 5.2 — so it is *not* part of this PR's diff, and both matrix jobs (`5.0` and `latest`/5.2) are green.

