### PR TITLE
Fix Equal constraint (does nothing + line/circle crash)

### DIFF
--- a/model/equal.py
+++ b/model/equal.py
@@ -29,6 +29,9 @@ class SlvsEqual(GenericConstraint, PropertyGroup):
     label = "Equal"
     signature = (line_arc_circle, line_arc_circle)
 
+    curve_id_1: StringProperty(name="Curve ID 1", default="")
+    curve_id_2: StringProperty(name="Curve ID 2", default="")
+
     @classmethod
     def get_types(cls, index, entities):
         e = entities[1] if index == 0 else entities[0]
@@ -40,10 +43,28 @@ class SlvsEqual(GenericConstraint, PropertyGroup):
             return cls.signature[index]
         return cls.signature[index]
 
+    @staticmethod
+    def _compatible(r1, r2):
+        """A line's length can't be equal to a circle's radius.
+
+        solvespace supports line=line, line=arc (length), and
+        arc/circle=arc/circle (radius), but has no line-vs-circle equality --
+        passing that pair crashes the solver, so reject it here.
+        """
+        if not r1 or not r2:
+            return True
+        return not (
+            (r1.is_line() and r2.is_circle())
+            or (r1.is_circle() and r2.is_line())
+        )
+
     def create_slvs_data_from_curves(self, solvesys, handle_map, wp, group):
         h1 = handle_map.get(self.curve_id_1)
         h2 = handle_map.get(self.curve_id_2)
         if h1 is None or h2 is None:
+            return None
+        if not self._compatible(self.ref(1), self.ref(2)):
+            self.failed = True
             return None
         kwargs = {}
         if wp:

--- a/operators/add_geometric_constraints.py
+++ b/operators/add_geometric_constraints.py
@@ -174,7 +174,6 @@ class VIEW3D_OT_slvs_add_equal(Operator, GenericConstraintOp):
     def main(self, context):
         if not self.exists(context, SlvsEqual):
             self.target = self.sketch.constraints.add_equal(
-                
                 curve_id_1=self.entity1.curve_id,
                 curve_id_2=self.entity2.curve_id,
             )

--- a/stateful_operator/integration.py
+++ b/stateful_operator/integration.py
@@ -241,7 +241,13 @@ class StatefulOperator(StatefulOperatorLogic):
         result = None
         if index is None:
             index = self.state_index
-        state = self.get_states_definition()[index]
+        # Use the operator-aware state list so per-state ``get_types`` narrowing
+        # (e.g. an EQUAL slot restricted once the other slot is picked) applies
+        # during selection prefill, exactly as it does for interactive picking.
+        # ``get_states_definition()`` builds states with ``operator=None`` and
+        # therefore skips that narrowing, which would let an incompatible
+        # preselection through.
+        state = self.get_states()[index]
         data = self.get_state_data(index)
 
         if state.pointer:

