### PR TITLE
Anchor points snapped to external geometry

### DIFF
--- a/operators/add_arc.py
+++ b/operators/add_arc.py
@@ -58,6 +58,8 @@ class View3D_OT_slvs_add_arc2d(Operator, Operator2d):
         wp = self._get_wp()
         snap_data = get_blender_snap_info(context, coords)
         self._snap = snap_data
+        # Anchor the endpoint if it landed on external geometry (see base_2d).
+        self.state_data["snapped"] = snap_data is not None
         mouse_pos = get_pos_2d(context, wp, coords, respect_snapping=True)
         if mouse_pos is None:
             return None

--- a/operators/add_line_2d.py
+++ b/operators/add_line_2d.py
@@ -1,16 +1,15 @@
 import logging
 
-from bpy.types import Operator, Context
 from bpy.props import BoolProperty
+from bpy.types import Context, Operator
 from mathutils import Vector
 
-from ..utilities.constants import HALF_TURN, QUARTER_TURN
-
-from ..declarations import Operators
-from ..stateful_operator.utilities.register import register_stateops_factory
-from ..stateful_operator.state import state_from_args
 from ..curve_solver import solve_system
+from ..declarations import Operators
 from ..model.curve_ref import LineRef
+from ..stateful_operator.state import state_from_args
+from ..stateful_operator.utilities.register import register_stateops_factory
+from ..utilities.constants import HALF_TURN, QUARTER_TURN
 from .base_2d import Operator2d
 from .constants import types_point_2d
 from .utilities import ignore_hover
@@ -54,10 +53,13 @@ class View3D_OT_slvs_add_line2d(Operator, Operator2d):
         self.target = LineRef.create(sketch, p1, p2, construction=construction)
         line_cid = self.target.curve_id
 
-        # auto vertical/horizontal constraint
+        # auto vertical/horizontal constraint. Skip it when both endpoints are
+        # anchored (e.g. both snapped to external geometry): the alignment can't
+        # move either point, so adding it would just make the sketch inconsistent.
         self.has_alignment = False
+        both_fixed = self.target.p1.fixed and self.target.p2.fixed
         vec_dir = self.target.direction_vec()
-        if vec_dir.length and self.use_auto_constraints(context):
+        if vec_dir.length and self.use_auto_constraints(context) and not both_fixed:
             angle = vec_dir.angle(Vector((1, 0)))
 
             threshold = 0.1

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -67,6 +67,11 @@ class Operator2d(GenericEntityOp):
         self._snap = get_blender_snap_info(context, coords)
         pos = get_pos_2d(context, wp, coords, respect_snapping=True)
 
+        # Remember whether this point landed on an external-geometry snap, so its
+        # deferred creation can anchor it (fixed) — otherwise an inferred
+        # constraint would drag the snapped point off target (see create_element).
+        self.state_data["snapped"] = self._snap is not None
+
         # Handle implicit properties based on state.types
         if SlvsPoint2D in state.types:
             return pos
@@ -98,7 +103,12 @@ class Operator2d(GenericEntityOp):
         sketch = self.sketch
         loc = values[0]
 
-        ref = PointRef.create(sketch, loc)
+        # A point snapped to external geometry is a deliberate placement: fix it
+        # so the solver keeps it there. Points snapped onto a sketch entity are
+        # pinned by the coincident constraint below instead, so skip those.
+        fixed = state_data.get("snapped", False) and not state_data.get("hovered")
+
+        ref = PointRef.create(sketch, loc, fixed=fixed)
         cid = ref.curve_id
 
         self.add_coincident(context, ref, state, state_data)

--- a/testing/test_prefill.py
+++ b/testing/test_prefill.py
@@ -15,8 +15,8 @@ import re
 from pathlib import Path
 from unittest import TestCase
 
-from .utils import Sketch2dTestCase, OpHarness
 from ..drawing import selection
+from .utils import OpHarness, Sketch2dTestCase
 
 
 class TestSelectionPrefill(Sketch2dTestCase):
@@ -35,9 +35,9 @@ class TestSelectionPrefill(Sketch2dTestCase):
 
     # -- a selected point fills the first (point) pointer state ---------------
     def test_selected_point_prefills_first_state(self):
