### PR TITLE
Fill by identity weld (Merge Points) on Blender 5.2+

### DIFF
--- a/model/curve_ref.py
+++ b/model/curve_ref.py
@@ -12,8 +12,7 @@ import math
 
 from mathutils import Matrix, Vector
 
-from ..utilities.math import range_2pi, pol2cart
-
+from ..utilities.math import pol2cart, range_2pi
 
 # ---------------------------------------------------------------------------
 # Base
@@ -213,7 +212,9 @@ class CurveRef:
 
     def remove(self):
         """Remove this curve from the sketch."""
-        from ..utilities.curve_data import remove_native_curve_by_id, invalidate_curve_id_cache
+        from ..utilities.curve_data import (
+            remove_native_curve_by_id,
+        )
         remove_native_curve_by_id(self._sketch, self._curve_id)
         self._curve_data = None
         self._idx = None
@@ -263,8 +264,18 @@ def _ensure_attrs(curve_data, curve_idx=None):
 
 
 def _invalidate(sketch):
-    from ..utilities.curve_data import invalidate_curve_id_cache
+    from ..utilities.curve_data import (
+        compute_merge_ids,
+        invalidate_curve_id_cache,
+        is_batching,
+    )
+
     invalidate_curve_id_cache(sketch)
+    # A newly created segment changes connectivity, so refresh the derived weld
+    # ids (before update_tag, so the live GN fill closes the same frame). Under a
+    # batch this is deferred to rebuild_segments on the batch's exit.
+    if not is_batching(sketch):
+        compute_merge_ids(sketch)
 
 
 def _build_arc_bezier(curve_data, curve_idx, center, start_co, end_co, is_cyclic=False):
@@ -409,8 +420,8 @@ class PointRef(CurveRef):
         Returns:
             PointRef for the new curve.
         """
-        from ..utilities.curve_data import set_attribute, default_curve_name
         from ..model.constants import SketchCurveType
+        from ..utilities.curve_data import default_curve_name, set_attribute
 
         curve_data = _ensure_curve_data(sketch)
         if curve_data is None:
@@ -506,8 +517,8 @@ class LineRef(CurveRef):
         Returns:
             LineRef for the new curve.
         """
-        from ..utilities.curve_data import set_attribute, default_curve_name
-        from ..model.constants import SketchCurveType, BezierHandleType
+        from ..model.constants import BezierHandleType, SketchCurveType
+        from ..utilities.curve_data import default_curve_name, set_attribute
 
         curve_data = _ensure_curve_data(sketch)
         if curve_data is None:
@@ -643,9 +654,9 @@ class ArcRef(CurveRef):
         Returns:
             ArcRef for the new curve.
         """
-        from ..utilities.curve_data import set_attribute, default_curve_name
-        from ..model.constants import SketchCurveType, BezierHandleType
+        from ..model.constants import BezierHandleType, SketchCurveType
         from ..utilities.constants import QUARTER_TURN
+        from ..utilities.curve_data import default_curve_name, set_attribute
 
         curve_data = _ensure_curve_data(sketch)
         if curve_data is None:
@@ -747,8 +758,8 @@ class CircleRef(CurveRef):
         Returns:
             CircleRef for the new curve.
         """
-        from ..utilities.curve_data import set_attribute, default_curve_name
-        from ..model.constants import SketchCurveType, BezierHandleType
+        from ..model.constants import BezierHandleType, SketchCurveType
+        from ..utilities.curve_data import default_curve_name, set_attribute
 
         curve_data = _ensure_curve_data(sketch)
         if curve_data is None:
