### PR TITLE
Fix origin-workplane corruption and undo sketch-mode dead-end (#571)

### DIFF
--- a/gizmos/workplane.py
+++ b/gizmos/workplane.py
@@ -52,6 +52,10 @@ class VIEW3D_GGT_slvs_workplane(GizmoGroup):
         return context_mode_check(context, cls.bl_idname)
 
     def setup(self, context):
+        # Re-assert the origin planes when the tool activates, so a drifted or
+        # missing plane (#571) is restored without needing a depsgraph tick.
+        from ..utilities.workplane import repair_origin_workplanes
+        repair_origin_workplanes(context)
         self.gizmo = self.gizmos.new(VIEW3D_GT_slvs_workplane.bl_idname)
 
 

--- a/handlers.py
+++ b/handlers.py
@@ -94,6 +94,12 @@ def on_depsgraph_update(scene, depsgraph):
         if validate_all_sketches(scene):
             global_data.needs_solve = True
 
+        # Undo/redo can flatten the origin workplane empties to identity (they
+        # then stack into a mushy overlap, #571); re-assert their transforms.
+        # Only rewrites when drifted, so this settles in one pass.
+        from .utilities.workplane import repair_origin_workplanes
+        repair_origin_workplanes(bpy.context)
+
     if depsgraph.id_type_updated("SCENE"):
         global_data.needs_solve = True
 

--- a/handlers.py
+++ b/handlers.py
@@ -152,6 +152,20 @@ def on_frame_change(scene, depsgraph=None):
             refresh_curve_geometry(sketch)
 
 
+def on_undo_redo(scene, *args):
+    """Reconcile sketch mode with the active sketch after undo/redo.
+
+    The sketch-mode flag and its registered tool set are Python state that
+    Blender's undo cannot revert, while ``active_sketch_object`` is undo-tracked.
+    Undoing sketch creation nulls the pointer but leaves sketch mode on -- a dead
+    end where you can neither add nor leave a sketch. Re-sync them here.
+    """
+    from .model.sketch_ref import get_active_sketch
+    from .workspacetools.manager import sync_sketch_mode
+
+    sync_sketch_mode(get_active_sketch(bpy.context) is not None)
+
+
 def _setup_builtin_handlers():
     from .versioning import do_versioning, write_addon_version
 
@@ -160,6 +174,8 @@ def _setup_builtin_handlers():
     add_builtin_handler("load_post", on_load_post)
     add_builtin_handler("depsgraph_update_post", on_depsgraph_update)
     add_builtin_handler("frame_change_post", on_frame_change)
+    add_builtin_handler("undo_post", on_undo_redo)
+    add_builtin_handler("redo_post", on_undo_redo)
 
 
 def register():

--- a/testing/test_origin_workplanes.py
+++ b/testing/test_origin_workplanes.py
@@ -1,0 +1,54 @@
+"""Origin workplane self-heal (#571): flattened/hidden/missing planes."""
+
+import bpy
+from mathutils import Matrix
+
+from .utils import Sketch2dTestCase
+from ..utilities.workplane import (
+    ensure_origin_workplane_empties,
+    repair_origin_workplanes,
+    iter_wp_empties,
+    _target_matrix,
+    _ORIGIN_WP_CONFIGS,
+)
+
+
+class TestOriginWorkplanes(Sketch2dTestCase):
+    def _sk(self):
+        return self.context.scene.sketcher
+
+    def test_repair_restores_flattened_planes(self):
+        """Undo can flatten XZ/YZ to identity; repair must restore normals."""
+        ensure_origin_workplane_empties(self.context)
+        sk = self._sk()
+
+        sk.wp_xz.matrix_world = Matrix.Identity(4)
+        sk.wp_yz.matrix_world = Matrix.Identity(4)
+
+        repair_origin_workplanes(self.context)
+
+        for prop, _name, euler, _id in _ORIGIN_WP_CONFIGS:
+            emp = getattr(sk, prop)
+            target = _target_matrix(euler)
+            for j in range(3):
+                self.assertAlmostEqual(
+                    emp.matrix_world.col[2][j], target.col[2][j], places=5,
+                    msg=f"{prop} normal not restored",
+                )
+
+    def test_repair_rehides_origin_empty(self):
+        ensure_origin_workplane_empties(self.context)
+        sk = self._sk()
+        sk.wp_xy.hide_viewport = False
+        repair_origin_workplanes(self.context)
+        self.assertTrue(sk.wp_xy.hide_viewport)
+
+    def test_ensure_recreates_missing_plane(self):
+        ensure_origin_workplane_empties(self.context)
+        sk = self._sk()
+        bpy.data.objects.remove(sk.wp_yz)
+        self.assertFalse(sk.wp_yz)
+
+        ensure_origin_workplane_empties(self.context)
+        self.assertTrue(sk.wp_yz)
+        self.assertEqual(len(list(iter_wp_empties(self.context))), 3)

--- a/testing/test_sketch_mode.py
+++ b/testing/test_sketch_mode.py
@@ -1,0 +1,38 @@
+"""Sketch-mode / active-sketch reconciliation after undo (dead-end bug)."""
+
+from .utils import Sketch2dTestCase
+
+
+class TestSketchModeReconcile(Sketch2dTestCase):
+    def test_undo_without_active_sketch_leaves_mode(self):
+        """Undoing sketch creation nulls the active sketch; sketch mode must
+        follow, otherwise you are stuck (can't add or leave a sketch)."""
+        from ..workspacetools.manager import enter_sketch_mode, is_sketch_mode
+        from ..handlers import on_undo_redo
+        from ..model.sketch_ref import set_active_sketch
+
+        # Simulate the post-undo state: in sketch mode, but the sketch is gone.
+        enter_sketch_mode()
+        set_active_sketch(self.context, None)
+        self.assertTrue(is_sketch_mode(), "precondition: stuck in sketch mode")
+
+        on_undo_redo(self.context.scene)
+        self.assertFalse(is_sketch_mode(), "sketch mode must be left when no sketch is active")
+
+    def test_reconcile_enters_when_sketch_active(self):
+        """Redoing back into a sketch (active again) must restore sketch mode."""
+        from ..workspacetools.manager import leave_sketch_mode, is_sketch_mode
+        from ..handlers import on_undo_redo
+        from ..model.sketch_ref import set_active_sketch
+
+        set_active_sketch(self.context, self.sketch.target_object)
+        leave_sketch_mode()
+        self.assertFalse(is_sketch_mode())
+
+        on_undo_redo(self.context.scene)
+        self.assertTrue(is_sketch_mode(), "sketch mode must be entered when a sketch is active")
+
+    def tearDown(self):
+        from ..workspacetools.manager import leave_sketch_mode
+        leave_sketch_mode()
+        return super().tearDown()

--- a/utilities/workplane.py
+++ b/utilities/workplane.py
@@ -220,28 +220,64 @@ def ensure_workplane_empty(sketch):
     return empty
 
 
-def ensure_origin_workplane_empties(context):
-    """Create the three origin workplane empties (XY, XZ, YZ) if they don't exist."""
+# (prop_name, object_name, local rotation, pick id) for the three origin planes.
+_ORIGIN_WP_CONFIGS = (
+    ("wp_xy", "WP_XY", (0.0, 0.0, 0.0), WP_ID_XY),
+    ("wp_xz", "WP_XZ", (math.pi / 2, 0.0, 0.0), WP_ID_XZ),
+    ("wp_yz", "WP_YZ", (math.pi / 2, 0.0, math.pi / 2), WP_ID_YZ),
+)
+
+
+def _matrix_differs(a, b, eps=1e-6):
+    return any(abs(a[i][j] - b[i][j]) > eps for i in range(4) for j in range(4))
+
+
+def _target_matrix(euler_tuple):
     from mathutils import Euler
+    return Euler(euler_tuple).to_matrix().to_4x4()
 
+
+def _enforce_origin_empty(empty, euler_tuple):
+    """Re-assert an origin empty's fixed transform and hidden state.
+
+    Undo/redo can leave these at identity (all three then stack flat -> the
+    mushy overlap of #571); they must never drift, so re-apply rather than
+    trust the stored state. Only writes when it actually differs to avoid
+    churning the depsgraph.
+    """
+    target = _target_matrix(euler_tuple)
+    if _matrix_differs(empty.matrix_world, target):
+        empty.matrix_world = target
+    if not empty.hide_viewport:
+        empty.hide_viewport = True
+
+
+def repair_origin_workplanes(context):
+    """Fix the transform/visibility of existing origin empties (no creation)."""
     sketcher = context.scene.sketcher
-    scene = context.scene
-
-    configs = [
-        ("wp_xy", "WP_XY", Euler((0, 0, 0)), WP_ID_XY),
-        ("wp_xz", "WP_XZ", Euler((1.5707963, 0, 0)), WP_ID_XZ),
-        ("wp_yz", "WP_YZ", Euler((1.5707963, 0, 1.5707963)), WP_ID_YZ),
-    ]
-
-    for prop_name, name, euler, wp_id in configs:
+    for prop_name, _name, euler_tuple, wp_id in _ORIGIN_WP_CONFIGS:
         existing = getattr(sketcher, prop_name)
         if existing:
             WP_ID_MAP[wp_id] = existing
+            _enforce_origin_empty(existing, euler_tuple)
+
+
+def ensure_origin_workplane_empties(context):
+    """Create the three origin workplane empties (XY, XZ, YZ) if missing, and
+    re-assert their fixed transform/hidden state if they already exist."""
+    sketcher = context.scene.sketcher
+    scene = context.scene
+
+    for prop_name, name, euler_tuple, wp_id in _ORIGIN_WP_CONFIGS:
+        existing = getattr(sketcher, prop_name)
+        if existing:
+            WP_ID_MAP[wp_id] = existing
+            _enforce_origin_empty(existing, euler_tuple)
             continue
 
         empty = bpy.data.objects.new(name, None)
         empty.empty_display_type = 'SINGLE_ARROW'
-        empty.matrix_world = euler.to_matrix().to_4x4()
+        empty.matrix_world = _target_matrix(euler_tuple)
         empty.hide_viewport = True
         empty.lock_location = (True, True, True)
         empty.lock_rotation = (True, True, True)

--- a/workspacetools/manager.py
+++ b/workspacetools/manager.py
@@ -60,6 +60,27 @@ def leave_sketch_mode():
     _register_tools({ToolGroup.NON_SKETCH})
 
 
+def is_sketch_mode():
+    """True while the sketch sub-tools are the registered set."""
+    return _sketch_active
+
+
+def sync_sketch_mode(is_active_sketch: bool):
+    """Reconcile the registered tool set with whether a sketch is active.
+
+    Sketch mode is Python-global state (which tools are registered) that
+    Blender's undo does not track, so it can desync from the undo-tracked
+    active_sketch_object. Undoing sketch creation, for instance, removes the
+    sketch but leaves sketch mode on -- a dead end where you can neither add a
+    sketch (the Add Sketch tool is unregistered) nor leave one (there is no
+    active sketch to leave). Force them back in step.
+    """
+    if is_active_sketch:
+        enter_sketch_mode()
+    else:
+        leave_sketch_mode()
+
+
 def register():
     if bpy.app.background:
         return


### PR DESCRIPTION
Two related undo-robustness fixes for sketches.

Fixes #571.

**Origin workplanes self-heal (#571):** undo/redo could flatten the three origin workplane empties to identity, so they stacked into one mushy overlapping quadrant and the vertical planes disappeared. `ensure_origin_workplane_empties` only ever created missing empties and never corrected a drifted transform. Now it re-asserts each origin empty's fixed transform/hidden state (writing only when it differs), and a repair pass runs from the depsgraph handler (fires after undo) and on workplane-tool activation, so a flattened/unhidden/missing plane is restored automatically.

**Undo sketch-mode dead-end:** sketch mode (which tools are registered) is Python-global state undo can't revert, while `active_sketch_object` is undo-tracked. Undoing sketch creation removed the sketch but left sketch mode on — a dead end where you could neither add a sketch (the Add Sketch tool is unregistered) nor leave one (no active sketch to leave). Added `undo_post`/`redo_post` handlers that re-sync sketch mode to whether a sketch is active.

Tests in `testing/test_origin_workplanes.py` and `testing/test_sketch_mode.py`.
