### PR TITLE
Independent constraint values for duplicated sketches

### DIFF
--- a/testing/test_duplicate_sketch.py
+++ b/testing/test_duplicate_sketch.py
@@ -1,0 +1,46 @@
+"""Duplicating a sketch object must yield independent constraint values (#14)."""
+
+import bpy
+
+from .utils import Sketch2dTestCase
+
+
+class TestDuplicateSketch(Sketch2dTestCase):
+    def _duplicate(self):
+        obj_a = self.sketch.target_object
+        obj_b = obj_a.copy()
+        obj_b.data = obj_a.data.copy()
+        bpy.context.scene.collection.objects.link(obj_b)
+        from ..model.sketch_ref import Sketch, stamp_sketch_props
+        stamp_sketch_props(obj_b)
+        return Sketch(obj_b)
+
+    def test_duplicate_gets_independent_constraint_value(self):
+        sc = self.sketch.constraints
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((2, 0))
+        line = self.add_line(p0, p1)
+        sc.add_distance(init=True, value=2.0, curve_id_1=line.curve_id)
+
+        sketch_b = self._duplicate()
+
+        # Right after duplication the copy shares the uid...
+        ca = list(self.sketch.constraints.all)[0]
+        cb = list(sketch_b.constraints.all)[0]
+        self.assertEqual(ca.constraint_uid, cb.constraint_uid)
+
+        # ...validation re-mints the copy's uid and preserves the value.
+        from ..utilities.validate import validate_all_sketches
+        validate_all_sketches(self.context.scene)
+
+        ca = list(self.sketch.constraints.all)[0]
+        cb = list(sketch_b.constraints.all)[0]
+        self.assertNotEqual(ca.constraint_uid, cb.constraint_uid,
+                            "duplicate must get its own constraint uid")
+        self.assertAlmostEqual(ca.value, 2.0)
+        self.assertAlmostEqual(cb.value, 2.0, msg="copy keeps its value")
+
+        # Editing one no longer affects the other.
+        cb.value = 9.0
+        self.assertAlmostEqual(ca.value, 2.0, msg="editing copy must not change original")
+        self.assertAlmostEqual(cb.value, 9.0)

--- a/utilities/validate.py
+++ b/utilities/validate.py
@@ -14,6 +14,7 @@ straight through — the solver treats them as tweaks on the next solve.
 """
 
 import logging
+import secrets
 
 from ..model.constants import SketchCurveType
 from .curve_data import (
@@ -172,6 +173,44 @@ def validate_sketch(sketch):
     return changed
 
 
+def _dedup_constraint_uids(scene):
+    """Give duplicated sketches independent constraint uids.
+
+    Dimensional values live in ``scene["slvs:c:<uid>"]``, so two sketches sharing
+    a constraint uid (e.g. after duplicating a sketch object) share the value.
+    Keep each uid's first occurrence; re-mint later ones and copy their current
+    value across so the copy stays independent.
+    """
+    from ..model.sketch_ref import get_sketches
+
+    seen = set()
+    changed = False
+    for sketch in get_sketches(scene):
+        try:
+            constraints = sketch.constraints
+        except Exception:
+            continue
+        for c in constraints.all:
+            uid = getattr(c, "constraint_uid", "")
+            if uid and uid not in seen:
+                seen.add(uid)
+                continue
+
+            new = secrets.token_hex(8)
+            while new in seen:
+                new = secrets.token_hex(8)
+            c.constraint_uid = new
+            # Carry the stored value over so the copy keeps its current value
+            # (dimensional constraints only; geometric ones store nothing).
+            old_key = f"slvs:c:{uid}" if uid else None
+            new_key = f"slvs:c:{new}"
+            if old_key and old_key in scene and new_key not in scene:
+                scene[new_key] = scene[old_key]
+            seen.add(new)
+            changed = True
+    return changed
+
+
 def validate_all_sketches(scene):
     """Validate every sketch in the scene. Returns True if anything changed."""
     from ..model.sketch_ref import get_sketches
@@ -183,4 +222,11 @@ def validate_all_sketches(scene):
                 any_changed = True
         except Exception:
             logger.exception("Sketch validation failed for '%s'", sketch.name)
+
+    try:
+        if _dedup_constraint_uids(scene):
+            any_changed = True
+    except Exception:
+        logger.exception("Constraint uid dedup failed")
+
     return any_changed


### PR DESCRIPTION
Relates to #14.

Duplicating a sketch object (Shift+D) copied its constraints with the same uids, and dimensional values are keyed by uid in `scene["slvs:c:<uid>"]` — so the copy shared values with the original (editing one changed both).

The self-heal pass now re-mints duplicated constraint uids across sketches and copies each stored value over, so duplicated sketches are independent. Test in `testing/test_duplicate_sketch.py`.