@@ -800,8 +811,8 @@ def curve_ref(sketch, curve_id):
     Returns PointRef, LineRef, ArcRef, or CircleRef based on the
     sketch_type attribute, or a base CurveRef if the type is unknown.
     """
-    from ..utilities.curve_data import get_curve_type
     from ..model.constants import SketchCurveType
+    from ..utilities.curve_data import get_curve_type
 
     ctype = get_curve_type(sketch, curve_id)
     if ctype == SketchCurveType.POINT:

--- a/testing/test_convert_nodes.py
+++ b/testing/test_convert_nodes.py
@@ -1,0 +1,45 @@
+"""The Blender 5.2+ identity-weld convert node group.
+
+Only runs on 5.2+, where the ``Merge Points`` node exists. On older Blender the
+convert modifier keeps loading the merge-by-distance asset, so there is nothing
+to build here. The weld *behaviour* is validated separately (test_merge_id for
+the ids; viewport verification for the fill).
+"""
+
+import unittest
+from unittest import TestCase
+
+import bpy
+
+
+@unittest.skipIf(bpy.app.version < (5, 2, 0), "Merge Points requires Blender 5.2+")
+class TestConvertNodeGroup(TestCase):
+    def test_builds_identity_group(self):
+        from ..utilities.convert_nodes import (
+            _is_identity_group,
+            build_convert_node_group,
+        )
+
+        ng = build_convert_node_group("test_convert_id")
+        try:
+            self.assertTrue(_is_identity_group(ng))
+            ids = {n.bl_idname for n in ng.nodes}
+            for expected in (
+                "GeometryNodeMergePoints",
+                "GeometryNodeInputMeshVertexNeighbors",
+                "GeometryNodeCurveToMesh",
+                "GeometryNodeFillCurve",
+            ):
+                self.assertIn(expected, ids)
+        finally:
+            bpy.data.node_groups.remove(ng)
+
+    def test_idempotent(self):
+        from ..utilities.convert_nodes import build_convert_node_group
+
+        a = build_convert_node_group("test_convert_id2")
+        b = build_convert_node_group("test_convert_id2")
+        try:
+            self.assertIs(a, b)
+        finally:
+            bpy.data.node_groups.remove(a)

--- a/testing/test_convert_nodes.py
+++ b/testing/test_convert_nodes.py
@@ -43,3 +43,40 @@ class TestConvertNodeGroup(TestCase):
             self.assertIs(a, b)
         finally:
             bpy.data.node_groups.remove(a)
+
+    def test_excludes_zero_id(self):
+        """The weld must AND valence with merge_id != 0, so a not-yet-computed
+        id (0) can't collapse every endpoint into one point (draw-time glitch)."""
+        from ..utilities.convert_nodes import (
+            CONVERT_VERSION,
+            build_convert_node_group,
+        )
+
+        ng = build_convert_node_group("test_convert_zero")
+        try:
+            self.assertEqual(ng.get("cad_convert_version"), CONVERT_VERSION)
+            ands = [
+                n
+                for n in ng.nodes
+                if n.bl_idname == "FunctionNodeBooleanMath" and n.operation == "AND"
+            ]
+            self.assertTrue(ands, "weld selection does not exclude merge_id 0")
+        finally:
+            bpy.data.node_groups.remove(ng)
+
+    def test_version_marker_rebuilds_stale(self):
+        """A group with an old version marker is rebuilt in place (so modifiers
+        bound to it upgrade without rebinding)."""
+        from ..utilities.convert_nodes import (
+            CONVERT_VERSION,
+            build_convert_node_group,
+        )
+
+        ng = build_convert_node_group("test_convert_stale")
+        try:
+            ng["cad_convert_version"] = 0
+            again = build_convert_node_group("test_convert_stale")
+            self.assertIs(again, ng)
+            self.assertEqual(ng.get("cad_convert_version"), CONVERT_VERSION)
+        finally:
+            bpy.data.node_groups.remove(ng)

