### PR TITLE
Fix trim leaving degenerate zero-sweep arcs

### DIFF
--- a/testing/test_trim_degenerate.py
+++ b/testing/test_trim_degenerate.py
@@ -1,0 +1,63 @@
+"""Degenerate (zero-sweep) arc handling from trimming a circle to nothing.
+
+Trimming a circle down could leave arcs whose start and end points coincide;
+their bezier degenerates into a stray sliver (the "trim leftover" lens). The
+self-heal removes such arcs and their orphaned points; the trim operation
+itself no longer creates them.
+"""
+
+from ..model.constants import SketchCurveType
+from ..utilities.curve_data import get_uuid
+from .utils import Sketch2dTestCase
+
+
+class TestTrimDegenerate(Sketch2dTestCase):
+    def _count(self, kind):
+        cd = self.sketch.data
+        ta = cd.attributes.get("sketch_type")
+        return sum(1 for i in range(len(cd.curves)) if ta.data[i].value == kind)
+
+    def test_points_coincident_helper(self):
+        from ..utilities.trimming import _points_coincident
+
+        p_a = self.add_point((1.0, 1.0))
+        p_b = self.add_point((1.0, 1.0))  # same location, different entity
+        p_c = self.add_point((2.0, 0.0))
+        self.assertTrue(_points_coincident(p_a, p_a))  # same entity
+        self.assertTrue(_points_coincident(p_a, p_b))  # coincident coords
+        self.assertFalse(_points_coincident(p_a, p_c))  # distinct
+        self.assertTrue(_points_coincident(p_a, None))  # missing -> treat as degenerate
+
+    def test_validate_removes_degenerate_arc(self):
+        from ..model.curve_ref import ArcRef, curve_ref
+        from ..utilities.validate import validate_all_sketches
+
+        # A well-formed arc survives.
+        ct = self.add_point((0, 0))
+        good = ArcRef.create(
+            ct=ct,
+            sketch=self.sketch,
+            start=self.add_point((2, 0)),
+            end=self.add_point((0, 2)),
+        )
+        # A degenerate arc: start and end at the same location.
+        ct2 = self.add_point((5, 0))
+        s = self.add_point((7, 0))
+        e = self.add_point((7, 0))  # coincident with start
+        bad = ArcRef.create(ct=ct2, sketch=self.sketch, start=s, end=e)
+
+        self.assertEqual(self._count(SketchCurveType.ARC), 2)
+
+        changed = validate_all_sketches(self.context.scene)
+        self.assertTrue(changed)
+
+        # Degenerate arc gone, good arc kept.
+        self.assertEqual(self._count(SketchCurveType.ARC), 1)
+        self.assertTrue(curve_ref(self.sketch, good.curve_id).valid)
+        self.assertFalse(curve_ref(self.sketch, bad.curve_id).valid)
+
+        # Its orphaned points (start/end/center) are cleaned up too.
+        cd = self.sketch.data
+        remaining = {get_uuid(cd, "curve_id", i) for i in range(len(cd.curves))}
+        for orphan in (s.curve_id, e.curve_id, ct2.curve_id):
+            self.assertNotIn(orphan, remaining)

--- a/utilities/trimming.py
+++ b/utilities/trimming.py
@@ -1,12 +1,25 @@
 """Trimming logic for splitting segments at intersection points."""
 
 import logging
+
 from mathutils import Vector
 
-from ..model.curve_ref import PointRef, LineRef, ArcRef, CircleRef, CurveRef, curve_ref
+from ..model.curve_ref import ArcRef, CircleRef, LineRef, PointRef
 from .curve_data import get_uuid, has_uuid_field
 
 logger = logging.getLogger(__name__)
+
+# Two trim points closer than this (sketch units) are treated as the same
+# location, so a piece bounded by them is a fully-trimmed (degenerate) segment.
+COINCIDENT_EPS = 1e-4
+
+
+def _points_coincident(p1, p2) -> bool:
+    if p1 is None or p2 is None:
+        return True
+    if getattr(p1, "curve_id", None) and p1.curve_id == getattr(p2, "curve_id", None):
+        return True
+    return (Vector(p1.co) - Vector(p2.co)).length < COINCIDENT_EPS
 
 
 class Intersection:
@@ -220,6 +233,13 @@ class TrimSegment:
             intr_2 = relevant[i * 2 + 1]
             p1 = intr_1.get_or_create_point(sketch)
             p2 = intr_2.get_or_create_point(sketch)