--- a/testing/test_equal.py
+++ b/testing/test_equal.py
@@ -1,0 +1,92 @@
+from .utils import Sketch2dTestCase, OpHarness
+from ..drawing import selection
+
+
+class TestEqual(Sketch2dTestCase):
+    def test_equal_lines(self):
+        sc = self.sketch.constraints
+
+        p0 = self.add_point((0, 0), fixed=True)
+
+        # Line 1: fixed length 3
+        p1 = self.add_point((3, 0), fixed=True)
+        line1 = self.add_line(p0, p1)
+
+        # Line 2: free endpoint, initial length 1
+        p2 = self.add_point((0, 1))
+        line2 = self.add_line(p0, p2)
+
+        sc.add_equal(curve_id_1=line1.curve_id, curve_id_2=line2.curve_id)
+        self.solve()
+
+        self.assertAlmostEqual(line2.length, 3.0)
+
+    def test_equal_circles(self):
+        sc = self.sketch.constraints
+
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((5, 0), fixed=True)
+
+        c1 = self.add_circle(p0, 2.0)
+        sc.add_diameter(curve_id_1=c1.curve_id, init=True, value=4.0)
+
+        c2 = self.add_circle(p1, 1.0)
+
+        sc.add_equal(curve_id_1=c1.curve_id, curve_id_2=c2.curve_id)
+        self.solve()
+
+        self.assertAlmostEqual(c2.radius, 2.0)
+
+    # -- preselect a circle + a line, invoke equal (issue #569 follow-up) -----
+    def test_equal_prefill_rejects_circle_and_line(self):
+        """Selection prefill must apply the same type narrowing as picking.
+
+        A circle and a line can't be made equal (length vs radius). The first
+        slot takes the circle; the second must then reject the line instead of
+        filling both slots (which used to feed an invalid pair to the solver
+        and crash it).
+        """
+        from ..operators.add_geometric_constraints import (
+            VIEW3D_OT_slvs_add_equal,
+        )
+
+        p0 = self.add_point((0, 0))
+        p1 = self.add_point((3, 0))
+        line = self.add_line(p0, p1)
+
+        pc = self.add_point((6, 0))
+        circle = self.add_circle(pc, 1.0)
+
+        selection.selected.clear()
+        selection.selected.append(circle.curve_id)
+        selection.selected.append(line.curve_id)
+
+        h = OpHarness(VIEW3D_OT_slvs_add_equal, self.sketch, self.context)
+        h.prefill()
+
+        # First slot filled with the circle...
+        self.assertTrue(h.op.get_state_data(0).get("is_existing_entity", False))
+        # ...but the incompatible line is rejected for the second slot.
+        self.assertFalse(h.op.get_state_data(1).get("is_existing_entity", False))
+        self.assertFalse(h.op.check_props())
+
+    # -- solver safety net: an incompatible pair (e.g. from a loaded file or a
+    #    script) must be skipped, never crash the solver ----------------------
+    def test_equal_incompatible_pair_does_not_crash_solver(self):
+        sc = self.sketch.constraints
+
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((3, 0), fixed=True)
+        line = self.add_line(p0, p1)
+
+        pc = self.add_point((6, 0), fixed=True)
+        circle = self.add_circle(pc, 1.0)
+
+        c = sc.add_equal(curve_id_1=line.curve_id, curve_id_2=circle.curve_id)
+        # Must not crash; the constraint is skipped and marked failed.
+        self.solve()
+        self.assertTrue(c.failed)
+
+    def tearDown(self):
+        selection.selected.clear()
+        return super().tearDown()


### PR DESCRIPTION
Fixes #569.

## Problems

1. **Equal constraint does nothing.** `SlvsEqual` was the only constraint missing its `curve_id_1` / `curve_id_2` `StringProperty` declarations. `add_equal(...)` set attributes that no RNA property backed, so the operands were never stored and the solver skipped the (empty) constraint.

2. **Crash when preselecting a circle + a line, then invoking Equal.** solvespace has no line-length ↔ circle-radius equality; passing that pair to `equal` segfaults. The `get_types` narrowing that blocks this during interactive picking was being bypassed during selection prefill.

## Root cause of the bypass

`parse_selection` read the accepted types from `get_states_definition()` (built with `operator=None`, so `get_types` narrowing is skipped) instead of the operator-aware `get_states()`. Interactive picking used the narrowed list, prefill did not — so preselection accepted incompatible operands. This affected **equal, distance, horizontal, and vertical**; the single fix repairs all four.

## Changes

- `model/equal.py` — add the missing `curve_id_1/2` properties; add a solver-level guard rejecting line-vs-circle (safety net for file-load / scripting paths, where a bad pair would otherwise segfault).
- `stateful_operator/integration.py` — `parse_selection` now uses the operator-aware, narrowed state list, matching interactive picking.
- `testing/test_equal.py` — equal-lines, equal-circles, prefill-rejects-circle+line, and incompatible-pair-doesn't-crash-solver.

## Testing

Full suite: 173/173 green.