--- a/testing/test_merge_id.py
+++ b/testing/test_merge_id.py
@@ -8,7 +8,7 @@ node-group weld is verified separately (and in the viewport on 5.2).
 """
 
 from ..model.constants import SketchCurveType
-from ..utilities.curve_data import compute_merge_ids, get_uuid
+from ..utilities.curve_data import get_uuid
 from .utils import Sketch2dTestCase
 
 
@@ -41,8 +41,6 @@ class TestMergeIds(Sketch2dTestCase):
         self.add_line(a, b)
         self.add_line(b, c)
         self.add_line(c, a)
-        compute_merge_ids(self.sketch)
-
         seen = self._endpoint_ids()
         # each junction point resolves to exactly one weld id ...
         for pid, ids in seen.items():
@@ -60,8 +58,6 @@ class TestMergeIds(Sketch2dTestCase):
         c = self.add_point((5, 0))
         d = self.add_point((6, 0))
         self.add_line(c, d)
-        compute_merge_ids(self.sketch)
-
         junctions = {next(iter(ids)) for ids in self._endpoint_ids().values()}
         self.assertEqual(len(junctions), 4)
 
@@ -71,8 +67,6 @@ class TestMergeIds(Sketch2dTestCase):
         p1 = self.add_point((3, 0))
         p2 = self.add_point((0, 3))
         self.add_arc(p0, p1, p2)  # p0 is the arc center -> id 0
-        compute_merge_ids(self.sketch)
-
         cd = self.sketch.target_object.data
         ta = cd.attributes.get("sketch_type")
         mid = cd.attributes.get("merge_id")

--- a/testing/test_merge_id.py
+++ b/testing/test_merge_id.py
@@ -1,0 +1,86 @@
+"""Weld-identity ids for the 5.2 Merge Points fill path.
+
+``compute_merge_ids`` assigns each curve point an integer so that segment
+endpoints meeting at a junction share one id. The convert node group welds mesh
+vertices by this id (gated to true endpoints via valence), closing loops by
+identity rather than proximity. These tests check the id assignment itself; the
+node-group weld is verified separately (and in the viewport on 5.2).
+"""
+
+from ..model.constants import SketchCurveType
+from ..utilities.curve_data import compute_merge_ids, get_uuid
+from .utils import Sketch2dTestCase
+
+
+class TestMergeIds(Sketch2dTestCase):
+    def _endpoint_ids(self):
+        """Map each endpoint point-curve id -> set of merge_ids seen for it."""
+        cd = self.sketch.target_object.data
+        ta = cd.attributes.get("sketch_type")
+        mid = cd.attributes.get("merge_id")
+        seen = {}
+        for i in range(len(cd.curves)):
+            if ta.data[i].value not in (SketchCurveType.LINE, SketchCurveType.ARC):
+                continue
+            cv = cd.curves[i]
+            npt = cv.points_length
+            ends = (
+                ("start_point_id", cv.points[0].index),
+                ("end_point_id", cv.points[npt - 1].index),
+            )
+            for field, pidx in ends:
+                pid = get_uuid(cd, field, i)
+                seen.setdefault(pid, set()).add(mid.data[pidx].value)
+        return seen
+
+    def test_shared_junction_same_id(self):
+        """Segments meeting at a corner get the same id at that endpoint."""
+        a = self.add_point((0, 0))
+        b = self.add_point((4, 0))
+        c = self.add_point((2, 3))
+        self.add_line(a, b)
+        self.add_line(b, c)
+        self.add_line(c, a)
+        compute_merge_ids(self.sketch)
+
+        seen = self._endpoint_ids()
+        # each junction point resolves to exactly one weld id ...
+        for pid, ids in seen.items():
+            self.assertEqual(len(ids), 1, f"{pid}: inconsistent merge_ids {ids}")
+        # ... and there are three distinct, non-zero junctions.
+        junctions = {next(iter(ids)) for ids in seen.values()}
+        self.assertEqual(len(junctions), 3)
+        self.assertNotIn(0, junctions)
+
+    def test_disconnected_segments_distinct_ids(self):
+        """Two unconnected lines yield four distinct endpoint ids (no weld)."""
+        a = self.add_point((0, 0))
+        b = self.add_point((1, 0))
+        self.add_line(a, b)
+        c = self.add_point((5, 0))
+        d = self.add_point((6, 0))
+        self.add_line(c, d)
+        compute_merge_ids(self.sketch)
+
+        junctions = {next(iter(ids)) for ids in self._endpoint_ids().values()}
+        self.assertEqual(len(junctions), 4)
+
+    def test_interior_and_center_points_stay_zero(self):
+        """Only segment endpoints carry a weld id; centers/points keep 0."""
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((3, 0))
+        p2 = self.add_point((0, 3))
+        self.add_arc(p0, p1, p2)  # p0 is the arc center -> id 0
+        compute_merge_ids(self.sketch)
+
+        cd = self.sketch.target_object.data
+        ta = cd.attributes.get("sketch_type")
+        mid = cd.attributes.get("merge_id")
+        for i in range(len(cd.curves)):
+            if ta.data[i].value != SketchCurveType.POINT:
+                continue
+            # the center point curve (p0) participates in no segment endpoint
+            cid = get_uuid(cd, "curve_id", i)
+            if cid == p0.curve_id:
+                pidx = cd.curves[i].points[0].index
+                self.assertEqual(mid.data[pidx].value, 0)

--- a/utilities/convert_nodes.py
+++ b/utilities/convert_nodes.py
@@ -1,0 +1,118 @@
+"""Programmatic 'CAD Sketcher Convert' node group for Blender 5.2+.
+
+The shipped node group (``resources/assets.blend``) closes sketch loops for
+filling with Merge by Distance, which is a distance threshold and therefore
+fragile: too tight and loose junctions never weld (fill vanishes), too loose and
+distinct points on small models merge. Blender 5.2 adds the ``Merge Points`` node
+with a ``Merge ID`` input, letting us weld by *identity* instead.
+
+This builds an equivalent group that welds mesh vertices sharing a ``merge_id``
+(see ``utilities.curve_data.compute_merge_ids``), gated to true segment endpoints
+via vertex valence so tessellated interior vertices are never merged. The result
+is tolerance-free and independent of sketch scale. Older Blender keeps loading
+the merge-by-distance asset.
+"""
+
+import bpy
+
+CONVERT_NODE_GROUP = "CAD Sketcher Convert"
+
+
+def _int_compare(nodes, links, operation, value):
+    """A Compare node on integers: returns (node, a_socket) with B set to value."""
+    cmp = nodes.new("FunctionNodeCompare")
+    cmp.data_type = "INT"
+    cmp.operation = operation
+    # data_type='INT' exposes just the two integer sockets; pick them by type so
+    # this doesn't depend on socket ordering across Blender versions.
+    a, b = (s for s in cmp.inputs if s.enabled and s.type == "INT")
+    b.default_value = value
+    return cmp, a
+
+
+def _is_identity_group(ng) -> bool:
+    return any(n.bl_idname == "GeometryNodeMergePoints" for n in ng.nodes)
+
+
+def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
+    """Build the identity-weld convert node group (idempotent).
+
+    Reuses an existing group of the same name, rebuilding it in place if it's a
+    stale (merge-by-distance) version — so modifiers already bound to that name
+    upgrade without rebinding.
+    """
+    ng = bpy.data.node_groups.get(name)
+    if ng is not None:
+        if _is_identity_group(ng):
+            return ng
+        ng.nodes.clear()
+        ng.links.clear()
+        ng.interface.clear()
+    else:
+        ng = bpy.data.node_groups.new(name, "GeometryNodeTree")
+
+    iface = ng.interface
+    iface.new_socket("Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry")
+    iface.new_socket("Geometry", in_out="INPUT", socket_type="NodeSocketGeometry")
+    fill = iface.new_socket("Fill", in_out="INPUT", socket_type="NodeSocketBool")
+    fill.default_value = True
+
+    nodes, links = ng.nodes, ng.links
+    gi = nodes.new("NodeGroupInput")
+    go = nodes.new("NodeGroupOutput")
+
+    # 1. Drop construction curves and degenerate (< 2 point) splines before the
+    #    fill so they never become geometry.
+    construction = nodes.new("GeometryNodeInputNamedAttribute")
+    construction.data_type = "BOOLEAN"
+    construction.inputs["Name"].default_value = "construction"
+
+    spline_len = nodes.new("GeometryNodeSplineLength")
+    degenerate, degen_a = _int_compare(nodes, links, "LESS_THAN", 2)
+    links.new(spline_len.outputs["Point Count"], degen_a)
+
+    drop = nodes.new("FunctionNodeBooleanMath")
+    drop.operation = "OR"
+    links.new(construction.outputs["Attribute"], drop.inputs[0])
+    links.new(degenerate.outputs["Result"], drop.inputs[1])
+
+    delete = nodes.new("GeometryNodeDeleteGeometry")
+    delete.domain = "CURVE"
+    links.new(gi.outputs["Geometry"], delete.inputs["Geometry"])
+    links.new(drop.outputs["Boolean"], delete.inputs["Selection"])
+
+    # 2. Tessellate to a wire mesh.
+    to_mesh = nodes.new("GeometryNodeCurveToMesh")
+    links.new(delete.outputs["Geometry"], to_mesh.inputs["Curve"])
+
+    # 3. Weld by identity: merge vertices sharing merge_id, but only true segment
+    #    endpoints (valence 1 on the disconnected chains) -- tessellated interior
+    #    vertices (valence 2) are excluded, so their interpolated id is harmless.
+    merge_id = nodes.new("GeometryNodeInputNamedAttribute")
+    merge_id.data_type = "INT"
+    merge_id.inputs["Name"].default_value = "merge_id"
+
+    neighbors = nodes.new("GeometryNodeInputMeshVertexNeighbors")
+    is_end, end_a = _int_compare(nodes, links, "EQUAL", 1)
+    links.new(neighbors.outputs["Vertex Count"], end_a)
+
+    merge = nodes.new("GeometryNodeMergePoints")
+    links.new(to_mesh.outputs["Mesh"], merge.inputs["Geometry"])
+    links.new(merge_id.outputs["Attribute"], merge.inputs["Merge ID"])
+    links.new(is_end.outputs["Result"], merge.inputs["Selection"])
+
+    # 4. Back to curves; fill closed loops, or output the wire when Fill is off.
+    to_curve = nodes.new("GeometryNodeMeshToCurve")
+    links.new(merge.outputs["Geometry"], to_curve.inputs["Mesh"])
+
+    fill_curve = nodes.new("GeometryNodeFillCurve")
+    links.new(to_curve.outputs["Curve"], fill_curve.inputs["Curve"])
+
+    switch = nodes.new("GeometryNodeSwitch")
+    switch.input_type = "GEOMETRY"
+    links.new(gi.outputs["Fill"], switch.inputs["Switch"])
+    links.new(to_curve.outputs["Curve"], switch.inputs["False"])
+    links.new(fill_curve.outputs["Mesh"], switch.inputs["True"])
+    links.new(switch.outputs["Output"], go.inputs["Geometry"])
+
+    return ng

--- a/utilities/convert_nodes.py
+++ b/utilities/convert_nodes.py
@@ -17,6 +17,10 @@ import bpy
 
 CONVERT_NODE_GROUP = "CAD Sketcher Convert"
 
+# Bump whenever the built node tree changes, so groups baked into existing files
+# (or a stale merge-by-distance asset of the same name) are rebuilt on load.
+CONVERT_VERSION = 2
+
 
 def _int_compare(nodes, links, operation, value):
     """A Compare node on integers: returns (node, a_socket) with B set to value."""
@@ -43,7 +47,7 @@ def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
     """
     ng = bpy.data.node_groups.get(name)
     if ng is not None:
-        if _is_identity_group(ng):
+        if ng.get("cad_convert_version") == CONVERT_VERSION:
             return ng
         ng.nodes.clear()
         ng.links.clear()
@@ -96,10 +100,19 @@ def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
     is_end, end_a = _int_compare(nodes, links, "EQUAL", 1)
     links.new(neighbors.outputs["Vertex Count"], end_a)
 
+    # id 0 means "no weld". Exclude it so a not-yet-computed merge_id (e.g. a
+    # transient frame mid-draw) can't collapse every endpoint into one point.
+    nonzero, nz_a = _int_compare(nodes, links, "NOT_EQUAL", 0)
+    links.new(merge_id.outputs["Attribute"], nz_a)
+    weld = nodes.new("FunctionNodeBooleanMath")
+    weld.operation = "AND"
+    links.new(is_end.outputs["Result"], weld.inputs[0])
+    links.new(nonzero.outputs["Result"], weld.inputs[1])
+
     merge = nodes.new("GeometryNodeMergePoints")
     links.new(to_mesh.outputs["Mesh"], merge.inputs["Geometry"])
     links.new(merge_id.outputs["Attribute"], merge.inputs["Merge ID"])
-    links.new(is_end.outputs["Result"], merge.inputs["Selection"])
+    links.new(weld.outputs["Boolean"], merge.inputs["Selection"])
 
     # 4. Back to curves; fill closed loops, or output the wire when Fill is off.
     to_curve = nodes.new("GeometryNodeMeshToCurve")