+
+            # A piece whose two boundaries collapse onto the same location is
+            # fully trimmed away -- creating a segment there yields a zero-length
+            # line or a zero-sweep arc (whose bezier degenerates into a stray
+            # sliver). Skip it; its now-orphan points are cleaned up below.
+            if _points_coincident(p1, p2):
+                continue
 
             if i == 0 and not self._is_closed:
                 # Reuse original segment for first piece

--- a/utilities/validate.py
+++ b/utilities/validate.py
@@ -14,6 +14,7 @@ straight through — the solver treats them as tweaks on the next solve.
 """
 
 import logging
+import math
 import secrets
 
 from ..model.constants import SketchCurveType
@@ -31,6 +32,9 @@ from .curve_data import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Start/end points closer than this (sketch units) make an arc zero-sweep.
+_DEGEN_ARC_EPS = 1e-4
 
 # object.name -> signature of the last validated state
 _validated = {}
@@ -64,6 +68,7 @@ def _signature(curve_data):
 def _other_sketch_ids(obj):
     """Curve ids belonging to every *other* sketch (cross-sketch references)."""
     import bpy
+
     from ..model.sketch_ref import get_sketches
 
     ids = set()
@@ -101,6 +106,23 @@ def _prune_dangling_constraints(sketch, valid_ids):
                 coll.remove(i)
                 removed = True
     return removed
+
+
+def _remove_orphan_points(sketch, candidate_ids):
+    """Remove point curves in ``candidate_ids`` no segment still references."""
+    cd = sketch.target_object.data
+    type_attr = cd.attributes.get("sketch_type")
+    if not type_attr:
+        return
+    referenced = set()
+    for i in range(len(cd.curves)):
+        if type_attr.data[i].value == SketchCurveType.POINT:
+            continue
+        for field in ("start_point_id", "end_point_id", "center_point_id"):
+            referenced.add(get_uuid(cd, field, i))
+    for cid in candidate_ids:
+        if cid and cid not in referenced:
+            remove_native_curve_by_id(sketch, cid)
 
 
 def validate_sketch(sketch):
@@ -159,6 +181,40 @@ def validate_sketch(sketch):
             if cid:
                 remove_native_curve_by_id(sketch, cid)
                 changed = True
+
+    # 3b. Remove degenerate arcs whose start and end points coincide (zero
+    #     sweep). Trimming a circle down to nothing can leave these; their
+    #     bezier degenerates into a stray sliver (the "trim leftover" lens).
+    #     Drop the arc and any points it orphans.
+    if type_attr:
+        pos_by_id = {
+            get_uuid(cd, "curve_id", i): tuple(
+                cd.points[cd.curves[i].points[0].index].position[:2]
+            )
+            for i in range(len(cd.curves))
+            if type_attr.data[i].value == SketchCurveType.POINT
+        }
+        degenerate_arcs = []
+        orphaned = set()
+        for i in range(len(cd.curves)):
+            if type_attr.data[i].value != SketchCurveType.ARC:
+                continue
+            sp = get_uuid(cd, "start_point_id", i)
+            ep = get_uuid(cd, "end_point_id", i)
+            a, b = pos_by_id.get(sp), pos_by_id.get(ep)
+            coincident = sp and (
+                sp == ep
+                or (a and b and math.hypot(a[0] - b[0], a[1] - b[1]) < _DEGEN_ARC_EPS)
+            )
+            if coincident:
+                degenerate_arcs.append(get_uuid(cd, "curve_id", i))
+                orphaned.update((sp, ep, get_uuid(cd, "center_point_id", i)))
+        for cid in degenerate_arcs:
+            if cid:
+                remove_native_curve_by_id(sketch, cid)
+                changed = True
+        if degenerate_arcs:
+            _remove_orphan_points(sketch, orphaned)
 
     # 4. Prune constraints referencing a curve that exists in no sketch.
     valid_ids = {get_uuid(cd, "curve_id", i) for i in range(len(cd.curves))}


### PR DESCRIPTION
Trimming a circle down to nothing could leave arcs whose start and end points coincide (zero sweep). Their bezier degenerates into a stray sliver — the "trim leftover" lens some users hit — and the pieces are never cleaned up.

Two layers:
- **Prevent**: trim skips creating a piece whose two boundary points coincide (within epsilon) — that region is fully trimmed, so no zero-length line / zero-sweep arc is produced.
- **Self-heal**: `validate.py` removes any existing degenerate arcs (coincident start/end) plus the points they orphan, so already-saved broken files repair on load. Dangling coincident constraints are then pruned by the existing pass.

Verified against a real failing file: the leftover collapsed from 2 degenerate arcs + 10 points + 8 constraints to a clean 4 lines + 5 points + 4 constraints, and it still solves. Tests in `testing/test_trim_degenerate.py`.
