### PR TITLE
Fix dimension constraint units and toggle behavior

### DIFF
--- a/model/angle.py
+++ b/model/angle.py
@@ -79,7 +79,11 @@ class SlvsAngle(DimensionalConstraint, PropertyGroup):
     )
     setting: BoolProperty(
         name="Measure supplementary angle",
-        update=DimensionalConstraint.assign_init_props,
+        # Just re-solve: the stored angle is unchanged, to_displayed_value flips
+        # the shown number to the supplementary, and the solver keeps the current
+        # geometry. Re-initialising here would rewrite the value through the
+        # supplementary conversion and deform the sketch.
+        update=update_system_cb,
     )
     draw_offset: FloatProperty(name="Draw Offset", default=1)
     draw_outset: FloatProperty(name="Draw Outset", default=0)

--- a/model/angle.py
+++ b/model/angle.py
@@ -47,6 +47,20 @@ class SlvsAngle(DimensionalConstraint, PropertyGroup):
         )
         self.draw_offset = dist if not self.setting else -dist
 
+    def _on_reference_checked(self, context: Context = None):
+        # Toggling reference mode re-inits props (recomputing draw_offset from
+        # geometry), which would discard the label position the user placed by
+        # hand. Preserve the placement across the toggle.
+        saved = self.draw_offset, self.draw_outset
+        DimensionalConstraint.on_reference_checked(self, context)
+        self.draw_offset, self.draw_outset = saved
+
+    is_reference: BoolProperty(
+        name="Only measure",
+        default=False,
+        update=_on_reference_checked,
+    )
+
     label = "Angle"
     value_store: FloatProperty(
         name="Angle Storage",

--- a/operators/bevel.py
+++ b/operators/bevel.py
@@ -135,7 +135,7 @@ class View3D_OT_slvs_bevel(Operator, Operator2d):
     bl_label = "Sketch Bevel"
     bl_options = {"REGISTER", "UNDO"}
 
-    radius: FloatProperty(name="Radius")
+    radius: FloatProperty(name="Radius", subtype="DISTANCE", unit="LENGTH")
 
     states = (
         state_from_args(

--- a/operators/offset.py
+++ b/operators/offset.py
@@ -53,7 +53,7 @@ class View3D_OT_slvs_add_offset(Operator, Operator2d):
     bl_label = "Offset"
     bl_options = {"REGISTER", "UNDO"}
 
-    distance: FloatProperty(name="Distance")
+    distance: FloatProperty(name="Distance", subtype="DISTANCE", unit="LENGTH")
 
     states = (
         state_from_args(

--- a/testing/test_dimension.py
+++ b/testing/test_dimension.py
@@ -1,0 +1,40 @@
+"""Dimension-constraint behaviour fixes (#450, #416)."""
+
+import bpy
+
+from .utils import Sketch2dTestCase
+
+
+class TestDimension(Sketch2dTestCase):
+    def test_450_bevel_offset_use_length_units(self):
+        """Bevel radius / offset distance must respect the scene unit system."""
+        for op, prop in (
+            (bpy.ops.view3d.slvs_bevel, "radius"),
+            (bpy.ops.view3d.slvs_offset, "distance"),
+        ):
+            p = op.get_rna_type().properties[prop]
+            self.assertEqual(p.subtype, "DISTANCE", f"{prop} subtype")
+            self.assertEqual(p.unit, "LENGTH", f"{prop} unit")
+
+    def test_416_angle_keeps_placement_on_reference_toggle(self):
+        """Toggling 'Only measure' must not move the angle's label."""
+        sc = self.sketch.constraints
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((2, 0), fixed=True)
+        p2 = self.add_point((0, 2), fixed=True)
+        l1 = self.add_line(p0, p1)
+        l2 = self.add_line(p0, p2)
+
+        c = sc.add_angle(init=True, curve_id_1=l1.curve_id, curve_id_2=l2.curve_id)
+
+        # User-placed label position.
+        c.draw_offset = 3.7
+        c.draw_outset = 0.25
+
+        c.is_reference = True
+        self.assertAlmostEqual(c.draw_offset, 3.7, places=4)
+        self.assertAlmostEqual(c.draw_outset, 0.25, places=4)
+
+        c.is_reference = False
+        self.assertAlmostEqual(c.draw_offset, 3.7, places=4)
+        self.assertAlmostEqual(c.draw_outset, 0.25, places=4)

--- a/testing/test_dimension.py
+++ b/testing/test_dimension.py
@@ -38,3 +38,39 @@ class TestDimension(Sketch2dTestCase):
         c.is_reference = False
         self.assertAlmostEqual(c.draw_offset, 3.7, places=4)
         self.assertAlmostEqual(c.draw_outset, 0.25, places=4)
+
+    def test_479_angle_supplementary_remeasures_without_deform(self):
+        """Supplementary toggle flips the shown value, never moves geometry."""
+        import math
+
+        sc = self.sketch.constraints
+        p0 = self.add_point((0, 0), fixed=True)
+        pa = self.add_point((2, 0), fixed=True)
+        pb = self.add_point((2, 2))
+        l1 = self.add_line(p0, pa)
+        l2 = self.add_line(p0, pb)
+
+        c = sc.add_angle(init=True, curve_id_1=l1.curve_id, curve_id_2=l2.curve_id)
+        self.solve()
+        self.assertAlmostEqual(math.degrees(c.value), 45.0, places=2)
+
+        c.setting = True          # supplementary
+        self.solve()
+        self.assertAlmostEqual(math.degrees(c.value), 135.0, places=2)
+        self.assertAlmostEqual(pb.co.x, 2.0, places=3)   # geometry unchanged
+        self.assertAlmostEqual(pb.co.y, 2.0, places=3)
+
+    def test_479_distance_align_remeasures_without_deform(self):
+        """Switching alignment re-measures the current geometry, no deform."""
+        sc = self.sketch.constraints
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((3, 3))
+
+        c = sc.add_distance(init=True, curve_id_1=p0.curve_id, curve_id_2=p1.curve_id)
+        self.solve()
+
+        c.align = "VERTICAL"
+        self.solve()
+        self.assertAlmostEqual(c.value, 3.0, places=3)   # vertical component
+        self.assertAlmostEqual(p1.co.x, 3.0, places=3)   # geometry unchanged
+        self.assertAlmostEqual(p1.co.y, 3.0, places=3)


### PR DESCRIPTION
Fixes #450, #416, #479.

- #450: bevel radius and offset distance now respect the scene unit system (DISTANCE/LENGTH).
- #416: angle constraint keeps its user-placed label position when toggling reference mode.
- #479: toggling supplementary angle re-measures (flips the shown value) instead of deforming the sketch. Distance alignment already behaved this way.

Tests added in `testing/test_dimension.py`.