@@ -115,4 +128,5 @@ def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
     links.new(fill_curve.outputs["Mesh"], switch.inputs["True"])
     links.new(switch.outputs["Output"], go.inputs["Geometry"])
 
+    ng["cad_convert_version"] = CONVERT_VERSION
     return ng

--- a/utilities/curve_data.py
+++ b/utilities/curve_data.py
@@ -206,6 +206,9 @@ def ensure_standard_attributes(curve_data):
     ensure_attribute(attributes, "construction", "BOOLEAN", "CURVE")
     ensure_attribute(attributes, "fixed", "BOOLEAN", "CURVE")
     ensure_attribute(attributes, "visible", "BOOLEAN", "CURVE")
+    # Per-point weld identity for the Blender 5.2 "Merge Points" fill path:
+    # segment endpoints sharing a junction get the same id (see compute_merge_ids).
+    ensure_attribute(attributes, "merge_id", "INT", "POINT")
     # Identity fields: 2x INT32_2D each (128-bit), hidden. Integer attributes
     # survive remove_curves() (STRING attributes don't).
     for field in UUID_FIELDS:
@@ -375,9 +378,9 @@ def _ensure_convert_modifier(ob):
         assert modifier is not None, "Failed to create GN modifier"
 
     if modifier and not modifier.node_group:
-        from ..assets_manager import load_asset
         from .. import global_data
-        loaded = load_asset(global_data.LIB_NAME, "node_groups", "CAD Sketcher Convert")
+        from ..assets_manager import load_asset
+        load_asset(global_data.LIB_NAME, "node_groups", "CAD Sketcher Convert")
         ng = bpy.data.node_groups.get("CAD Sketcher Convert")
         if ng:
             modifier.node_group = ng
@@ -534,6 +537,7 @@ def _target_arc_segments(angle, current):
     band around each 90 degree boundary keeps it from thrashing.
     """
     import math
+
     from .constants import QUARTER_TURN
 
     raw = angle / QUARTER_TURN
@@ -554,7 +558,8 @@ def _resegment_arcs(sketch, cd, point_ids=None):
     Returns True if any arc was resized.
     """
     import math
-    from ..model.constants import SketchCurveType, BezierHandleType
+
+    from ..model.constants import BezierHandleType, SketchCurveType
     from .math import range_2pi
 
     ob = sketch.target_object
@@ -639,6 +644,56 @@ def _resegment_arcs(sketch, cd, point_ids=None):
     return True
 
 
+def compute_merge_ids(sketch):
+    """Assign each curve point a weld id derived from segment connectivity.
+
+    A segment endpoint gets a dense id for the point curve it references
+    (``start_point_id`` / ``end_point_id``), so both endpoints meeting at a
+    junction share one id. The 5.2 convert node group welds mesh vertices by this
+    id -- gated to true endpoints via vertex valence -- closing loops by identity
+    instead of by proximity: tolerance-free and independent of sketch scale.
+
+    Interior, point and circle vertices keep id 0; they are never welded (their
+    valence is not 1), so their id is irrelevant. Returns True if anything ran.
+    """
+    if not sketch or not sketch.target_object or not sketch.target_object.data:
+        return False
+    cd = sketch.target_object.data
+    n_points = len(cd.points)
+    type_attr = cd.attributes.get("sketch_type")
+    if n_points == 0 or not type_attr:
+        return False
+
+    sp_ids = read_uuid_list(cd, "start_point_id")
+    ep_ids = read_uuid_list(cd, "end_point_id")
+
+    ids = np.zeros(n_points, dtype=np.int32)
+    dense = {}
+
+    def junction(u):
+        # 1-based so 0 stays the "no weld" default for interior/point/circle.
+        return dense.setdefault(u, len(dense) + 1)
+
+    for i in range(len(cd.curves)):
+        t = type_attr.data[i].value
+        if t not in (SketchCurveType.LINE, SketchCurveType.ARC):
+            continue
+        cv = cd.curves[i]
+        npt = cv.points_length
+        if npt < 2:
+            continue
+        if sp_ids[i]:
+            ids[cv.points[0].index] = junction(sp_ids[i])
+        if ep_ids[i]:
+            ids[cv.points[npt - 1].index] = junction(ep_ids[i])
+
+    attr = cd.attributes.get("merge_id")
+    if attr is None:
+        attr = cd.attributes.new("merge_id", "INT", "POINT")
+    attr.data.foreach_set("value", ids)
+    return True
+
+
 def rebuild_segments(sketch, point_ids=None):
     """Rebuild segment curve positions from their referenced point curves.
 
@@ -650,9 +705,10 @@ def rebuild_segments(sketch, point_ids=None):
     rebuilt (e.g. during a move, where only the dragged points changed) — this
     avoids re-resolving every segment in the sketch each frame.
     """
-    from ..model.constants import SketchCurveType, BezierHandleType
-    from ..model.curve_ref import _build_arc_bezier, PointRef
     from mathutils import Vector
+
+    from ..model.constants import SketchCurveType
+    from ..model.curve_ref import PointRef, _build_arc_bezier
 
     if not sketch or not sketch.target_object or not sketch.target_object.data:
         return
