### PR TITLE
Don't draw/pick hidden geometry (workplanes, sketches, meshes)

### DIFF
--- a/model/sketch_ref.py
+++ b/model/sketch_ref.py
@@ -5,8 +5,8 @@ the Sketch wrapper class and helpers for discovery and activation.
 """
 
 import bpy
-from .. import global_data
 
+from .. import global_data
 
 # Custom property keys on the Curves object
 _TAG = "is_cad_sketch"
@@ -85,7 +85,10 @@ class Sketch:
         active = get_active_sketch(context)
         if active and active._obj == self._obj:
             return True
-        return not self._obj.hide_viewport
+        # visible_get() covers the eye-icon hide and collection visibility, not
+        # just hide_viewport (the monitor icon) -- so an eye-hidden sketch isn't
+        # drawn or pickable, matching the workplane overlay behaviour.
+        return self._obj.visible_get()
 
     # -- Solver --
 

--- a/stateful_operator/utilities/geometry.py
+++ b/stateful_operator/utilities/geometry.py
@@ -1,12 +1,12 @@
+from typing import Optional
+
 from bpy.types import Context, Object, RegionView3D
 from bpy_extras import view3d_utils
-from mathutils import Vector
 from bpy_extras.view3d_utils import region_2d_to_location_3d, region_2d_to_vector_3d
+from mathutils import Vector
 
 # TODO: Move into StateOps
 from ..utilities.generic import bvhtree_from_object
-
-from typing import Optional
 
 
 def get_placement_pos(context: Context, coords: Vector) -> Vector:
@@ -50,6 +50,10 @@ def get_mesh_element(
         result, loc, _normal, face_index, ob, _matrix = scene.ray_cast(
             depsgraph, ray_origin, view_vector
         )
+        # ray_cast hits geometry regardless of viewport visibility; don't pick a
+        # face on an object hidden with the eye/monitor icon or via its collection.
+        if result and ob is not None and not ob.visible_get():
+            return None, None, None
     else:
         # Alternatively do a object raycast if we know the object already
         tree = bvhtree_from_object(object)

--- a/utilities/view.py
+++ b/utilities/view.py
@@ -469,10 +469,13 @@ def get_blender_snap_info(context: Context, coords: Vector) -> Optional[dict]:
         # every frame.
         if not hit or hit_ob is None:
             return None
-        if active_obj is None or hit_ob.original != active_obj:
+        # Skip the sketch being drawn in (#591) and any hidden object -- ray_cast
+        # hits geometry regardless of viewport visibility, so without this you
+        # could snap to an invisible mesh. Advance past and keep looking behind.
+        is_active = active_obj is not None and hit_ob.original == active_obj
+        if not is_active and hit_ob.visible_get():
             ob, face_index = hit_ob, hit_face
             break
-        # Advance just past this hit to see what's behind the active sketch.
         ray_origin = Vector(location) + view_vector * 1e-4
     else:
         return None

--- a/utilities/workplane.py
+++ b/utilities/workplane.py
@@ -5,7 +5,6 @@ import math
 import bpy
 from mathutils import Vector
 
-
 # ---------------------------------------------------------------------------
 # Workplane empty IDs for picking
 # ---------------------------------------------------------------------------
@@ -66,7 +65,10 @@ def iter_wp_empties(context):
 
     pick_id = _EMPTY_PICK_START
     for obj in context.scene.objects:
-        if obj.type != 'EMPTY' or obj.name in origin_names or obj.hide_viewport:
+        # visible_get() covers the eye-icon hide and collection visibility too,
+        # not just hide_viewport (the monitor icon) -- an empty hidden with the
+        # eye was still getting its workplane overlay drawn.
+        if obj.type != 'EMPTY' or obj.name in origin_names or not obj.visible_get():
             continue
         yield obj, pick_id
         pick_id += 1
@@ -117,7 +119,7 @@ def hit_test_workplane(context, coords, border_only=False):
     rectangle outline count (used to give the border pick priority over meshes);
     otherwise any hit inside the rectangle counts.
     """
-    from .view import get_pos_2d, get_picking_origin_dir
+    from .view import get_picking_origin_dir, get_pos_2d
 
     half = wp_display_half_size(context)
     border_width = half * WP_BORDER_FRACTION


### PR DESCRIPTION
The pick/draw paths only excluded objects disabled via `hide_viewport` (the monitor icon), so geometry hidden with the **eye icon** (or excluded via its collection) was still drawn and pickable. Fixed across all of them by using `visible_get()` (which covers the eye hide, collection visibility, and the monitor icon):

- **Workplane overlays** (`iter_wp_empties`): an eye-hidden empty no longer draws its overlay or stays pickable (feeds both drawing and `hit_test_workplane`).
- **Sketch curves** (`Sketch.is_visible`): an eye-hidden *inactive* sketch isn't drawn or pickable. The active sketch stays pickable (you're editing it).
- **Mesh snapping** (`get_blender_snap_info`): `scene.ray_cast` hits geometry regardless of visibility, so it now advances past hidden objects instead of snapping to an invisible mesh.
- **Mesh face picking** (`get_mesh_element`): a face hit on a hidden object is dropped, so Add Sketch can't build a workplane from an invisible mesh face.

Verified: eye/monitor/collection-hidden objects are skipped; visible ones unaffected; full suite (205 tests) green. The ray_cast-visibility paths are viewport-bound so a quick in-viewport check (hide a mesh with the eye, confirm you can't snap to it) is appreciated.