-        from ..operators.add_line_2d import View3D_OT_slvs_add_line2d
-        from ..operators.add_circle import View3D_OT_slvs_add_circle2d
         from ..operators.add_arc import View3D_OT_slvs_add_arc2d
+        from ..operators.add_circle import View3D_OT_slvs_add_circle2d
+        from ..operators.add_line_2d import View3D_OT_slvs_add_line2d
         from ..operators.add_rectangle import View3D_OT_slvs_add_rectangle
 
         point_ops = (
@@ -64,9 +64,9 @@ class TestSelectionPrefill(Sketch2dTestCase):
 
     # -- a selected segment fills the first (segment) pointer state -----------
     def test_selected_segment_prefills_first_state(self):
+        from ..operators.bevel import View3D_OT_slvs_bevel
         from ..operators.offset import View3D_OT_slvs_add_offset
         from ..operators.trim import View3D_OT_slvs_trim
-        from ..operators.bevel import View3D_OT_slvs_bevel
 
         segment_ops = (
             View3D_OT_slvs_add_offset,  # entity
@@ -103,6 +103,39 @@ class TestSelectionPrefill(Sketch2dTestCase):
         self.assertEqual(line.p1.curve_id, pt.curve_id)
         # The endpoint is a freshly created point, not the selected one.
         self.assertNotEqual(line.p2.curve_id, pt.curve_id)
+
+    # -- a point placed on an external snap is anchored (issue #106) -----------
+    def test_external_snap_creates_fixed_point(self):
+        """A point placed on an external-geometry snap is created fixed, so a
+        later inferred constraint (e.g. auto vertical/horizontal) adjusts the
+        free endpoint instead of dragging the snapped one off its target."""
+        from ..operators.add_line_2d import View3D_OT_slvs_add_line2d
+
+        h = self._harness(View3D_OT_slvs_add_line2d)
+        h.place_point((0.0, 0.0))                 # start point (a click)
+        h.op.get_state_data(0)["snapped"] = True  # simulate an external snap
+        h.place_point((3.0, 1.0))                 # endpoint, not snapped
+        h.finish()
+
+        line = h.op.target
+        self.assertTrue(line.p1.fixed)            # snapped start -> anchored
+        self.assertFalse(line.p2.fixed)           # free endpoint stays free
+
+    def test_both_ends_snapped_skips_inferred_alignment(self):
+        """When both endpoints are snapped (fixed), the inferred vertical/
+        horizontal is skipped -- it could only over-constrain two pinned points
+        and flip the sketch to inconsistent."""
+        from ..operators.add_line_2d import View3D_OT_slvs_add_line2d
+
+        h = self._harness(View3D_OT_slvs_add_line2d)
+        h.place_point((0.0, 0.0))
+        h.op.get_state_data(0)["snapped"] = True
+        h.place_point((0.05, 3.0))                # almost vertical, both snapped
+        h.op.get_state_data(1)["snapped"] = True
+        h.finish()
+
+        self.assertFalse(h.op.has_alignment)      # no inferred constraint added
+        self.assertNotEqual(self.sketch.solver_state, "INCONSISTENT")
 
     # -- immediate execution: a full selection fills every state at once ------
     def test_two_selected_points_complete_line_immediately(self):


### PR DESCRIPTION
From discussion #106: an inferred vertical/horizontal could drag a point off the location the user snapped it to.

**Cause.** Snapping a point to external Blender geometry is position-only — you can't coincidence-constrain a sketch point to a non-sketch vertex — so the solver treats the snapped point as free. Adding an inferred alignment then lets the solver satisfy it by moving *both* endpoints, sliding the snapped one off target.

**Fix.** Record the snap on the point's placement state (reusing the `get_blender_snap_info` already computed for the marker) and create such points `fixed`, so the inferred constraint adjusts the *free* endpoint instead. Points snapped onto a *sketch* entity are skipped — the coincident constraint already pins them. Covers the shared 2D point path and the arc endpoint.

Also skips the inferred line alignment when *both* endpoints are anchored — it could only over-constrain two pinned points and flip the sketch to inconsistent.

**Tests** (`test_prefill.py`): a snapped start is created fixed while the free end isn't; both-ends-snapped adds no inferred constraint and stays consistent.

Companion to #588 (drag-path marker + anchor-on-drag); independent files, so either can merge first.