### PR TITLE
Snapping while dragging: marker, anchor, orthogonal projection

### DIFF
--- a/operators/tweak.py
+++ b/operators/tweak.py
@@ -7,9 +7,12 @@ from ..curve_solver import CurveSolver
 from ..declarations import Operators
 from ..drawing import selection
 from ..drawing.snap import draw_snap_marker
+from ..model.constants import SketchCurveType
+from ..model.curve_ref import PointRef
 from ..model.sketch_ref import get_active_sketch
 from ..utilities.curve_data import (
     get_curve_data,
+    get_curve_type,
     refresh_curve_geometry,
 )
 from ..utilities.view import (
@@ -96,6 +99,14 @@ class View3D_OT_slvs_tweak(Operator):
 
     def modal(self, context: Context, event: Event):
         if event.type == "LEFTMOUSE" and event.value == "RELEASE":
+            # Dragging a point onto an external-geometry snap anchors it there,
+            # matching placement snapping (issue #106) — otherwise a later solve
+            # could pull the point back off the snapped location.
+            if (
+                self._snap is not None
+                and get_curve_type(self.sketch, self.curve_id) == SketchCurveType.POINT
+            ):
+                PointRef(self.sketch, self.curve_id).fixed = True
             # Topology rebuild to trigger GN modifier refresh
             refresh_curve_geometry(self.sketch)
             self._remove_snap_marker()

--- a/operators/tweak.py
+++ b/operators/tweak.py
@@ -1,14 +1,23 @@
-from bpy.types import Operator, Context, Event
-from ..model.sketch_ref import get_active_sketch
+import bpy
+from bpy.types import Context, Event, Operator
 from bpy.utils import register_classes_factory
 
 from .. import global_data
-from ..drawing import selection
-from ..declarations import Operators
 from ..curve_solver import CurveSolver
-from ..utilities.view import get_picking_origin_dir, get_pos_2d, get_wp_matrix
-from ..utilities.curve_data import get_curve_data, get_curve_type, refresh_curve_geometry
-from ..model.constants import SketchCurveType
+from ..declarations import Operators
+from ..drawing import selection
+from ..drawing.snap import draw_snap_marker
+from ..model.sketch_ref import get_active_sketch
+from ..utilities.curve_data import (
+    get_curve_data,
+    refresh_curve_geometry,
+)
+from ..utilities.view import (
+    get_blender_snap_info,
+    get_picking_origin_dir,
+    get_pos_2d,
+    get_wp_matrix,
+)
 
 
 class View3D_OT_slvs_tweak(Operator):
@@ -17,6 +26,25 @@ class View3D_OT_slvs_tweak(Operator):
     bl_idname = Operators.Tweak
     bl_label = "Tweak Solvespace Entities"
     bl_options = {"UNDO"}
+
+    # Current geometry snap target for the marker (dict from get_blender_snap_info
+    # or None), and the POST_PIXEL draw handle that renders it while dragging.
+    _snap = None
+    _snap_handle = None
+
+    def _register_snap_marker(self, context: Context):
+        """Show the same snap marker the draw tools use, for the drag's lifetime."""
+        self._snap = None
+        self._snap_handle = bpy.types.SpaceView3D.draw_handler_add(
+            draw_snap_marker, (self, context), "WINDOW", "POST_PIXEL"
+        )
+
+    def _remove_snap_marker(self):
+        handle = getattr(self, "_snap_handle", None)
+        if handle is not None:
+            bpy.types.SpaceView3D.draw_handler_remove(handle, "WINDOW")
+            self._snap_handle = None
+        self._snap = None
 
     def _get_wp(self):
         """The sketch's workplane object (same resolution as the solver uses)."""
@@ -62,6 +90,7 @@ class View3D_OT_slvs_tweak(Operator):
 
         self.depth = (pos - origin).length
 
+        self._register_snap_marker(context)
         context.window_manager.modal_handler_add(self)
         return {"RUNNING_MODAL"}
 
@@ -69,6 +98,7 @@ class View3D_OT_slvs_tweak(Operator):
         if event.type == "LEFTMOUSE" and event.value == "RELEASE":
             # Topology rebuild to trigger GN modifier refresh
             refresh_curve_geometry(self.sketch)
+            self._remove_snap_marker()
             context.window.cursor_modal_restore()
             return {"FINISHED"}
 
@@ -78,6 +108,9 @@ class View3D_OT_slvs_tweak(Operator):
             coords = (event.mouse_region_x, event.mouse_region_y)
 
             global_data.snap_bypass = bool(event.shift)  # Shift bypasses snapping
+            # Same snap target the position uses, surfaced as a marker while
+            # dragging (issue #106).
+            self._snap = get_blender_snap_info(context, coords)
             pos = self._get_tweak_pos(context, coords)
             if pos is None:
                 return {"RUNNING_MODAL"}

--- a/utilities/view.py
+++ b/utilities/view.py
@@ -12,10 +12,8 @@ from mathutils.geometry import intersect_line_line, intersect_line_plane
 
 
 def get_picking_origin_dir(context: Context, coords: Vector) -> Tuple[Vector, Vector]:
-    scene = context.scene
     region = context.region
     rv3d = context.region_data
-    viewlayer = context.view_layer
 
     # get the ray from the viewport and mouse
     view_vector = region_2d_to_vector_3d(region, rv3d, coords)
@@ -24,10 +22,8 @@ def get_picking_origin_dir(context: Context, coords: Vector) -> Tuple[Vector, Ve
 
 
 def get_picking_origin_end(context: Context, coords: Vector) -> Tuple[Vector, Vector]:
-    scene = context.scene
     region = context.region
     rv3d = context.region_data
-    viewlayer = context.view_layer
 
     # get the ray from the viewport and mouse
     view_vector = region_2d_to_vector_3d(region, rv3d, coords)
@@ -512,9 +508,14 @@ def get_pos_2d(
     if respect_snapping:
         snap_info = get_blender_snap_info(context, coords)
         if snap_info and "world_point" in snap_info:
-            # Project the snapped 3D point onto the workplane along the view ray.
+            # Drop the snapped 3D point straight onto the workplane -- its
+            # orthogonal projection (foot of the perpendicular), not where the
+            # view ray happens to cross the plane. So an edge floating above the
+            # ground snaps to its footprint on the workplane, independent of the
+            # viewing angle.
+            wp_point = snap_info["world_point"]
             closest_point = intersect_line_plane(
-                snap_info["world_point"], origin, wp_origin, wp_normal
+                wp_point, wp_point + wp_normal, wp_origin, wp_normal
             )
             if closest_point is None:
                 return None


### PR DESCRIPTION
Extends snap feedback (#577) to the drag path and fixes how snaps map onto the workplane, from discussion #106.

**Marker.** The tweak (drag) operator now registers the shared `draw_snap_marker` as a POST_PIXEL handler for the drag's lifetime and refreshes its target each mouse-move, so the same marker the placement tools show appears while dragging existing geometry. Shift still bypasses snapping.

**Anchor.** When a point drag ends on an external-geometry snap, the point is set `fixed` so a later solve keeps it at the snapped location. Point drags only.

**Orthogonal projection.** `get_pos_2d` projected the snapped 3D point onto the workplane along the view/cursor ray, so a feature floating above the plane (e.g. a cube edge) snapped to wherever the line of sight crossed the ground — drifting with the viewing angle. It now projects **orthogonally** (foot of the perpendicular), so the point lands on the feature's footprint on the workplane regardless of view. This also fixes placement snapping.

Also drops pre-existing unused imports/locals in the touched files.

Scope: covers the click-drag (`tweak`) path; the grab-selection Move operator still doesn't snap. Placement-time snap anchoring is a companion change in #589.