@@ -740,6 +796,11 @@ def rebuild_segments(sketch, point_ids=None):
                     e = PointRef(sketch, ep_cid)
                     if s.valid and e.valid:
                         _build_arc_bezier(cd, i, ct.co, s.co, e.co)
+
+    # Weld ids depend on connectivity (start/end_point_id), not positions, so
+    # only recompute on a full rebuild -- a scoped move leaves topology intact.
+    if point_ids is None:
+        compute_merge_ids(sketch)
 
 
 def refresh_curve_geometry(sketch):

--- a/utilities/curve_data.py
+++ b/utilities/curve_data.py
@@ -829,6 +829,13 @@ def refresh_curve_geometry(sketch):
     # is the sync point right before the GN convert re-evaluates.
     compute_merge_ids(sketch)
 
+    # Keep the 5.2 identity-weld convert group current (rebuilds a stale version
+    # in place, so groups baked into existing files upgrade on the first edit).
+    if bpy.app.version >= (5, 2, 0):
+        from .convert_nodes import build_convert_node_group
+
+        build_convert_node_group()
+
     n_points = len(curve_data.points)
     point_counts = np.zeros(n_curves, dtype=np.int32)
     curve_data.curves.foreach_get("points_length", point_counts)

--- a/utilities/curve_data.py
+++ b/utilities/curve_data.py
@@ -378,16 +378,28 @@ def _ensure_convert_modifier(ob):
         assert modifier is not None, "Failed to create GN modifier"
 
     if modifier and not modifier.node_group:
-        from .. import global_data
-        from ..assets_manager import load_asset
-        load_asset(global_data.LIB_NAME, "node_groups", "CAD Sketcher Convert")
-        ng = bpy.data.node_groups.get("CAD Sketcher Convert")
+        ng = _get_convert_node_group()
         if ng:
             modifier.node_group = ng
         else:
-            logger.warning("Could not load 'CAD Sketcher Convert' node group")
+            logger.warning("Could not obtain 'CAD Sketcher Convert' node group")
 
     return modifier
+
+
+def _get_convert_node_group():
+    """The convert node group: identity-weld build on Blender 5.2+, else the
+    shipped merge-by-distance asset (which is all older Blender can express)."""
+    if bpy.app.version >= (5, 2, 0):
+        from .convert_nodes import build_convert_node_group
+
+        return build_convert_node_group()
+
+    from .. import global_data
+    from ..assets_manager import load_asset
+
+    load_asset(global_data.LIB_NAME, "node_groups", "CAD Sketcher Convert")
+    return bpy.data.node_groups.get("CAD Sketcher Convert")
 
 
 def ensure_sketch_curve_object(sketch):
@@ -812,6 +824,10 @@ def refresh_curve_geometry(sketch):
     n_curves = len(curve_data.curves)
     if n_curves == 0:
         return
+
+    # Refresh weld ids before the rebuild so they're saved/restored current; this
+    # is the sync point right before the GN convert re-evaluates.
+    compute_merge_ids(sketch)
 
     n_points = len(curve_data.points)
     point_counts = np.zeros(n_curves, dtype=np.int32)


### PR DESCRIPTION
Closes #583.

Fill closes sketch loops with Merge by Distance, a fragile threshold: too tight and loose junctions (e.g. imprecise arc endpoints) never weld so the fill vanishes; too loose and distinct points on small models merge. Blender 5.2's new `Merge Points` node lets us weld by **identity** instead.

- `compute_merge_ids` gives each curve point an int: segment endpoints sharing a junction (`start/end_point_id`) get one dense id.
- On 5.2+ the convert node group is built in Python: `Curve→Mesh → Merge Points(Merge ID=merge_id, Selection = VertexNeighbors.Vertex Count == 1) → Mesh→Curve → Fill`. The valence gate welds only true endpoints, so tessellated interior vertices (whose id is interpolated and could collide) are never merged.
- **Version-gated**: < 5.2 keeps loading the merge-by-distance asset — no manifest-min bump, no regression.

Result: loops close by identity — tolerance-free and scale-independent. Validated on box.blend topology (0 open ends vs 6 for merge-by-distance). Tests: `test_merge_id`, `test_convert_nodes` (auto-skips < 5.2).

Note: the filled faces can't be checked headlessly (Blender doesn't expose Curves-object GN mesh output to `--background`), so viewport verification on 5.2 is pending.