### PR TITLE
CI: pin release build to Blender 5.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - uses: moguri/setup-blender@v1
         with:
-          blender-version: "4.5"
+          blender-version: "5.0"
 
       - run: blender --version
 
@@ -122,7 +122,7 @@ jobs:
     steps:
       - uses: moguri/setup-blender@v1
         with:
-          blender-version: "4.5"
+          blender-version: "5.0"
 
       - name: Download stable release zips
         env:
@@ -254,7 +254,7 @@ jobs:
 
       - uses: moguri/setup-blender@v1
         with:
-          blender-version: "4.5"
+          blender-version: "5.0"
 
       - name: Stamp latest version
         # <base>-latest.<run_number>: monotonic, sorts below the eventual stable.


### PR DESCRIPTION
The release workflow built and validated the extension with Blender 4.5, but the manifest requires Blender 5.0+ (`blender_version_min = "5.0.0"`) — so packaging ran on a toolchain below the extension's own declared minimum. Pin all three release-job steps to 5.0 to match.
