### PR TITLE
Fix Blender crash on horizontal/vertical constraint with malformed point ref (#342)

### DIFF
--- a/model/horizontal.py
+++ b/model/horizontal.py
@@ -1,15 +1,15 @@
 import logging
 
-from bpy.types import PropertyGroup
 from bpy.props import StringProperty
+from bpy.types import PropertyGroup
 from bpy.utils import register_classes_factory
 
 from ..curve_solver import Solver
 from ..global_data import WpReq
 from .base_constraint import GenericConstraint
-from .utilities import slvs_entity_pointer
-from .point_2d import SlvsPoint2D
 from .line_2d import SlvsLine2D
+from .point_2d import SlvsPoint2D
+from .utilities import slvs_entity_pointer
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ class SlvsHorizontal(GenericConstraint, PropertyGroup):
 
         kwargs = {}
         if self.entity1.is_point():
-            kwargs['entityB'] = self.entity2.py_data
+            kwargs["entityB"] = self.entity2.py_data
 
         return solvesys.horizontal(group, self.entity1.py_data, wp, **kwargs)
 
@@ -54,11 +54,25 @@ class SlvsHorizontal(GenericConstraint, PropertyGroup):
         if h1 is None:
             return None
 
+        # The solver form depends on the first entity's *type*, not merely on
+        # whether a second curve id is stored: a line is constrained on its own,
+        # a point needs a valid partner point. Old/corrupt files can leave a
+        # point-based constraint without a resolvable partner -- feeding that to
+        # the single-line form makes solvespace treat a point as a line and
+        # crash Blender (issue #342), so skip anything we can't build cleanly.
+        ref1 = self.ref(1)
         kwargs = {}
-        if self.curve_id_2:
-            h2 = handle_map.get(self.curve_id_2)
-            if h2:
-                kwargs['entityB'] = h2
+        if ref1 and ref1.is_line():
+            pass  # single-line form
+        elif ref1 and ref1.is_point():
+            h2 = handle_map.get(self.curve_id_2) if self.curve_id_2 else None
+            if h2 is None:
+                self.failed = True
+                return None
+            kwargs["entityB"] = h2
+        else:
+            self.failed = True
+            return None
 
         return solvesys.horizontal(group, h1, wp, **kwargs)
 

--- a/model/vertical.py
+++ b/model/vertical.py
@@ -1,15 +1,15 @@
 import logging
 
-from bpy.types import PropertyGroup
 from bpy.props import StringProperty
+from bpy.types import PropertyGroup
 from bpy.utils import register_classes_factory
 
 from ..curve_solver import Solver
 from ..global_data import WpReq
 from .base_constraint import GenericConstraint
-from .utilities import slvs_entity_pointer
-from .point_2d import SlvsPoint2D
 from .line_2d import SlvsLine2D
+from .point_2d import SlvsPoint2D
+from .utilities import slvs_entity_pointer
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ class SlvsVertical(GenericConstraint, PropertyGroup):
         kwargs = {}
 
         if self.entity1.is_point():
-            kwargs['entityB'] = self.entity2.py_data
+            kwargs["entityB"] = self.entity2.py_data
 
         return solvesys.vertical(group, self.entity1.py_data, wp, **kwargs)
 
@@ -53,11 +53,23 @@ class SlvsVertical(GenericConstraint, PropertyGroup):
         if h1 is None:
             return None
 
+        # See SlvsHorizontal: pick the solver form from the first entity's type,
+        # not from the presence of a second curve id. A point-based constraint
+        # with no resolvable partner would otherwise be passed as the single-line
+        # form and crash the solver on old/corrupt files (issue #342).
+        ref1 = self.ref(1)
         kwargs = {}
-        if self.curve_id_2:
-            h2 = handle_map.get(self.curve_id_2)
-            if h2:
-                kwargs['entityB'] = h2
+        if ref1 and ref1.is_line():
+            pass  # single-line form
+        elif ref1 and ref1.is_point():
+            h2 = handle_map.get(self.curve_id_2) if self.curve_id_2 else None
+            if h2 is None:
+                self.failed = True
+                return None
+            kwargs["entityB"] = h2
+        else:
+            self.failed = True
+            return None
 
         return solvesys.vertical(group, h1, wp, **kwargs)
 

--- a/testing/test_constraint_init.py
+++ b/testing/test_constraint_init.py
@@ -41,6 +41,28 @@ class TestConstraintAdd(Sketch2dTestCase):
         self.solve()
         self.assertAlmostEqual(p2.co.x, 0.0)
 
+    # -- solver safety net (issue #342) --------------------------------------
+    # An old/corrupt file can carry a point-based horizontal/vertical whose
+    # partner point didn't survive versioning. Feeding that single point to the
+    # solver's line form makes solvespace treat a point as a line and hard-abort
+    # (crashes Blender). It must be skipped and marked failed, never reach the
+    # solver.
+    def test_horizontal_point_without_partner_does_not_crash(self):
+        sc = self.sketch.constraints
+
+        p0 = self.add_point((0, 0), fixed=True)
+        c = sc.add_horizontal(curve_id_1=p0.curve_id)  # no curve_id_2
+        self.solve()
+        self.assertTrue(c.failed)
+
+    def test_vertical_point_without_partner_does_not_crash(self):
+        sc = self.sketch.constraints
+
+        p0 = self.add_point((0, 0), fixed=True)
+        c = sc.add_vertical(curve_id_1=p0.curve_id)  # no curve_id_2
+        self.solve()
+        self.assertTrue(c.failed)
+
     def test_tangent(self):
         sc = self.sketch.constraints
 

--- a/testing/test_constraint_init.py
+++ b/testing/test_constraint_init.py
@@ -1,5 +1,4 @@
 import math
-from unittest import skip
 
 from .utils import Sketch2dTestCase
 


### PR DESCRIPTION
## Problem

Opening the reporter's file from #342 and pressing the solve/refresh button crashes Blender outright. The last output before the process dies is:

```
Invalid arguments for horizontal constraint
```

That message comes from the native solvespace library, immediately before an internal `oops()`/assert that **aborts the process** — a C-level abort our Python `try/except` around constraint init cannot catch.

## Cause

`SlvsHorizontal`/`SlvsVertical.create_slvs_data_from_curves` chose the solver form (single-line vs. two-point) based on *whether a second curve id was stored*, not on the first entity's actual type. An old/corrupt file can carry a **point-based** horizontal/vertical whose partner point didn't survive versioning. With no resolvable partner, the code fell through to the single-line form and handed a **point** to solvespace as if it were a line → treated as a line → assert → hard crash.

## Fix

Pick the form from the first entity's real type (`self.ref(1)`):

- line → single-line form,
- point → two-point form, but **only** with a valid partner handle; otherwise skip and mark the constraint `failed`,
- anything else → skip and mark failed.

A skipped constraint surfaces as a normal solver-failed state on the sketch instead of killing Blender.

## Verification

Reproduced headlessly against the reporter's `box.blend`:

- **before:** process hard-aborts at `Invalid arguments for horizontal constraint` while solving the first sketch.
- **after:** all three sketches solve, no crash; the malformed sketch reports a solver failure (`ok=False`) as expected.

Added regression tests (`test_constraint_init.py`) for the point-without-partner horizontal and vertical forms; the full `test_constraint_init` module (14 tests, incl. the existing valid point-pair/line forms) passes.