### PR TITLE
Fix crash creating a sketch on a modified mesh face

### DIFF
--- a/operators/add_sketch.py
+++ b/operators/add_sketch.py
@@ -1,17 +1,16 @@
 import logging
 
 import bpy
-from bpy.types import Operator, Context, Event
+from bpy.types import Context, Event, Operator
 
 from ..declarations import Operators
-from ..stateful_operator.utilities.register import register_stateops_factory
+from ..model.curve_ref import PointRef
 from ..stateful_operator.state import state_from_args
+from ..stateful_operator.utilities.register import register_stateops_factory
+from ..utilities.geometry import face_workplane_matrix
+from ..utilities.workplane import ensure_origin_workplane_empties, resolve_sketch_base
 from .base_3d import Operator3d
 from .utilities import activate_sketch
-from ..utilities.workplane import ensure_origin_workplane_empties, resolve_sketch_base
-from ..utilities.geometry import face_workplane_matrix
-from ..model.curve_ref import PointRef
-
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +68,7 @@ class View3D_OT_slvs_add_sketch(Operator, Operator3d):
         transform from the evaluated mesh, so it follows edits and deformation
         (see utilities/face_anchor).
         """
+        from ..stateful_operator.utilities.geometry import get_evaluated_obj
         from ..utilities.face_anchor import stamp_face_anchor
 
         empty = bpy.data.objects.new("Workplane", None)
@@ -77,7 +77,20 @@ class View3D_OT_slvs_add_sketch(Operator, Operator3d):
         context.scene.collection.objects.link(empty)
 
         empty.matrix_world = face_workplane_matrix(context, ob, face_index)
-        stamp_face_anchor(empty, ob, face_index)
+
+        # face_index is an evaluated-mesh index; it only maps to an original face
+        # (which the anchor stamps a persistent id on) when no modifier changed
+        # the topology. When it doesn't line up (Solidify/Bevel/etc.), leave the
+        # empty as a plain fixed workplane rather than anchor the wrong face or
+        # index out of range (issue #342-adjacent crash on box.blend meshes).
+        orig = ob.data
+        eval_mesh = get_evaluated_obj(context, ob).data
+        if (
+            hasattr(orig, "polygons")
+            and hasattr(eval_mesh, "polygons")
+            and len(eval_mesh.polygons) == len(orig.polygons)
+        ):
+            stamp_face_anchor(empty, ob, face_index)
         return empty
 
     def prepare_origin_elements(self, context):
@@ -105,7 +118,6 @@ class View3D_OT_slvs_add_sketch(Operator, Operator3d):
 
     def main(self, context: Context):
         from ..model.sketch_ref import Sketch
-        from ..utilities.curve_data import ensure_sketch_curve_object
 
         wp_empty = self.wp
         if not wp_empty or wp_empty.type != 'EMPTY':

--- a/utilities/face_anchor.py
+++ b/utilities/face_anchor.py
@@ -58,8 +58,16 @@ def stamp_face_anchor(empty, source_ob, face_index):
     ``empty.matrix_world`` must already hold the intended frame; its X axis is
     stored in source-local space as the in-plane reference so the recomputed
     orientation stays rigid with the mesh as the object rotates.
+
+    Returns True if the face was anchored. ``face_index`` comes from a ray_cast
+    against the *evaluated* mesh; the persistent id lives on the *original* mesh,
+    so an index past the original face count (a modifier-generated face) can't be
+    anchored -- return False rather than raise (issue: IndexError on Solidify/
+    Bevel meshes). The caller leaves the empty as a plain fixed workplane.
     """
     mesh = source_ob.data
+    if not hasattr(mesh, "polygons") or not (0 <= face_index < len(mesh.polygons)):
+        return False
     attr = mesh.attributes.get(FACE_ID_ATTR)
     if attr is None:
         attr = mesh.attributes.new(FACE_ID_ATTR, "INT", "FACE")
@@ -76,6 +84,7 @@ def stamp_face_anchor(empty, source_ob, face_index):
     empty[KEY_DETACHED] = False
     empty[KEY_LAST_CO] = list(mesh.polygons[face_index].center)
     empty[KEY_REF] = list(ref_local)
+    return True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Creating a sketch on a mesh face in box.blend crashed:

```
File "utilities/face_anchor.py", line 67, in stamp_face_anchor
    attr.data[face_index].value = face_id
IndexError: bpy_prop_collection[index]: index 4876 out of range, size 2
```

**Cause:** the face pick's `face_index` comes from a `ray_cast` against the **evaluated** mesh, but `stamp_face_anchor` writes a persistent face id on the **original** mesh. On a mesh with topology-changing modifiers (Solidify/Bevel), the evaluated mesh has far more faces, so the index is out of range for the original — IndexError, and the operator aborts.

**Fix:** only anchor when the evaluated and original face counts match (no topology change, so indices line up); otherwise create a plain fixed workplane. Its transform already comes from `face_workplane_matrix` (evaluated face), so it's placed correctly — it just won't re-derive from the face on later edits, which isn't possible for a modifier-generated face anyway. `stamp_face_anchor` also bounds-checks and returns False rather than raising.

Verified: a Solidify'd plane (1 orig face → 6 eval) no longer crashes and creates a plain workplane; an unmodified face still anchors. Full suite (205) green.