### PR TITLE
Docs: auto-constraints, driven dimensions, and keymap reference

### DIFF
--- a/docs/content/constraints.md
+++ b/docs/content/constraints.md
@@ -43,3 +43,17 @@ will be colored red, additionally the failed sketch will be marked.
 ::: CAD_Sketcher.model.types.SlvsDiameter
 
 ::: CAD_Sketcher.model.types.SlvsAngle
+
+## Driven & Animated Dimensions
+The value of a dimensional constraint (distance, diameter or angle) is stored as
+a regular scene property and shown as an editable field in the **Constraints**
+panel. Because it's an ordinary Blender property you can **right-click it** and
+**Add Driver** or **Insert Keyframe**, just like any other value.
+
+The sketch re-solves whenever the value changes — including on frame changes — so
+the geometry follows a driven or animated dimension across the timeline. This
+lets you, for example, drive one dimension from another property or animate a
+dimension to create parametric motion.
+
+> Reference dimensions (measurements) only report the current value and can't be
+> driven or keyframed.

--- a/docs/content/interaction_system.md
+++ b/docs/content/interaction_system.md
@@ -85,3 +85,20 @@ Hold **Shift** while placing or tweaking a point to temporarily bypass snapping.
 > Face-center snapping to a shape built from several separate lines (rather than
 > one closed curve) is not supported — that region only exists in the generated
 > mesh, which can't be inspected while sketching.
+
+## Auto Constraints
+
+While drawing geometry the extension can infer and add obvious constraints for
+you automatically, so you don't have to place them by hand:
+
+- **Auto axis alignment** — a segment drawn close to horizontal or vertical gets
+  a **Horizontal** / **Vertical** constraint.
+- **Auto coincident** — a new point placed on an existing point gets a
+  **Coincident** constraint.
+
+This is controlled by the **Auto Constraints** toggle in the tool settings bar
+(top of the viewport) of the sketch tools — *Add Line*, *Rectangle*, *Circle*,
+*Arc* and *Point*. It's enabled by default.
+
+Hold **Shift** while placing or confirming a point to skip the auto constraints
+for that step only, without having to change the toggle.

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -26,14 +26,16 @@ Whenever one of the extension's tools is active the tool access keymap allows to
 
 |Key|Modifier|Action|
 |:---:|---|---|
-|ESC|-   |Activate Tool: Select|
+|Esc / Rmb|-   |Activate Tool: Select|
 |P|-   |Invoke Tool: Add Point 2D|
 |L|-   |Invoke Tool: Add Line 2D|
 |C|-   |Invoke Tool: Add Circle|
 |A|-   |Invoke Tool: Add Arc|
 |R|-   |Invoke Tool: Add Rectangle|
-|S|-   |Invoke Tool: Add Sketch|
 |Y|-   |Invoke Tool: Trim|
+|B|-   |Invoke Tool: Bevel|
+|O|-   |Invoke Tool: Offset|
+|S|-   |Invoke Tool: Add Sketch|
 
 **Dimensional Constraints:**
 
@@ -54,11 +56,35 @@ Whenever one of the extension's tools is active the tool access keymap allows to
 |V|Shift   |Vertical|
 |H|Shift   |Horizontal|
 |E|Shift   |Equal|
-|P|Shift   |Parallel|
-|N|Shift   |Perpendicular|
+|A|Shift   |Parallel|
+|P|Shift   |Perpendicular|
 |T|Shift   |Tangent|
 |M|Shift   |Midpoint|
 |R|Shift   |Ratio|
+
+### Editing Keymap
+Available while any of the extension's tools is active.
+
+|Key|Modifier|Action|
+|:---:|---|---|
+|X / Del|-|Delete selected entities|
+|C|Ctrl|Copy|
+|V|Ctrl|Paste|
+|D|Shift|Duplicate & move|
+|G|-|Move|
+|V|-|Align view to the active entity|
+|M|Alt|Merge points|
+|C|Alt+Shift|Toggle construction mode|
+
+### Global Shortcuts
+Available in Object Mode regardless of the active tool.
+
+|Key|Modifier|Action|
+|:---:|---|---|
+|A|Ctrl+Shift|Add sketch / leave the active sketch|
+|E|Ctrl+Shift|Extrude the active sketch|
+|D|Ctrl+Shift|Linear array of the active sketch|
+|Esc|Shift|Switch to Blender's Select tool|
 
 ### Basic Tool Keymap
 The basic tool interaction is consistent between tools.
@@ -93,11 +119,18 @@ The basic tool interaction is consistent between tools.
 
 |Key|Modifier|Action|
 |---|---|---|
-|LMB|-   |Toggle Select|
-|ESC|-   |Deselect All|
-|I|Ctrl |Inverse selection|
+|LMB (click)|-   |Toggle select|
+|LMB (click)|Shift|Extend selection|
+|LMB (click)|Ctrl|Subtract from selection|
+|LMB (drag)|-|Box select, or tweak the hovered entity|
+|LMB (drag)|Shift|Box select (extend)|
+|LMB (drag)|Ctrl|Box select (subtract)|
+|A|Ctrl|Select all|
+|Esc|-   |Deselect all|
+|I|Ctrl |Invert selection|
 |E|Ctrl |Extend selection in chain|
 |E|Ctrl+Shift   |Select full chain|
+|Rmb|-|Open the context menu|
 
 > **INFO:** LMB in empty space will also deselect all.
 


### PR DESCRIPTION
Documentation-only updates for recently added features and the keyboard shortcut reference.

## Auto Constraints (`interaction_system.md`)
New section covering the **Auto Constraints** toggle (auto axis-alignment + auto coincident) shown in the sketch tools' settings bar, and the **Shift** per-step bypass.

## Driven & Animated Dimensions (`constraints.md`)
New section explaining that dimension values are ordinary scene properties — right-click to **Add Driver** / **Insert Keyframe** — and that the sketch re-solves on value/frame changes so geometry follows animated dimensions.

## Keyboard shortcut reference (`tools.md`)
Corrected and completed the keymap tables to match `keymaps.py`:
- Fixed wrong bindings: **Parallel = Shift+A**, **Perpendicular = Shift+P** (was Shift+P / Shift+N).
- Added tools **B** (Bevel) and **O** (Offset).
- New **Editing** table (delete, copy/paste, duplicate, move, align-view, merge, construction toggle).
- New **Global Shortcuts** table (add/leave sketch, extrude, linear array, back-to-select).
- Expanded the **Selection** table (click modifiers, box-select, tweak, select-all, context menu).