### PR TITLE
Visual feedback when snapped to geometry (#577)

### DIFF
--- a/drawing/snap.py
+++ b/drawing/snap.py
@@ -1,27 +1,34 @@
-"""Viewport marker for the current geometry snap target while drawing.
+"""Shared viewport marker for the current geometry snap target.
 
-Draws a small screen-space glyph at the point the cursor is snapped to, so the
-user gets clear feedback when locked onto external geometry — with the glyph
-shape encoding the snap type (issue #577). Rendered by a POST_PIXEL draw handler
-the placement operator owns for the lifetime of its modal (see
-``operators.base_2d.Operator2d``), so nothing lingers past the draw.
+Draws a small screen-space glyph at the point the cursor is snapped to, so it's
+clear when locked onto external geometry -- the glyph shape encodes the snap type
+(issue #577). One renderer is shared by both feedback paths:
+
+- while a draw tool is *active but idle*, the preselection gizmo computes and
+  draws the snap (``gizmos.preselection``),
+- while a draw *operator* runs (which suspends gizmos), the operator draws it
+  from a POST_PIXEL handler it owns (``operators.base_2d.Operator2d``).
+
+Each owner just holds its own ``_snap`` (dict from ``get_blender_snap_info`` or
+None); this module owns the drawing. It sets up a region-pixel matrix itself, so
+the same code renders correctly from a POST_PIXEL handler or a gizmo ``draw()``.
 """
 
 import gpu
+from bpy_extras.view3d_utils import location_3d_to_region_2d
 from gpu_extras.batch import batch_for_shader
-from mathutils import Vector
+from mathutils import Matrix, Vector
 
 from ..shaders import Shaders
 from ..utilities.preferences import get_prefs, get_scale
-from ..utilities.view import get_2d_coords
 
 # Half-extent of the marker in pixels, before UI scaling.
 _SIZE = 7.0
 
 
 def _glyph(snap_type: str, center, s: float):
-    """Line-segment endpoints (flat list of points, taken in pairs) for a snap
-    type's marker.
+    """Line-segment endpoints (flat list, taken in pairs) for a snap type's
+    marker.
 
     Square = vertex/endpoint, down-triangle = a midpoint (edge or face centre),
     X = a point on an edge. Anything else falls back to the square.
@@ -36,14 +43,34 @@ def _glyph(snap_type: str, center, s: float):
     return [a, b, b, c, c, d, d, a]
 
 
-def draw_snap_marker(operator, context):
-    """POST_PIXEL callback: mark the operator's current snap point, if any."""
-    snap = getattr(operator, "_snap", None)
+def _region_pixel_projection(region):
+    """Ortho projection mapping region pixels (origin bottom-left) to clip space.
+
+    Lets the marker draw in screen space from any GPU context (POST_PIXEL already
+    sets this up; a gizmo ``draw()`` does not).
+    """
+    w = max(region.width, 1)
+    h = max(region.height, 1)
+    return Matrix(
+        (
+            (2.0 / w, 0.0, 0.0, -1.0),
+            (0.0, 2.0 / h, 0.0, -1.0),
+            (0.0, 0.0, -1.0, 0.0),
+            (0.0, 0.0, 0.0, 1.0),
+        )
+    )
+
+
+def draw_snap_marker(owner, context):
+    """Draw ``owner._snap``'s marker, if any. Safe from a POST_PIXEL handler or a
+    gizmo ``draw()`` (sets up its own region-pixel matrix)."""
+    snap = getattr(owner, "_snap", None)
     if not snap or "world_point" not in snap:
         return
-    if context.region is None or context.region_data is None:
+    region, rv3d = context.region, context.region_data
+    if region is None or rv3d is None:
         return
-    p = get_2d_coords(context, Vector(snap["world_point"]))
+    p = location_3d_to_region_2d(region, rv3d, Vector(snap["world_point"]))
     if p is None:
         return
 
@@ -62,13 +89,16 @@ def draw_snap_marker(operator, context):
 
     gpu.state.blend_set("ALPHA")
     gpu.state.line_width_set(2.0)
-    shader.bind()
-    shader.uniform_float("color", col)
-    if not is_vk_metal:
-        try:
-            shader.uniform_float("lineWidth", 2.0)
-        except Exception:
-            pass
-    batch_for_shader(shader, "LINES", {"pos": coords}).draw(shader)
+    with gpu.matrix.push_pop(), gpu.matrix.push_pop_projection():
+        gpu.matrix.load_identity()
+        gpu.matrix.load_projection_matrix(_region_pixel_projection(region))
+        shader.bind()
+        shader.uniform_float("color", col)
+        if not is_vk_metal:
+            try:
+                shader.uniform_float("lineWidth", 2.0)
+            except Exception:
+                pass
+        batch_for_shader(shader, "LINES", {"pos": coords}).draw(shader)
     gpu.state.line_width_set(1.0)
     gpu.state.blend_set("NONE")

--- a/drawing/snap.py
+++ b/drawing/snap.py
@@ -1,0 +1,74 @@
+"""Viewport marker for the current geometry snap target while drawing.
+
+Draws a small screen-space glyph at the point the cursor is snapped to, so the
+user gets clear feedback when locked onto external geometry — with the glyph
+shape encoding the snap type (issue #577). Rendered by a POST_PIXEL draw handler
+the placement operator owns for the lifetime of its modal (see
+``operators.base_2d.Operator2d``), so nothing lingers past the draw.
+"""
+
+import gpu
+from gpu_extras.batch import batch_for_shader
+from mathutils import Vector
+
+from ..shaders import Shaders
+from ..utilities.preferences import get_prefs, get_scale
+from ..utilities.view import get_2d_coords
+
+# Half-extent of the marker in pixels, before UI scaling.
+_SIZE = 7.0
+
+
+def _glyph(snap_type: str, center, s: float):
+    """Line-segment endpoints (flat list of points, taken in pairs) for a snap
+    type's marker.
+
+    Square = vertex/endpoint, down-triangle = a midpoint (edge or face centre),
+    X = a point on an edge. Anything else falls back to the square.
+    """
+    x, y = center
+    if snap_type in ("EDGE_MIDPOINT", "FACE_MIDPOINT"):
+        a, b, c = (x, y + s), (x - s, y - s), (x + s, y - s)
+        return [a, b, b, c, c, a]
+    if snap_type == "EDGE":
+        return [(x - s, y - s), (x + s, y + s), (x - s, y + s), (x + s, y - s)]
+    a, b, c, d = (x - s, y - s), (x + s, y - s), (x + s, y + s), (x - s, y + s)
+    return [a, b, b, c, c, d, d, a]
+
+
+def draw_snap_marker(operator, context):
+    """POST_PIXEL callback: mark the operator's current snap point, if any."""
+    snap = getattr(operator, "_snap", None)
+    if not snap or "world_point" not in snap:
+        return
+    if context.region is None or context.region_data is None:
+        return
+    p = get_2d_coords(context, Vector(snap["world_point"]))
+    if p is None:
+        return
+
+    coords = _glyph(snap.get("type", ""), (p.x, p.y), _SIZE * get_scale())
+    col = (*get_prefs().theme_settings.entity.highlight[:3], 1.0)
+
+    try:
+        is_vk_metal = gpu.platform.backend_type_get() in ("VULKAN", "METAL")
+    except Exception:
+        is_vk_metal = False
+    shader = (
+        gpu.shader.from_builtin("UNIFORM_COLOR")
+        if is_vk_metal
+        else Shaders.uniform_color_line_2d()
+    )
+
+    gpu.state.blend_set("ALPHA")
+    gpu.state.line_width_set(2.0)
+    shader.bind()
+    shader.uniform_float("color", col)
+    if not is_vk_metal:
+        try:
+            shader.uniform_float("lineWidth", 2.0)
+        except Exception:
+            pass
+    batch_for_shader(shader, "LINES", {"pos": coords}).draw(shader)
+    gpu.state.line_width_set(1.0)
+    gpu.state.blend_set("NONE")

--- a/drawing/snap.py
+++ b/drawing/snap.py
@@ -23,7 +23,7 @@ from ..shaders import Shaders
 from ..utilities.preferences import get_prefs, get_scale
 
 # Half-extent of the marker in pixels, before UI scaling.
-_SIZE = 7.0
+_SIZE = 5.0
 
 
 def _glyph(snap_type: str, center, s: float):

--- a/gizmos/preselection.py
+++ b/gizmos/preselection.py
@@ -1,8 +1,10 @@
 from bpy.types import Gizmo, GizmoGroup
+from mathutils import Vector
 
-from ..drawing import selection
-from ..declarations import Gizmos, GizmoGroups
-from ..drawing import picking
+from ..declarations import GizmoGroups, Gizmos
+from ..drawing import picking, selection
+from ..drawing.snap import draw_snap_marker
+from ..utilities.view import get_blender_snap_info
 from .utilities import context_mode_check
 
 
@@ -29,10 +31,13 @@ class VIEW3D_GGT_slvs_preselection(GizmoGroup):
 class VIEW3D_GT_slvs_preselection(Gizmo):
     bl_idname = Gizmos.Preselection
 
-    __slots__ = ()
+    # ``_snap``: current geometry snap target (dict or None); ``_snap_key``: a
+    # cheap comparison key so we only redraw when the snap actually changes.
+    __slots__ = ("_snap", "_snap_key")
 
     def draw(self, context):
-        pass
+        # Same marker the draw operator uses; shown while the tool is idle.
+        draw_snap_marker(self, context)
 
     def test_select(self, context, location):
         # reset gizmo highlight
@@ -52,5 +57,14 @@ class VIEW3D_GT_slvs_preselection(Gizmo):
         cid = picking.pick(context, location)
         if cid != selection.hover:
             selection.hover = cid
+            context.area.tag_redraw()
+
+        # Snap to external geometry, mirroring the operator's live snapping, and
+        # redraw only when the snapped point/type changes.
+        snap = get_blender_snap_info(context, Vector(location))
+        key = (snap.get("type"), tuple(snap["world_point"])) if snap else None
+        if key != getattr(self, "_snap_key", None):
+            self._snap = snap
+            self._snap_key = key
             context.area.tag_redraw()
         return -1

--- a/gizmos/preselection.py
+++ b/gizmos/preselection.py
@@ -1,11 +1,23 @@
 from bpy.types import Gizmo, GizmoGroup
 from mathutils import Vector
 
-from ..declarations import GizmoGroups, Gizmos
+from ..declarations import GizmoGroups, Gizmos, WorkSpaceTools
 from ..drawing import picking, selection
 from ..drawing.snap import draw_snap_marker
 from ..utilities.view import get_blender_snap_info
 from .utilities import context_mode_check
+
+# Tools that place a point by snapping — the only ones that show a snap marker.
+# Edit tools (select/trim/offset/bevel) act on picked curves, not snap points.
+_SNAP_TOOLS = frozenset(
+    (
+        WorkSpaceTools.AddPoint2D,
+        WorkSpaceTools.AddLine2D,
+        WorkSpaceTools.AddRectangle,
+        WorkSpaceTools.AddCircle2D,
+        WorkSpaceTools.AddArc2D,
+    )
+)
 
 
 class VIEW3D_GGT_slvs_preselection(GizmoGroup):
@@ -60,8 +72,12 @@ class VIEW3D_GT_slvs_preselection(Gizmo):
             context.area.tag_redraw()
 
         # Snap to external geometry, mirroring the operator's live snapping, and
-        # redraw only when the snapped point/type changes.
-        snap = get_blender_snap_info(context, Vector(location))
+        # redraw only when the snapped point/type changes. Skip on edit tools
+        # (select/trim/…) — they act on picked curves, so a snap marker is noise.
+        snap = None
+        tool = context.workspace.tools.from_space_view3d_mode(context.mode)
+        if tool and tool.idname in _SNAP_TOOLS:
+            snap = get_blender_snap_info(context, Vector(location))
         key = (snap.get("type"), tuple(snap["world_point"])) if snap else None
         if key != getattr(self, "_snap_key", None):
             self._snap = snap

--- a/operators/add_arc.py
+++ b/operators/add_arc.py
@@ -1,20 +1,20 @@
 import logging
 import math
 
-from bpy.types import Operator, Context, Event
+from bpy.types import Context, Event, Operator
 from mathutils import Vector
 
-from ..declarations import Operators
-from ..stateful_operator.utilities.register import register_stateops_factory
-from ..stateful_operator.state import state_from_args
 from ..curve_solver import solve_system
-from ..utilities.math import pol2cart
-from ..utilities.geometry import intersect_line_sphere_2d
+from ..declarations import Operators
 from ..model.curve_ref import ArcRef
+from ..stateful_operator.state import state_from_args
+from ..stateful_operator.utilities.register import register_stateops_factory
+from ..utilities.geometry import intersect_line_sphere_2d
+from ..utilities.math import pol2cart
+from ..utilities.view import get_blender_snap_info, get_pos_2d, get_wp_matrix
 from .base_2d import Operator2d
 from .constants import types_point_2d
 from .utilities import ignore_hover
-from ..utilities.view import get_blender_snap_info, get_pos_2d, get_wp_matrix
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,7 @@ class View3D_OT_slvs_add_arc2d(Operator, Operator2d):
     def get_endpoint_pos(self, context: Context, coords):
         wp = self._get_wp()
         snap_data = get_blender_snap_info(context, coords)
+        self._snap = snap_data
         mouse_pos = get_pos_2d(context, wp, coords, respect_snapping=True)
         if mouse_pos is None:
             return None
@@ -89,7 +90,6 @@ class View3D_OT_slvs_add_arc2d(Operator, Operator2d):
 
         x, y = Vector(mouse_pos) - ct
         mouse_angle = math.atan2(y, x)
-        start_angle = math.atan2((p1 - ct).y, (p1 - ct).x)
 
         # Track cumulative angular displacement from start
         if not hasattr(self, "_prev_mouse_angle"):

--- a/operators/add_circle.py
+++ b/operators/add_circle.py
@@ -1,16 +1,16 @@
 import logging
 
-from bpy.types import Operator, Context
 from bpy.props import FloatProperty
+from bpy.types import Context, Operator
 from mathutils import Vector
 from mathutils.geometry import intersect_point_line
 
-from ..declarations import Operators
-from ..stateful_operator.utilities.register import register_stateops_factory
-from ..stateful_operator.state import state_from_args
 from ..curve_solver import solve_system
-from ..utilities.view import get_blender_snap_info, get_pos_2d, get_wp_matrix
+from ..declarations import Operators
 from ..model.curve_ref import CircleRef
+from ..stateful_operator.state import state_from_args
+from ..stateful_operator.utilities.register import register_stateops_factory
+from ..utilities.view import get_blender_snap_info, get_pos_2d, get_wp_matrix
 from .base_2d import Operator2d
 from .constants import types_point_2d
 from .utilities import ignore_hover
@@ -56,6 +56,7 @@ class View3D_OT_slvs_add_circle2d(Operator, Operator2d):
     def get_radius(self, context: Context, coords):
         wp = self._get_wp()
         snap_data = get_blender_snap_info(context, coords)
+        self._snap = snap_data
         pos = get_pos_2d(context, wp, coords, respect_snapping=True)
 
         # Snap the radius so the circle is tangent to an edge or coincident with

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -1,22 +1,42 @@
-import math
 from typing import Any, List
 
 import bpy
 from bpy.types import Context, Event
-from mathutils import Vector
 
-from ..model.types import SlvsPoint2D
-from ..model.types import SlvsLine2D, SlvsCircle, SlvsArc
 from ..model.curve_ref import CurveRef, PointRef, curve_ref
+from ..model.types import SlvsPoint2D
+from ..utilities.view import get_blender_snap_info, get_pos_2d, get_scale_from_pos
 from .base_stateful import GenericEntityOp
 from .utilities import ignore_hover
-from ..utilities.view import get_pos_2d, get_scale_from_pos
 
 
 class Operator2d(GenericEntityOp):
+    # Current geometry snap target (dict from get_blender_snap_info) or None,
+    # updated as the cursor moves and drawn by the snap-marker handler.
+    _snap = None
+    _snap_handle = None
+
     @classmethod
     def poll(cls, context: Context):
         return context.scene.sketcher.active_sketch_object is not None
+
+    def invoke(self, context: Context, event: Event):
+        # Own a POST_PIXEL marker for the current snap target for the lifetime of
+        # the modal (removed in _end), so it can never linger past the draw.
+        from ..drawing.snap import draw_snap_marker
+
+        self._snap = None
+        self._snap_handle = bpy.types.SpaceView3D.draw_handler_add(
+            draw_snap_marker, (self, context), "WINDOW", "POST_PIXEL"
+        )
+        return super().invoke(context, event)
+
+    def _end(self, context: Context, succeede, *args, **kwargs):
+        handle = getattr(self, "_snap_handle", None)
+        if handle is not None:
+            bpy.types.SpaceView3D.draw_handler_remove(handle, "WINDOW")
+            self._snap_handle = None
+        return super()._end(context, succeede, *args, **kwargs)
 
     def init(self, context: Context, event: Event):
         from ..model.sketch_ref import get_active_sketch
@@ -26,8 +46,9 @@ class Operator2d(GenericEntityOp):
     @property
     def sketch(self):
         if not self._active_sketch:
-            from ..model.sketch_ref import get_active_sketch
             import bpy
+
+            from ..model.sketch_ref import get_active_sketch
             self._active_sketch = get_active_sketch(bpy.context)
         return self._active_sketch
 
@@ -43,6 +64,7 @@ class Operator2d(GenericEntityOp):
     def state_func(self, context: Context, coords):
         state = self.state
         wp = self._get_wp()
+        self._snap = get_blender_snap_info(context, coords)
         pos = get_pos_2d(context, wp, coords, respect_snapping=True)
 
         # Handle implicit properties based on state.types
@@ -88,7 +110,7 @@ class Operator2d(GenericEntityOp):
 
     def _check_constrain(self, context: Context, curve_id: int):
         """Check if a hovered curve_id is a constrainable type (line/arc/circle)."""
-        from ..model.curve_ref import LineRef, ArcRef, CircleRef
+        from ..model.curve_ref import ArcRef, CircleRef, LineRef
         sketch = self.sketch
         if not sketch:
             return False


### PR DESCRIPTION
Fixes #577.

Shows a screen-space marker at the point the cursor is snapped to, so it's clear when locked onto external geometry. The glyph encodes the snap type — **square = vertex/endpoint, ▽ triangle = edge/face midpoint, X = edge** — which makes face-centre snapping (the reporter's specific gripe) obvious.

Feedback appears in both states, through one shared renderer:
- **Tool active but idle (hovering):** the preselection gizmo (the draw tools' widget) computes the snap in `test_select` and draws it in `draw()`.
- **Mid-draw (operator running, which suspends gizmos):** the draw operator owns a POST_PIXEL handler for the lifetime of its modal.

`draw_snap_marker` sets up its own region-pixel matrix, so the same code renders from either a POST_PIXEL handler or a gizmo `draw()`. Each owner (operator instance / gizmo instance) just holds its own `_snap`; no module-global state. Snapping itself reuses the existing `get_blender_snap_info`.
