### PR TITLE
Fix crash: don't repair origin planes from gizmo setup (#595)

### DIFF
--- a/gizmos/workplane.py
+++ b/gizmos/workplane.py
@@ -5,8 +5,8 @@ from bpy.types import Gizmo, GizmoGroup
 from gpu_extras.batch import batch_for_shader
 from mathutils import Vector
 
-from ..drawing import selection
 from ..declarations import GizmoGroups, Gizmos
+from ..drawing import selection
 from ..shaders import Shaders
 from ..utilities import preferences
 from ..utilities.geometry import face_bounds_in_plane, face_workplane_matrix
@@ -20,7 +20,6 @@ from ..utilities.workplane import (
     wp_plane_bounds,
 )
 from .utilities import context_mode_check
-
 
 # Blender-style axis colors used to tint the origin planes by their normal
 # (XY -> Z/blue, XZ -> Y/green, YZ -> X/red).
@@ -52,10 +51,13 @@ class VIEW3D_GGT_slvs_workplane(GizmoGroup):
         return context_mode_check(context, cls.bl_idname)
 
     def setup(self, context):
-        # Re-assert the origin planes when the tool activates, so a drifted or
-        # missing plane (#571) is restored without needing a depsgraph tick.
-        from ..utilities.workplane import repair_origin_workplanes
-        repair_origin_workplanes(context)
+        # NOTE: don't repair the origin planes here. A GizmoGroup.setup runs in a
+        # restricted context where writing to ID data (Object.matrix_world) is
+        # disallowed -- doing so raised "Writing to ID classes in this context is
+        # not allowed" and broke the whole gizmo group, leaving geometry invisible
+        # and blocking new sketches (#595). The depsgraph handler already repairs
+        # drifted/flattened planes (#571) in a safe context, so nothing is needed
+        # here beyond creating the gizmo.
         self.gizmo = self.gizmos.new(VIEW3D_GT_slvs_workplane.bl_idname)
 
 


### PR DESCRIPTION
Closes #595.

After some copy/delete/create sketch operations, drawn geometry became invisible and new sketches couldn't be created, with:

```
AttributeError: Writing to ID classes in this context is not allowed: WP_XZ, Object data-block, error setting Object.matrix_world
```

**Cause:** the workplane `GizmoGroup.setup` called `repair_origin_workplanes`, which writes `Object.matrix_world`. Gizmo setup runs in a restricted context where writing to ID data is disallowed (enforced on Blender 5.2), so it raised and broke the whole gizmo group.

**Fix:** remove the repair call from gizmo setup. The depsgraph handler already repairs drifted/flattened origin planes (#571) in a safe context, so the gizmo-setup call was both redundant and unsafe.

Verified the origin-workplane repair still works from its safe callers (handler/operator); `test_origin_workplanes` passes. The ID-write-in-gizmo-context restriction can't be reproduced headlessly, so viewport verification (repeat the copy/delete/create flow) is appreciated.