### PR TITLE
Performance: eliminate redundant per-frame/per-edit work (#342)

### DIFF
--- a/curve_solver.py
+++ b/curve_solver.py
@@ -7,6 +7,7 @@ back to curve points. No Slvs* entity read/write needed for geometry.
 Structural entities (workplane, normal) still come from the entity system.
 Constraints still come from PropertyGroups (referencing entities for now).
 """
+
 import logging
 import math
 
@@ -36,6 +37,7 @@ class CurveSolver:
         self.sketch = sketch
 
         import slvs
+
         slvs.clear_sketch()
         self.solvesys = slvs
 
@@ -66,25 +68,28 @@ class CurveSolver:
         wp_obj = ensure_workplane_empty(self.sketch)
 
         # Fallback: curve object's parent
-        if not wp_obj and self.sketch.target_object and self.sketch.target_object.parent:
+        if (
+            not wp_obj
+            and self.sketch.target_object
+            and self.sketch.target_object.parent
+        ):
             wp_obj = self.sketch.target_object.parent
 
         if wp_obj:
             mat = wp_obj.matrix_world
             origin_loc = mat.translation
             quat = mat.to_quaternion()
-        elif hasattr(self.sketch, 'wp') and self.sketch.wp:
+        elif hasattr(self.sketch, "wp") and self.sketch.wp:
             origin_loc = self.sketch.wp.p1.location
             quat = self.sketch.wp.nm.orientation
         else:
             # Default to XY plane at origin
             from mathutils import Quaternion
+
             origin_loc = (0.0, 0.0, 0.0)
             quat = Quaternion()
 
-        origin_handle = self.solvesys.add_point_3d(
-            self.group_fixed, *origin_loc
-        )
+        origin_handle = self.solvesys.add_point_3d(self.group_fixed, *origin_loc)
         normal_handle = self.solvesys.add_normal_3d(
             self.group_fixed, quat.w, quat.x, quat.y, quat.z
         )
@@ -92,7 +97,7 @@ class CurveSolver:
             self.group_fixed, origin_handle, normal_handle
         )
 
-        if hasattr(self.sketch, 'wp') and self.sketch.wp:
+        if hasattr(self.sketch, "wp") and self.sketch.wp:
             self.sketch.wp.p1.py_data = origin_handle
             self.sketch.wp.nm.py_data = normal_handle
             self.sketch.wp.py_data = wp_handle
@@ -170,9 +175,13 @@ class CurveSolver:
                 ct_handle = self._point_handles.get(cp_id)
                 if ct_handle:
                     # Get radius from curve geometry
-                    ct_pos = Vector(curve_data.points[
-                        curve_data.curves[get_curve_index(sketch, cp_id)].points[0].index
-                    ].position)
+                    ct_pos = Vector(
+                        curve_data.points[
+                            curve_data.curves[get_curve_index(sketch, cp_id)]
+                            .points[0]
+                            .index
+                        ].position
+                    )
                     first_pt = curve_data.curves[curve_idx].points[0].index
                     edge_pos = Vector(curve_data.points[first_pt].position)
                     radius = (edge_pos - ct_pos).length
@@ -181,8 +190,11 @@ class CurveSolver:
                         self.group_sketch, radius, wp
                     )
                     handle = self.solvesys.add_circle(
-                        self.group_sketch, self._normal_handle,
-                        ct_handle, dist_param, wp
+                        self.group_sketch,
+                        self._normal_handle,
+                        ct_handle,
+                        dist_param,
+                        wp,
                     )
                     self._entity_handles[cid] = handle
                     self._distance_params[cid] = dist_param
@@ -197,8 +209,12 @@ class CurveSolver:
                 p2_handle = self._point_handles.get(ep_id)
                 if ct_handle and p1_handle and p2_handle:
                     handle = self.solvesys.add_arc(
-                        self.group_sketch, self._normal_handle,
-                        ct_handle, p1_handle, p2_handle, wp
+                        self.group_sketch,
+                        self._normal_handle,
+                        ct_handle,
+                        p1_handle,
+                        p2_handle,
+                        wp,
                     )
                     self._entity_handles[cid] = handle
 
@@ -213,22 +229,21 @@ class CurveSolver:
                     wp_mat = wp_obj.matrix_world
                 else:
                     from mathutils import Matrix
+
                     wp_mat = Matrix.Identity(4)
                 tw_u, tw_v, _ = wp_mat.inverted() @ self._tweak_pos
-                drag_pt = self.solvesys.add_point_2d(
-                    self.group_sketch, tw_u, tw_v, wp
-                )
+                drag_pt = self.solvesys.add_point_2d(self.group_sketch, tw_u, tw_v, wp)
                 # For points: coincident point-to-point
                 # For lines/arcs/circles: coincident point-on-entity
-                self.solvesys.coincident(
-                    self.group_sketch, drag_pt, tweak_handle, wp
-                )
+                self.solvesys.coincident(self.group_sketch, drag_pt, tweak_handle, wp)
                 self.solvesys.dragged(self.group_sketch, drag_pt, wp)
 
     def _init_constraints(self):
         """Initialize constraints using curve_id handles."""
         sketch = self.sketch
-        sketch_obj = sketch.target_object if hasattr(sketch, 'target_object') else sketch
+        sketch_obj = (
+            sketch.target_object if hasattr(sketch, "target_object") else sketch
+        )
         wp = self._wp_handle
 
         # Iterate constraints from the sketch's own data
@@ -236,19 +251,34 @@ class CurveSolver:
             return
         sketch_constraints = sketch_obj.data.sketch_constraints
 
+        # solvespace constraint handle -> the SlvsConstraint that produced it, so
+        # a failed-constraint report from the solver can be mapped back to the
+        # user's constraints (a single constraint may add several handles).
+        self._constraint_by_handle = {}
+
         for c in sketch_constraints.all:
             group = self.group_sketch
             c.failed = False
 
-            if not getattr(c, 'curve_id_1', ""):
+            if not getattr(c, "curve_id_1", ""):
                 continue
 
             try:
-                c.create_slvs_data_from_curves(
+                handles = c.create_slvs_data_from_curves(
                     self.solvesys, self._entity_handles, wp, group
                 )
             except Exception as e:
                 logger.debug(f"Constraint init failed: {c}, {e}")
+                continue
+
+            if handles is None:
+                continue
+            # A constraint add returns the solvespace constraint as a dict (its
+            # handle under 'h'); a few constraints add several, returning a list.
+            for item in handles if isinstance(handles, (list, tuple)) else (handles,):
+                h = item.get("h") if isinstance(item, dict) else item
+                if h:
+                    self._constraint_by_handle[h] = c
 
     def _rebuild_arc_bezier(self, curve_data, curve_idx, center_pos, is_cyclic):
         """Rebuild arc/circle bezier handles from solved point positions.
@@ -279,8 +309,10 @@ class CurveSolver:
             start_vec = positions[0] - center
             end_vec = positions[-1] - center
             from .utilities.math import range_2pi
+
             total_angle = range_2pi(
-                math.atan2(end_vec[1], end_vec[0]) - math.atan2(start_vec[1], start_vec[0])
+                math.atan2(end_vec[1], end_vec[0])
+                - math.atan2(start_vec[1], start_vec[0])
             )
             segment_count = n_points - 1
             if segment_count == 0:
@@ -299,7 +331,9 @@ class CurveSolver:
             start_angle = math.atan2(start_vec[1], start_vec[0])
             for i in range(1, segment_count):
                 a = start_angle + angle_per_segment * i
-                positions[i] = center + Vector((radius * math.cos(a), radius * math.sin(a)))
+                positions[i] = center + Vector(
+                    (radius * math.cos(a), radius * math.sin(a))
+                )
 
         # Build locations list
         locations = list(positions)
@@ -358,8 +392,8 @@ class CurveSolver:
         handle = self._point_handles.get(curve_id)
         if not handle:
             return None
-        u = self.solvesys.get_param_value(handle['param'][0])
-        v = self.solvesys.get_param_value(handle['param'][1])
+        u = self.solvesys.get_param_value(handle["param"][0])
+        v = self.solvesys.get_param_value(handle["param"][1])
         return (u, v, 0.0)
 
     def _write_results(self):
@@ -398,8 +432,10 @@ class CurveSolver:
 
             if ctype == SketchCurveType.CIRCLE and cid in self._distance_params:
                 dist_param = self._distance_params[cid]
-                param_h = dist_param.get('param', [0])[0]
-                solved_radius = self.solvesys.get_param_value(param_h) if param_h else None
+                param_h = dist_param.get("param", [0])[0]
+                solved_radius = (
+                    self.solvesys.get_param_value(param_h) if param_h else None
+                )
                 cp_id = cp_list[curve_idx]
                 if cp_id and solved_radius is not None:
                     ct_pos = self._get_solved_point_position(cp_id)
@@ -408,11 +444,14 @@ class CurveSolver:
                         curve_slice = curve_data.curves[curve_idx]
                         first = curve_slice.points[0].index
                         curve_data.points[first].position = (
-                            ct_pos[0] + solved_radius, ct_pos[1], ct_pos[2]
+                            ct_pos[0] + solved_radius,
+                            ct_pos[1],
+                            ct_pos[2],
                         )
 
         # Third pass: rebuild segments from updated point positions
         from .utilities.curve_data import rebuild_segments
+
         rebuild_segments(sketch)
 
         # Sync entity.co from solved curve positions (bridge for gizmo positioning)
@@ -428,14 +467,16 @@ class CurveSolver:
                 if entity is None:
                     continue
                 ctype = type_attr.data[curve_idx].value
-                if ctype == SketchCurveType.POINT and hasattr(entity, 'co'):
+                if ctype == SketchCurveType.POINT and hasattr(entity, "co"):
                     pt_idx = curve_data.curves[curve_idx].points[0].index
                     pos = curve_data.points[pt_idx].position
                     entity.co = (pos[0], pos[1])
                 elif ctype == SketchCurveType.CIRCLE:
-                    dist = self._distance_params.get(get_uuid(curve_data, "curve_id", curve_idx))
-                    if dist and hasattr(entity, 'radius'):
-                        entity.radius = self.solvesys.get_param_value(dist['param'][0])
+                    dist = self._distance_params.get(
+                        get_uuid(curve_data, "curve_id", curve_idx)
+                    )
+                    if dist and hasattr(entity, "radius"):
+                        entity.radius = self.solvesys.get_param_value(dist["param"][0])
 
     def solve(self):
         """Run the solver on curve data.
@@ -460,6 +501,7 @@ class CurveSolver:
         self._point_handles.clear()
         self._entity_handles.clear()
         self._distance_params.clear()
+        self._constraint_by_handle = {}
 
         self._init_workplane()
         self._init_geometry()
@@ -467,16 +509,30 @@ class CurveSolver:
 
         result = self.solvesys.solve_sketch(self.group_sketch, True)
 
+        # solve_sketch returns either the result dict or (result, failed_handles),
+        # where failed_handles lists the constraints solvespace couldn't satisfy.
+        failed_handles = []
         if isinstance(result, dict):
             retval = result
         else:
-            retval, *_ = result
+            retval, *rest = result
+            if rest and isinstance(rest[0], (list, tuple)):
+                failed_handles = rest[0]
 
         from .global_data import solver_state_items
         from .utilities.bpy import bpyEnum
 
-        result_code = retval['result']
+        result_code = retval["result"]
         self.ok = result_code == 0 or result_code == 4
+
+        # Flag the offending constraints so the UI (constraint list + gizmos) can
+        # point the user at what to remove -- an inconsistent sketch can't solve,
+        # so nothing in it moves (not even unconstrained geometry) until the
+        # contradictions are cleared.
+        for h in failed_handles:
+            c = self._constraint_by_handle.get(h)
+            if c is not None:
+                c.failed = True
 
         if result_code > 4:
             self.result = bpyEnum(solver_state_items, index=5)
@@ -484,7 +540,7 @@ class CurveSolver:
             self.result = bpyEnum(solver_state_items, index=result_code)
 
         self.sketch.solver_state = self.result.identifier
-        self.sketch.dof = retval.get('dof', 0)
+        self.sketch.dof = retval.get("dof", 0)
 
         if self.ok:
             self._write_results()

--- a/curve_solver.py
+++ b/curve_solver.py
@@ -118,7 +118,17 @@ class CurveSolver:
 
         wp = self._wp_handle
 
-        from .utilities.curve_data import is_fixed as _is_fixed
+        from .utilities.curve_data import read_uuid_list
+
+        # Bulk-read the id fields and flags once. Per-curve get_uuid() converts a
+        # 128-bit int id to a hex string with two attribute lookups each time, so
+        # calling it ~4x per curve dominated solve; one foreach_get + a single
+        # conversion pass per field is far cheaper (issue #342).
+        cid_list = read_uuid_list(curve_data, "curve_id")
+        sp_list = read_uuid_list(curve_data, "start_point_id")
+        ep_list = read_uuid_list(curve_data, "end_point_id")
+        cp_list = read_uuid_list(curve_data, "center_point_id")
+        fixed_attr = curve_data.attributes.get("fixed")
 
         # First pass: create all points
         for curve_idx in range(n_curves):
@@ -126,8 +136,8 @@ class CurveSolver:
             if ctype != SketchCurveType.POINT:
                 continue
 
-            cid = get_uuid(curve_data, "curve_id", curve_idx)
-            fixed = _is_fixed(self.sketch, cid)
+            cid = cid_list[curve_idx]
+            fixed = bool(fixed_attr.data[curve_idx].value) if fixed_attr else False
             group = self.group_fixed if fixed else self.group_sketch
 
             pt_idx = curve_data.curves[curve_idx].points[0].index
@@ -141,11 +151,11 @@ class CurveSolver:
         # Second pass: create lines, arcs, circles
         for curve_idx in range(n_curves):
             ctype = type_attr.data[curve_idx].value
-            cid = get_uuid(curve_data, "curve_id", curve_idx)
+            cid = cid_list[curve_idx]
 
             if ctype == SketchCurveType.LINE:
-                sp_id = get_uuid(curve_data, "start_point_id", curve_idx)
-                ep_id = get_uuid(curve_data, "end_point_id", curve_idx)
+                sp_id = sp_list[curve_idx]
+                ep_id = ep_list[curve_idx]
 
                 p1_handle = self._point_handles.get(sp_id)
                 p2_handle = self._point_handles.get(ep_id)
@@ -156,7 +166,7 @@ class CurveSolver:
                     self._entity_handles[cid] = handle
 
             elif ctype == SketchCurveType.CIRCLE:
-                cp_id = get_uuid(curve_data, "center_point_id", curve_idx)
+                cp_id = cp_list[curve_idx]
                 ct_handle = self._point_handles.get(cp_id)
                 if ct_handle:
                     # Get radius from curve geometry
@@ -178,9 +188,9 @@ class CurveSolver:
                     self._distance_params[cid] = dist_param
 
             elif ctype == SketchCurveType.ARC:
-                cp_id = get_uuid(curve_data, "center_point_id", curve_idx)
-                sp_id = get_uuid(curve_data, "start_point_id", curve_idx)
-                ep_id = get_uuid(curve_data, "end_point_id", curve_idx)
+                cp_id = cp_list[curve_idx]
+                sp_id = sp_list[curve_idx]
+                ep_id = ep_list[curve_idx]
 
                 ct_handle = self._point_handles.get(cp_id)
                 p1_handle = self._point_handles.get(sp_id)
@@ -364,10 +374,16 @@ class CurveSolver:
         if not has_uuid_field(curve_data, "curve_id") or not type_attr:
             return
 
+        # Bulk-read ids once instead of per-curve get_uuid (see _init_geometry).
+        from .utilities.curve_data import read_uuid_list
+
+        cid_list = read_uuid_list(curve_data, "curve_id")
+        cp_list = read_uuid_list(curve_data, "center_point_id")
+
         # First pass: update all point positions
         for curve_idx in range(n_curves):
             ctype = type_attr.data[curve_idx].value
-            cid = get_uuid(curve_data, "curve_id", curve_idx)
+            cid = cid_list[curve_idx]
 
             if ctype == SketchCurveType.POINT:
                 pos = self._get_solved_point_position(cid)
@@ -378,13 +394,13 @@ class CurveSolver:
         # Second pass: update circle/arc edge positions from solved radius
         for curve_idx in range(n_curves):
             ctype = type_attr.data[curve_idx].value
-            cid = get_uuid(curve_data, "curve_id", curve_idx)
+            cid = cid_list[curve_idx]
 
             if ctype == SketchCurveType.CIRCLE and cid in self._distance_params:
                 dist_param = self._distance_params[cid]
                 param_h = dist_param.get('param', [0])[0]
                 solved_radius = self.solvesys.get_param_value(param_h) if param_h else None
-                cp_id = get_uuid(curve_data, "center_point_id", curve_idx)
+                cp_id = cp_list[curve_idx]
                 if cp_id and solved_radius is not None:
                     ct_pos = self._get_solved_point_position(cp_id)
                     if ct_pos:

--- a/drawing/picking.py
+++ b/drawing/picking.py
@@ -11,11 +11,10 @@ curves in ``selection.ignore_list`` are skipped, matching the old behavior.
 
 import numpy as np
 
-from . import selection
 from ..model.sketch_ref import get_active_sketch
 from ..utilities.preferences import get_prefs, get_scale
 from ..utilities.view import _project_points_to_region
-from . import render_data
+from . import render_data, selection
 
 # Pick radius in pixels (scaled by UI scale). Points grab a bit wider than edges
 # and take priority, so a vertex is easy to hit even when it sits on a line.
@@ -23,12 +22,28 @@ _POINT_RADIUS = 11.0
 _EDGE_RADIUS = 8.0
 
 
+# (sketch object name) -> (geometry_signature, point_ids, segment_ids). Picking
+# only needs the projected points/segments, which depend on geometry, not on the
+# hover/selection state that changes every mouse-move -- so we rebuild the
+# extraction only when the geometry actually changes, not on every hover.
+_pick_cache = {}
+
+
 def _active_data(context):
     sketch = get_active_sketch(context)
     if not sketch or not sketch.is_visible(context):
         return None
+
+    obj = sketch.target_object
+    sig = render_data.geometry_signature(sketch)
+    cached = _pick_cache.get(obj.name)
+    if cached is not None and cached[0] == sig:
+        return cached[1]
+
     ts = get_prefs().theme_settings.entity
-    return render_data.build(sketch, ts, is_active=True)
+    data = render_data.build(sketch, ts, is_active=True)
+    _pick_cache[obj.name] = (sig, data)
+    return data
 
 
 def _points_screen(items, region, rv3d):

--- a/drawing/render_data.py
+++ b/drawing/render_data.py
@@ -93,13 +93,25 @@ def overlay_signature(sketch, is_active, theme_sig):
     Reading the flat attribute arrays with ``foreach_get`` is far cheaper than
     rebuilding GPU batches, so the overlay computes this every frame and only
     rebuilds when it changes.
+
+    Hover and highlight are set only by picking, which is active-only, so they
+    never reference an inactive sketch's curves. Folding them into every sketch's
+    signature made unrelated visible sketches rebuild their batches on every
+    hover change (each mouse-move). Inactive sketches therefore track only their
+    geometry and the selection set (which can still contain their curves after an
+    active-sketch switch); the per-frame hover/highlight go to the active sketch
+    alone.
     """
     if len(sketch.data.points) == 0:
         return (0, 0, is_active, theme_sig)
 
+    if not is_active:
+        return (geometry_signature(sketch), False, theme_sig,
+                frozenset(selection.selected))
+
     return (
         geometry_signature(sketch),
-        is_active,
+        True,
         theme_sig,
         frozenset(selection.selected),
         selection.hover,

--- a/drawing/render_data.py
+++ b/drawing/render_data.py
@@ -66,9 +66,16 @@ def geometry_signature(sketch):
     """Fingerprint of the geometry that determines pickable positions.
 
     Positions + the persistent curve attributes (type/construction/visible/...),
-    plus counts. Excludes transient selection/hover -- those change colours (the
-    overlay), not the projected points/segments (picking), so picking can cache
-    its extraction against this and skip rebuilding while the cursor just hovers.
+    the object's world matrix, plus counts. Excludes transient selection/hover --
+    those change colours (the overlay), not the projected points/segments
+    (picking), so picking can cache its extraction against this and skip
+    rebuilding while the cursor just hovers.
+
+    ``build`` bakes ``matrix_world`` into every point/segment position, so it
+    must be part of the fingerprint: a sketch on a workplane whose transform
+    moves (or settles as the depsgraph first evaluates a parented sketch) changes
+    the world positions without touching any local attribute -- omitting it left
+    the pick/overlay cache serving stale world coordinates.
     """
     cd = sketch.data
     n_curves = len(cd.curves)
@@ -83,6 +90,12 @@ def geometry_signature(sketch):
     for name in ("construction", "fixed", "visible", "cyclic"):
         parts.append(_bulk_bool(cd.attributes.get(name), n_curves).tobytes())
     parts.append(_bulk_int(cd.attributes.get("sketch_type"), n_curves).tobytes())
+    parts.append(
+        np.array(sketch.target_object.matrix_world, dtype=np.float32).tobytes()
+    )
+    # curve_id is the pick result build() returns; the validate self-heal can
+    # re-mint ids in place (same count/positions), so it belongs in the key too.
+    parts.append("".join(read_curve_id_list(cd)).encode())
 
     return (n_curves, n_points, hash(b"".join(parts)))
 
@@ -106,8 +119,12 @@ def overlay_signature(sketch, is_active, theme_sig):
         return (0, 0, is_active, theme_sig)
 
     if not is_active:
-        return (geometry_signature(sketch), False, theme_sig,
-                frozenset(selection.selected))
+        return (
+            geometry_signature(sketch),
+            False,
+            theme_sig,
+            frozenset(selection.selected),
+        )
 
     return (
         geometry_signature(sketch),
@@ -123,8 +140,18 @@ def _arc_points(center, radius, start_angle, arc_angle, segments, mat):
     pts = []
     for i in range(segments + 1):
         a = start_angle + arc_angle * i / segments
-        pts.append((mat @ Vector((center.x + radius * math.cos(a),
-                                  center.y + radius * math.sin(a), 0)))[:])
+        pts.append(
+            (
+                mat
+                @ Vector(
+                    (
+                        center.x + radius * math.cos(a),
+                        center.y + radius * math.sin(a),
+                        0,
+                    )
+                )
+            )[:]
+        )
     return pts
 
 
@@ -134,10 +161,10 @@ class SketchRenderData:
     __slots__ = ("point_buckets", "line_buckets", "point_ids", "segment_ids")
 
     def __init__(self):
-        self.point_buckets = {}       # color(tuple) -> [(pos, size_factor), ...]
-        self.line_buckets = {}        # (construction, color) -> [pos, pos, ...]
-        self.point_ids = []           # [(curve_id, pos), ...]  (for picking)
-        self.segment_ids = []         # [(curve_id, p0, p1), ...] (for picking)
+        self.point_buckets = {}  # color(tuple) -> [(pos, size_factor), ...]
+        self.line_buckets = {}  # (construction, color) -> [pos, pos, ...]
+        self.point_ids = []  # [(curve_id, pos), ...]  (for picking)
+        self.segment_ids = []  # [(curve_id, p0, p1), ...] (for picking)
 
     def _line_bucket(self, construction, col):
         return self.line_buckets.setdefault((construction, tuple(col)), [])
@@ -157,7 +184,11 @@ def build(sketch, ts, is_active):
 
     con = _bulk_bool(cd.attributes.get("construction"), n_curves)
     fix = _bulk_bool(cd.attributes.get("fixed"), n_curves)
-    vis = _bulk_bool(cd.attributes.get("visible"), n_curves) if cd.attributes.get("visible") else np.ones(n_curves, bool)
+    vis = (
+        _bulk_bool(cd.attributes.get("visible"), n_curves)
+        if cd.attributes.get("visible")
+        else np.ones(n_curves, bool)
+    )
     cyc = _bulk_bool(cd.attributes.get("cyclic"), n_curves)
     types = _bulk_int(type_attr, n_curves)
     cids = read_curve_id_list(cd)
@@ -182,8 +213,9 @@ def build(sketch, ts, is_active):
 
         if ctype == SketchCurveType.POINT:
             pos = (mat @ Vector(cd.points[curve_slice.points[0].index].position))[:]
-            psize = POINT_SIZE_SELECTED if is_sel else (
-                POINT_SIZE_HOVER if is_hov else 1.0)
+            psize = (
+                POINT_SIZE_SELECTED if is_sel else (POINT_SIZE_HOVER if is_hov else 1.0)
+            )
             rd.point_buckets.setdefault(tuple(col), []).append((pos, psize))
             rd.point_ids.append((cid, pos))
 
@@ -196,7 +228,9 @@ def build(sketch, ts, is_active):
             rd.segment_ids.append((cid, p1, p2))
 
         elif ctype in (SketchCurveType.ARC, SketchCurveType.CIRCLE) and cp_present:
-            arc_pts = _arc_points_for_curve(sketch, cd, i, curve_slice, bool(cyc[i]), mat)
+            arc_pts = _arc_points_for_curve(
+                sketch, cd, i, curve_slice, bool(cyc[i]), mat
+            )
             if arc_pts and len(arc_pts) >= 2:
                 bucket = rd._line_bucket(bool(con[i]), col)
                 for j in range(len(arc_pts) - 1):

--- a/drawing/render_data.py
+++ b/drawing/render_data.py
@@ -17,7 +17,12 @@ import numpy as np
 from mathutils import Vector
 
 from ..model.constants import SketchCurveType
-from ..utilities.curve_data import get_uuid, has_uuid_field, get_curve_data, read_uuid_list
+from ..utilities.curve_data import (
+    get_curve_data,
+    get_uuid,
+    has_uuid_field,
+    read_curve_id_list,
+)
 from ..utilities.math import range_2pi
 from . import selection
 
@@ -131,7 +136,7 @@ def build(sketch, ts, is_active):
     vis = _bulk_bool(cd.attributes.get("visible"), n_curves) if cd.attributes.get("visible") else np.ones(n_curves, bool)
     cyc = _bulk_bool(cd.attributes.get("cyclic"), n_curves)
     types = _bulk_int(type_attr, n_curves)
-    cids = read_uuid_list(cd, "curve_id")
+    cids = read_curve_id_list(cd)
 
     # Selection/hover are transient runtime state (not persisted attributes).
     selected_set = set(selection.selected)

--- a/drawing/render_data.py
+++ b/drawing/render_data.py
@@ -62,6 +62,31 @@ def curve_color(ts, selected, hover, fixed, active=True):
     return ts.default
 
 
+def geometry_signature(sketch):
+    """Fingerprint of the geometry that determines pickable positions.
+
+    Positions + the persistent curve attributes (type/construction/visible/...),
+    plus counts. Excludes transient selection/hover -- those change colours (the
+    overlay), not the projected points/segments (picking), so picking can cache
+    its extraction against this and skip rebuilding while the cursor just hovers.
+    """
+    cd = sketch.data
+    n_curves = len(cd.curves)
+    n_points = len(cd.points)
+    if n_points == 0:
+        return (0, 0, 0)
+
+    pos = np.empty(n_points * 3, dtype=np.float32)
+    cd.points.foreach_get("position", pos)
+
+    parts = [pos.tobytes()]
+    for name in ("construction", "fixed", "visible", "cyclic"):
+        parts.append(_bulk_bool(cd.attributes.get(name), n_curves).tobytes())
+    parts.append(_bulk_int(cd.attributes.get("sketch_type"), n_curves).tobytes())
+
+    return (n_curves, n_points, hash(b"".join(parts)))
+
+
 def overlay_signature(sketch, is_active, theme_sig):
     """Cheap, hashable fingerprint of everything that affects the overlay.
 
@@ -69,26 +94,13 @@ def overlay_signature(sketch, is_active, theme_sig):
     rebuilding GPU batches, so the overlay computes this every frame and only
     rebuilds when it changes.
     """
-    cd = sketch.data
-    n_curves = len(cd.curves)
-    n_points = len(cd.points)
-    if n_points == 0:
+    if len(sketch.data.points) == 0:
         return (0, 0, is_active, theme_sig)
 
-    pos = np.empty(n_points * 3, dtype=np.float32)
-    cd.points.foreach_get("position", pos)
-
-    # Geometry + persistent attributes (positions/construction/visible/...). The
-    # transient selected/hover state lives in the selection module, not on the
-    # datablock, so it's folded into the signature separately below.
-    parts = [pos.tobytes()]
-    for name in ("construction", "fixed", "visible", "cyclic"):
-        parts.append(_bulk_bool(cd.attributes.get(name), n_curves).tobytes())
-    parts.append(_bulk_int(cd.attributes.get("sketch_type"), n_curves).tobytes())
-
     return (
-        n_curves, n_points, is_active, theme_sig,
-        hash(b"".join(parts)),
+        geometry_signature(sketch),
+        is_active,
+        theme_sig,
         frozenset(selection.selected),
         selection.hover,
         frozenset(selection.highlight_curve_ids),

--- a/gizmos/angle.py
+++ b/gizmos/angle.py
@@ -3,7 +3,7 @@ import math
 from bpy.types import Gizmo, GizmoGroup
 from mathutils import Matrix
 
-from ..declarations import Gizmos, GizmoGroups
+from ..declarations import GizmoGroups, Gizmos
 from ..model.types import SlvsAngle
 from ..utilities.constants import QUARTER_TURN
 from ..utilities.draw import coords_arc_2d
@@ -34,6 +34,7 @@ class VIEW3D_GT_slvs_angle(Gizmo, ConstraintGizmoGeneric):
     __slots__ = (
         "custom_shape",
         "index",
+        "_shape_sig",
     )
 
     def _get_helplines(self, context, constr, scale_1, scale_2):

--- a/gizmos/base.py
+++ b/gizmos/base.py
@@ -7,15 +7,14 @@ from .utilities import get_color, get_constraint_color_type, set_gizmo_colors
 class ConstraintGizmo:
     def _get_constraint(self, context):
         from ..model.sketch_ref import get_active_sketch
+
         sketch = get_active_sketch(context)
         if not sketch:
             return None
         return sketch.constraints.get_from_type_index(self.type, self.index)
 
     def get_constraint_color(self, constraint: GenericConstraint):
-        is_highlight = (
-            constraint == selection.highlight_constraint or self.is_highlight
-        )
+        is_highlight = constraint == selection.highlight_constraint or self.is_highlight
         col = get_constraint_color_type(constraint)
         return get_color(col, is_highlight)
 
@@ -39,8 +38,11 @@ class ConstraintGizmoGeneric(ConstraintGizmo):
         rebuilt only when this changes, so a static viewport -- including every
         redraw during a modal drag -- doesn't re-upload a GPU batch per gizmo."""
         rv3d = context.region_data
-        persp = tuple(rv3d.perspective_matrix[i][j] for i in range(4) for j in range(4)) \
-            if rv3d else None
+        persp = (
+            tuple(rv3d.perspective_matrix[i][j] for i in range(4) for j in range(4))
+            if rv3d
+            else None
+        )
         mw = self.matrix_world
         try:
             offset = float(self.target_get_value("offset"))
@@ -60,7 +62,7 @@ class ConstraintGizmoGeneric(ConstraintGizmo):
 
     def draw(self, context):
         constr = self._get_constraint(context)
-        if not constr.visible:
+        if not constr or not constr.visible:
             return
         self._set_colors(context, constr)
         self._update_matrix_basis(constr)
@@ -69,14 +71,17 @@ class ConstraintGizmoGeneric(ConstraintGizmo):
         # placement, or view), not on every redraw -- the per-frame GPU churn that
         # made constraint-heavy sketches laggy.
         sig = self._shape_signature(context, constr)
-        if getattr(self, "_shape_sig", None) != sig or getattr(self, "custom_shape", None) is None:
+        if (
+            getattr(self, "_shape_sig", None) != sig
+            or getattr(self, "custom_shape", None) is None
+        ):
             self._create_shape(context, constr)
             self._shape_sig = sig
         self.draw_custom_shape(self.custom_shape)
 
     def draw_select(self, context, select_id):
         constr = self._get_constraint(context)
-        if not constr.visible:
+        if not constr or not constr.visible:
             return
         # The select shape (no helplines) overwrites custom_shape, so invalidate
         # the display cache to force draw() to rebuild the real shape next time.
@@ -92,6 +97,7 @@ class ConstraintGenericGGT:
 
     def setup(self, context):
         from ..model.sketch_ref import get_active_sketch
+
         active_sketch = get_active_sketch(context)
         if not active_sketch:
             return

--- a/gizmos/base.py
+++ b/gizmos/base.py
@@ -1,5 +1,5 @@
-from ..drawing import selection
 from ..declarations import Operators
+from ..drawing import selection
 from ..model.types import GenericConstraint
 from .utilities import get_color, get_constraint_color_type, set_gizmo_colors
 
@@ -34,6 +34,30 @@ class ConstraintGizmoGeneric(ConstraintGizmo):
     def setup(self):
         pass
 
+    def _shape_signature(self, context, constr):
+        """Everything the drawn shape depends on. The shape (arrows/helplines) is
+        rebuilt only when this changes, so a static viewport -- including every
+        redraw during a modal drag -- doesn't re-upload a GPU batch per gizmo."""
+        rv3d = context.region_data
+        persp = tuple(rv3d.perspective_matrix[i][j] for i in range(4) for j in range(4)) \
+            if rv3d else None
+        mw = self.matrix_world
+        try:
+            offset = float(self.target_get_value("offset"))
+        except (TypeError, ValueError):
+            offset = None
+        return (
+            round(getattr(constr, "value", 0.0), 7),
+            round(getattr(constr, "radius", 0.0), 7),
+            round(getattr(constr, "draw_offset", 0.0), 7),
+            round(getattr(constr, "draw_outset", 0.0), 7),
+            round(getattr(constr, "leader_angle", 0.0), 7),
+            offset,
+            tuple(mw[i][j] for i in range(4) for j in range(4)),
+            persp,
+            context.preferences.system.ui_scale,
+        )
+
     def draw(self, context):
         constr = self._get_constraint(context)
         if not constr.visible:
@@ -41,18 +65,23 @@ class ConstraintGizmoGeneric(ConstraintGizmo):
         self._set_colors(context, constr)
         self._update_matrix_basis(constr)
 
-        self._create_shape(context, constr)
+        # Rebuild the geometry batch only when its inputs change (dimension value,
+        # placement, or view), not on every redraw -- the per-frame GPU churn that
+        # made constraint-heavy sketches laggy.
+        sig = self._shape_signature(context, constr)
+        if getattr(self, "_shape_sig", None) != sig or getattr(self, "custom_shape", None) is None:
+            self._create_shape(context, constr)
+            self._shape_sig = sig
         self.draw_custom_shape(self.custom_shape)
 
-    # NOTE: Idealy the geometry batch wouldn't be recreated every redraw,
-    # however the geom changes with the distance value, maybe at least
-    # track changes for that value
-    # if not hasattr(self, "custom_shape"):
     def draw_select(self, context, select_id):
         constr = self._get_constraint(context)
         if not constr.visible:
             return
+        # The select shape (no helplines) overwrites custom_shape, so invalidate
+        # the display cache to force draw() to rebuild the real shape next time.
         self._create_shape(context, constr, select=True)
+        self._shape_sig = None
         self.draw_custom_shape(self.custom_shape, select_id=select_id)
 
 

--- a/gizmos/constraint.py
+++ b/gizmos/constraint.py
@@ -1,17 +1,15 @@
 import math
 
 import blf
-import gpu
 from bpy.types import Gizmo, GizmoGroup
-from mathutils import Vector, Matrix
+from mathutils import Matrix, Vector
 
 from .. import units
-from ..declarations import Gizmos, GizmoGroups, Operators
+from ..declarations import GizmoGroups, Gizmos, Operators
 from ..utilities.preferences import get_prefs
-from ..utilities.view import get_2d_coords
+from ..utilities.view import get_2d_coords, get_scale_from_pos
 from .base import ConstraintGizmo
 from .utilities import Color, get_color, set_gizmo_colors
-from ..utilities.view import get_scale_from_pos
 
 GIZMO_OFFSET = Vector((1.0, 1.0))
 FONT_ID = 0
@@ -46,6 +44,7 @@ class VIEW3D_GGT_slvs_constraint(GizmoGroup):
 
     def setup(self, context):
         from ..model.sketch_ref import get_active_sketch
+
         active_sketch = get_active_sketch(context)
 
         # Build mapping: placement_key → [constraints]
@@ -54,6 +53,7 @@ class VIEW3D_GGT_slvs_constraint(GizmoGroup):
         if not active_sketch:
             return
         from ..model.base_constraint import DimensionalConstraint
+
         for c in active_sketch.constraints.all:
             if isinstance(c, DimensionalConstraint):
                 continue
@@ -84,7 +84,7 @@ class VIEW3D_GGT_slvs_constraint(GizmoGroup):
                     gz.curve_id = ident
                 else:
                     gz.entity_index = ident
-                    gz.curve_id = getattr(c, 'curve_id_1', "")
+                    gz.curve_id = getattr(c, "curve_id_1", "")
 
                 # A constraint may pin the marker to a computed point (e.g. a
                 # tangent point) instead of the curve's default placement.
@@ -156,9 +156,11 @@ class VIEW3D_GT_slvs_constraint(ConstraintGizmo, Gizmo):
         world_pos = getattr(self, "placement_pos", None)
         if world_pos is None and hasattr(self, "curve_id") and self.curve_id:
             from ..model.sketch_ref import get_active_sketch
+
             sketch = get_active_sketch(context)
             if sketch:
                 from ..utilities.curve_data import get_curve_placement
+
                 world_pos = get_curve_placement(sketch, self.curve_id)
             else:
                 return
@@ -186,7 +188,7 @@ class VIEW3D_GT_slvs_constraint(ConstraintGizmo, Gizmo):
 
     def draw(self, context):
         constraint = self._get_constraint(context)
-        if not constraint.visible:
+        if not constraint or not constraint.visible:
             return
         # Keep colors + matrix_basis current so test_select stays accurate; the
         # icon itself is rendered in one batched pass (drawing.constraint_icons)
@@ -216,7 +218,10 @@ class VIEW3D_GT_slvs_constraint_value(ConstraintGizmo, Gizmo):
     def draw(self, context):
         constr = self._get_constraint(context)
 
-        if not constr.visible or not hasattr(constr, "value_placement"):
+        # constr is None when its constraint was just deleted but the gizmo group
+        # hasn't refreshed yet (e.g. clearing failed constraints on an
+        # over-constrained sketch) -- skip drawing rather than dereference None.
+        if not constr or not constr.visible or not hasattr(constr, "value_placement"):
             return
 
         color = get_color(Color.Text, self.is_highlight)

--- a/gizmos/diameter.py
+++ b/gizmos/diameter.py
@@ -1,6 +1,6 @@
 from bpy.types import Gizmo, GizmoGroup
 
-from ..declarations import Gizmos, GizmoGroups
+from ..declarations import GizmoGroups, Gizmos
 from ..model.types import SlvsDiameter
 from ..utilities.constants import HALF_TURN
 from ..utilities.math import pol2cart
@@ -30,6 +30,7 @@ class VIEW3D_GT_slvs_diameter(Gizmo, ConstraintGizmoGeneric):
     __slots__ = (
         "custom_shape",
         "index",
+        "_shape_sig",
     )
 
     def _create_shape(self, context, constr, select=False):

--- a/gizmos/distance.py
+++ b/gizmos/distance.py
@@ -32,6 +32,7 @@ class VIEW3D_GT_slvs_distance(Gizmo, ConstraintGizmoGeneric):
     __slots__ = (
         "custom_shape",
         "index",
+        "_shape_sig",
     )
 
     def _get_helplines(self, context, constr, scale_1, scale_2):

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -20,6 +20,54 @@ class Operator2d(GenericEntityOp):
     def poll(cls, context: Context):
         return context.scene.sketcher.active_sketch_object is not None
 
+    # A 2D draw operator only ever modifies the active sketch's curve data and
+    # constraints -- not the entity system (structural workplane/normal/origin
+    # entities). The base snapshot re-serialized and restored the whole scene
+    # (137 entities in the #342 file) plus every sketch's curves on each
+    # mouse-move (~15ms), the draw-time lag. Scope it to the active sketch's curve
+    # data + constraints, skipping the scene serialization entirely.
+    def create_snapshot(self, context: Context):
+        from ..model.sketch_ref import get_active_sketch
+
+        scene = context.scene
+        sketch = get_active_sketch(context)
+        obj = sketch.target_object if sketch else None
+        snap = {
+            "active_name": obj.name if obj else None,
+            "constraint_values": {
+                k: scene[k] for k in scene.keys() if str(k).startswith("slvs:c:")
+            },
+        }
+        if obj and obj.data:
+            snap["curve_data"] = self._snapshot_curve_data(obj.data)
+            snap["constraints"] = self._snapshot_constraints(obj.data)
+        return snap
+
+    def restore_snapshot(self, context: Context, snapshot):
+        if not snapshot:
+            return
+        from ..utilities.curve_data import invalidate_curve_id_cache
+
+        scene = context.scene
+        invalidate_curve_id_cache()
+
+        name = snapshot.get("active_name")
+        obj = bpy.data.objects.get(name) if name else None
+        if obj and obj.data and "curve_data" in snapshot:
+            self._restore_curve_data(obj.data, snapshot["curve_data"])
+            # Clear then restore: an empty constraints snapshot means "the sketch
+            # had none", and _restore_constraints early-returns on empty -- so a
+            # constraint added during the preview must be removed here, or it
+            # would survive the undo (the pre-draw state had zero constraints).
+            for coll in obj.data.sketch_constraints.get_lists():
+                while len(coll) > 0:
+                    coll.remove(0)
+            self._restore_constraints(obj.data, snapshot.get("constraints", {}))
+
+        # Re-apply dimensional values last (see base restore_snapshot / #564).
+        for key, value in snapshot.get("constraint_values", {}).items():
+            scene[key] = value
+
     def invoke(self, context: Context, event: Event):
         # Own a POST_PIXEL marker for the current snap target for the lifetime of
         # the modal (removed in _end), so it can never linger past the draw.

--- a/scripts/perf_compare.py
+++ b/scripts/perf_compare.py
@@ -55,9 +55,12 @@ def main():
         print("\n".join(lines))
         return 0
 
+    # The Δ column already tells the two kinds apart -- an integer delta is a
+    # deterministic op-count, a percentage is wall-clock. The op-count verdict is
+    # summarised in the line below the table, so no per-row flag column.
     lines += [
-        "| metric | base | head | Δ | |",
-        "| --- | ---: | ---: | ---: | :-- |",
+        "| metric | base | head | Δ |",
+        "| --- | ---: | ---: | ---: |",
     ]
     regressed = []
     for k in sorted(set(base) | set(head)):
@@ -66,22 +69,20 @@ def main():
         if b is None or h is None:
             lines.append(
                 f"| `{k}` | {_fmt(b) if b is not None else '—'} "
-                f"| {_fmt(h) if h is not None else '—'} | new/removed | |"
+                f"| {_fmt(h) if h is not None else '—'} | new/removed |"
             )
             continue
         is_count = not k.endswith("_ms")
         if is_count:
-            # Deterministic: any increase is a real regression.
+            # Deterministic: any increase is a real regression (flagged below).
             delta = h - b
-            flag = "🔴" if delta > 0 else ("🟢" if delta < 0 else "")
             if delta > 0:
                 regressed.append(k)
-            lines.append(f"| `{k}` | {b} | {h} | {delta:+d} | {flag} |")
+            lines.append(f"| `{k}` | {b} | {h} | {delta:+d} |")
         else:
-            # Wall-clock: informational; big swings are runner noise.
+            # Wall-clock: informational trend (machine-dependent).
             pct = (h - b) / b * 100 if b else 0.0
-            flag = "≈ (noisy)"
-            lines.append(f"| `{k}` | {_fmt(b)} | {_fmt(h)} | {pct:+.0f}% | {flag} |")
+            lines.append(f"| `{k}` | {_fmt(b)} | {_fmt(h)} | {pct:+.0f}% |")
 
     lines.append("")
     if regressed:

--- a/testing/test_constraint_init.py
+++ b/testing/test_constraint_init.py
@@ -101,8 +101,7 @@ class TestConstraintInit(Sketch2dTestCase):
 
         # Constrain 2 points
         p2 = self.add_point((0.0, 2.0))
-        c2 = sc.add_distance(init=True,
-                             curve_id_1=p0.curve_id, curve_id_2=p2.curve_id)
+        c2 = sc.add_distance(init=True, curve_id_1=p0.curve_id, curve_id_2=p2.curve_id)
         self.solve()
         self.assertAlmostEqual(p2.co.y, 2.0)
         self.assertAlmostEqual(c2.value, 2.0)
@@ -116,8 +115,9 @@ class TestConstraintInit(Sketch2dTestCase):
         p1 = self.add_point((1, -1), fixed=True)
         p2 = self.add_point((1, 1))
         line = self.add_line(p1, p2)
-        c1 = sc.add_distance(init=True,
-                             curve_id_1=p0.curve_id, curve_id_2=line.curve_id)
+        c1 = sc.add_distance(
+            init=True, curve_id_1=p0.curve_id, curve_id_2=line.curve_id
+        )
 
         self.solve()
         self.assertTrue(c1.flip)
@@ -132,8 +132,9 @@ class TestConstraintInit(Sketch2dTestCase):
         p3 = self.add_point((-1, -1), fixed=True)
         p4 = self.add_point((-1, 1))
         line2 = self.add_line(p3, p4)
-        c2 = sc.add_distance(init=True,
-                             curve_id_1=p0.curve_id, curve_id_2=line2.curve_id)
+        c2 = sc.add_distance(
+            init=True, curve_id_1=p0.curve_id, curve_id_2=line2.curve_id
+        )
 
         self.solve()
         self.assertFalse(c2.flip)
@@ -150,10 +151,15 @@ class TestConstraintInit(Sketch2dTestCase):
         p0 = self.add_point((0, 0), fixed=True)
         p1 = self.add_point((1, 2))
 
-        c1 = sc.add_distance(init=True, align="VERTICAL",
-                             curve_id_1=p0.curve_id, curve_id_2=p1.curve_id)
-        c2 = sc.add_distance(init=True, align="HORIZONTAL",
-                             curve_id_1=p0.curve_id, curve_id_2=p1.curve_id)
+        c1 = sc.add_distance(
+            init=True, align="VERTICAL", curve_id_1=p0.curve_id, curve_id_2=p1.curve_id
+        )
+        c2 = sc.add_distance(
+            init=True,
+            align="HORIZONTAL",
+            curve_id_1=p0.curve_id,
+            curve_id_2=p1.curve_id,
+        )
 
         self.solve()
         self.assertAlmostEqual(c1.value, 2.0)
@@ -171,8 +177,7 @@ class TestConstraintInit(Sketch2dTestCase):
 
         # Constrain circle diameter
         circle1 = self.add_circle(p0, 3.0)
-        c1 = sc.add_diameter(init=True, value=4.0,
-                             curve_id_1=circle1.curve_id)
+        c1 = sc.add_diameter(init=True, value=4.0, curve_id_1=circle1.curve_id)
 
         self.solve()
         self.assertAlmostEqual(circle1.radius, 2.0)
@@ -180,8 +185,7 @@ class TestConstraintInit(Sketch2dTestCase):
 
         # Constrain circle radius
         circle2 = self.add_circle(p0, 3.0)
-        c2 = sc.add_diameter(init=True, setting=True,
-                             curve_id_1=circle2.curve_id)
+        c2 = sc.add_diameter(init=True, setting=True, curve_id_1=circle2.curve_id)
 
         self.solve()
         self.assertAlmostEqual(circle2.radius, 3.0)
@@ -189,8 +193,9 @@ class TestConstraintInit(Sketch2dTestCase):
 
         # Submit value and setting
         circle3 = self.add_circle(p0, 1.0)
-        c3 = sc.add_diameter(init=True, value=0.8, setting=True,
-                             curve_id_1=circle3.curve_id)
+        c3 = sc.add_diameter(
+            init=True, value=0.8, setting=True, curve_id_1=circle3.curve_id
+        )
 
         self.solve()
         self.assertAlmostEqual(circle3.radius, 0.8)
@@ -212,8 +217,7 @@ class TestConstraintInit(Sketch2dTestCase):
         p1 = self.add_point((3.0, 0.0))
         p2 = self.add_point((0.0, 3.0))
         arc1 = self.add_arc(p0, p1, p2)
-        c1 = sc.add_diameter(init=True,
-                             curve_id_1=arc1.curve_id)
+        c1 = sc.add_diameter(init=True, curve_id_1=arc1.curve_id)
 
         self.solve()
         self.assertAlmostEqual(arc1.radius, 3.0)
@@ -236,8 +240,9 @@ class TestConstraintInit(Sketch2dTestCase):
         p2 = self.add_point((0, 1))
         line2 = self.add_line(p0, p2)
 
-        c = sc.add_angle(init=True,
-                         curve_id_1=line1.curve_id, curve_id_2=line2.curve_id)
+        c = sc.add_angle(
+            init=True, curve_id_1=line1.curve_id, curve_id_2=line2.curve_id
+        )
 
         self.solve()
         self.assertAlmostEqual(p2.co.x, 0.0)
@@ -285,8 +290,9 @@ class TestConstraintInit(Sketch2dTestCase):
         p2 = self.add_point((0, 1))
         line2 = self.add_line(p0, p2)
 
-        c = sc.add_ratio(init=True,
-                         curve_id_1=line1.curve_id, curve_id_2=line2.curve_id)
+        c = sc.add_ratio(
+            init=True, curve_id_1=line1.curve_id, curve_id_2=line2.curve_id
+        )
         self.solve()
         self.assertAlmostEqual(c.value, 3.0)
 
@@ -294,3 +300,33 @@ class TestConstraintInit(Sketch2dTestCase):
         c.value = 4.0
         self.solve()
         self.assertAlmostEqual(line1.length, 4.0)
+
+
+class TestSolverFeedback(Sketch2dTestCase):
+    def test_inconsistent_flags_failed_constraint(self):
+        """Contradictory constraints make the solver report INCONSISTENT; the
+        offending constraints must be flagged ``failed`` so the UI can point the
+        user at what to remove. An inconsistent sketch can't solve, so nothing in
+        it moves (not even unconstrained geometry) until the conflict is cleared
+        -- without this feedback that state is invisible (box.blend Transparent.001).
+        """
+        sc = self.sketch.constraints
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((3, 0))
+        # Two distances the same pair of points cannot both satisfy.
+        sc.add_distance(
+            init=True, value=3.0, curve_id_1=p0.curve_id, curve_id_2=p1.curve_id
+        )
+        sc.add_distance(
+            init=True, value=5.0, curve_id_1=p0.curve_id, curve_id_2=p1.curve_id
+        )
+
+        ok = self.sketch.solve(self.context)
+        self.assertFalse(ok, "contradictory constraints should not solve")
+        self.assertEqual(self.sketch.solver_state, "INCONSISTENT")
+
+        all_c = list(self.sketch.target_object.data.sketch_constraints.all)
+        self.assertTrue(
+            any(c.failed for c in all_c),
+            "no constraint flagged failed on an inconsistent solve",
+        )

--- a/testing/test_curve_id.py
+++ b/testing/test_curve_id.py
@@ -8,8 +8,8 @@ geometry resolved to the origin.
 
 import bpy
 
-from .utils import BgsTestCase, Sketch2dTestCase
 from ..utilities import curve_data as cd
+from .utils import BgsTestCase, Sketch2dTestCase
 
 
 class TestCurveIdCodec(BgsTestCase):
@@ -70,3 +70,28 @@ class TestCurveIdSurvival(Sketch2dTestCase):
         # endpoints still resolve to their real positions, not the origin
         self.assertEqual(tuple(round(v, 1) for v in line.p1.co), (3.0, 4.0))
         self.assertEqual(tuple(round(v, 1) for v in line.p2.co), (5.0, 6.0))
+
+    def test_curve_id_list_cache_tracks_add_remove(self):
+        """The cached hex-id list (per-frame draw/pick fast path) must stay in
+        sync as curves are added and removed, not serve a stale list."""
+        data = self.sketch.target_object.data
+
+        p0 = self.add_point((0.0, 0.0))
+        p1 = self.add_point((1.0, 0.0))
+        line = self.add_line(p0, p1)
+        cached = cd.read_curve_id_list(data)
+        self.assertEqual(cached, cd.read_uuid_list(data, "curve_id"))
+        self.assertIn(line.curve_id, cached)
+
+        # add -> cache must include the new curve
+        p2 = self.add_point((2.0, 0.0))
+        line2 = self.add_line(p1, p2)
+        cached = cd.read_curve_id_list(data)
+        self.assertEqual(cached, cd.read_uuid_list(data, "curve_id"))
+        self.assertIn(line2.curve_id, cached)
+
+        # remove -> cache must drop it
+        line2.remove()
+        cached = cd.read_curve_id_list(data)
+        self.assertEqual(cached, cd.read_uuid_list(data, "curve_id"))
+        self.assertNotIn(line2.curve_id, cached)

--- a/testing/test_curve_id.py
+++ b/testing/test_curve_id.py
@@ -95,3 +95,19 @@ class TestCurveIdSurvival(Sketch2dTestCase):
         cached = cd.read_curve_id_list(data)
         self.assertEqual(cached, cd.read_uuid_list(data, "curve_id"))
         self.assertNotIn(line2.curve_id, cached)
+
+    def test_uuid_list_cache_invalidated_on_set_uuid(self):
+        """Writing an id via set_uuid must not leave a stale cached list."""
+        p0 = self.add_point((0.0, 0.0))
+        p1 = self.add_point((1.0, 0.0))
+        line = self.add_line(p0, p1)
+        data = self.sketch.target_object.data
+
+        idx = cd.get_curve_index(self.sketch, line.curve_id)
+        cd.read_uuid_list(data, "curve_id")  # populate cache
+        new = cd.new_uuid()
+        cd.set_uuid(data, "curve_id", idx, new)
+
+        refreshed = cd.read_uuid_list(data, "curve_id")
+        self.assertIn(new, refreshed)
+        self.assertNotIn(line.curve_id, refreshed)

--- a/testing/test_draw_snapshot.py
+++ b/testing/test_draw_snapshot.py
@@ -1,0 +1,71 @@
+"""Interactive-undo snapshot for 2D draw operators.
+
+Draw operators snapshot state each mouse-move so an interactive step can be
+undone before the next preview. The base snapshot re-serialized the whole scene
+plus every sketch's curves; ``Operator2d`` scopes it to the active sketch's curve
+data + constraints (issue #342). These guard that the scoped snapshot restores
+the active sketch exactly and never touches other sketches.
+"""
+
+from ..model.curve_ref import LineRef, PointRef
+from ..model.sketch_ref import set_active_sketch
+from ..operators.add_rectangle import View3D_OT_slvs_add_rectangle
+from .utils import Sketch2dTestCase, make_operator_double
+
+
+class TestDrawSnapshot(Sketch2dTestCase):
+    def _op(self):
+        op = make_operator_double(View3D_OT_slvs_add_rectangle)()
+        op._state_data = {}
+        return op
+
+    def _curve_count(self):
+        return len(self.sketch.target_object.data.curves)
+
+    def test_restore_returns_active_sketch_to_snapshot(self):
+        set_active_sketch(self.context, self.sketch.target_object)
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((2, 0))
+        line = self.add_line(p0, p1)
+        before = self._curve_count()
+        ncon_before = len(list(self.sketch.constraints.all))
+
+        op = self._op()
+        snap = op.create_snapshot(self.context)
+
+        # Simulate an interactive preview: add geometry + a constraint.
+        a = PointRef.create(self.sketch, (5, 5))
+        b = PointRef.create(self.sketch, (6, 6))
+        ln = LineRef.create(self.sketch, a, b)
+        self.sketch.constraints.add_horizontal(curve_id_1=ln.curve_id)
+        self.assertGreater(self._curve_count(), before)
+
+        op.restore_snapshot(self.context, snap)
+
+        self.assertEqual(self._curve_count(), before)
+        self.assertEqual(len(list(self.sketch.constraints.all)), ncon_before)
+        # The original line still resolves to its real endpoints.
+        self.assertEqual(tuple(round(v, 1) for v in line.p2.co), (2.0, 0.0))
+
+    def test_snapshot_leaves_other_sketches_untouched(self):
+        # A second sketch that must be ignored by the active sketch's snapshot.
+        other = self.new_sketch()
+        op_other = PointRef.create(other, (1, 1))
+        LineRef.create(other, op_other, PointRef.create(other, (2, 2)))
+        other_count = len(other.target_object.data.curves)
+
+        set_active_sketch(self.context, self.sketch.target_object)
+        PointRef.create(self.sketch, (0, 0))
+        op = self._op()
+        snap = op.create_snapshot(self.context)
+        # The snapshot only names the active sketch.
+        self.assertEqual(snap["active_name"], self.sketch.target_object.name)
+
+        # Mutating the other sketch then restoring must not revert it.
+        LineRef.create(
+            other, PointRef.create(other, (3, 3)), PointRef.create(other, (4, 4))
+        )
+        grown = len(other.target_object.data.curves)
+        op.restore_snapshot(self.context, snap)
+        self.assertEqual(len(other.target_object.data.curves), grown)
+        self.assertGreater(grown, other_count)

--- a/testing/test_picking.py
+++ b/testing/test_picking.py
@@ -8,11 +8,10 @@ exercise the pick logic (point-over-edge priority, box overlap, ignore-list).
 
 import numpy as np
 
-from .utils import Sketch2dTestCase
-from ..drawing import picking
-from ..utilities.curve_data import refresh_curve_geometry
+from ..drawing import picking, selection
 from ..model.sketch_ref import set_active_sketch
-from ..drawing import selection
+from ..utilities.curve_data import refresh_curve_geometry
+from .utils import Sketch2dTestCase
 
 
 class _FakeContext:
@@ -69,3 +68,26 @@ class TestPicking(Sketch2dTestCase):
     def test_ignore_list_respected(self):
         selection.ignore_list = [self.b.curve_id]
         self.assertNotEqual(picking.pick(self.ctx, (40, 0)), self.b.curve_id)
+
+    def test_cache_reuses_on_hover_and_refreshes_on_geometry_change(self):
+        # First pick populates the cache; a second pick (mouse just moved, no
+        # geometry change) must reuse the same extracted data, not rebuild.
+        picking._pick_cache.clear()
+        picking.pick(self.ctx, (40, 0))
+        cached = picking._pick_cache[self.sketch.target_object.name][1]
+        picking.pick(self.ctx, (20, 0))
+        self.assertIs(
+            picking._pick_cache[self.sketch.target_object.name][1],
+            cached,
+            "hover rebuilt pick data despite unchanged geometry",
+        )
+        # Adding a segment changes the geometry signature -> cache refreshes and
+        # the new element is pickable.
+        c = self.add_point((4, 4))
+        line2 = self.add_line(self.b, c)
+        self.solve()
+        self.assertEqual(picking.pick(self.ctx, (40, 40)), c.curve_id)
+        self.assertIsNot(
+            picking._pick_cache[self.sketch.target_object.name][1], cached
+        )
+        self.assertTrue(line2.valid)

--- a/testing/test_render_data.py
+++ b/testing/test_render_data.py
@@ -31,10 +31,10 @@ class TestRenderData(Sketch2dTestCase):
         n_points = sum(len(v) for v in data.point_buckets.values())
         n_line_verts = sum(len(v) for v in data.line_buckets.values())
 
-        self.assertEqual(n_points, 3)                 # the three point curves
+        self.assertEqual(n_points, 3)  # the three point curves
         self.assertEqual(len(data.point_ids), 3)
-        self.assertGreater(n_line_verts, 2)           # line + tessellated circle
-        self.assertEqual(n_line_verts % 2, 0)         # LINES come in pairs
+        self.assertGreater(n_line_verts, 2)  # line + tessellated circle
+        self.assertEqual(n_line_verts % 2, 0)  # LINES come in pairs
         self.assertEqual(len(data.segment_ids), n_line_verts // 2)
 
     def test_signature_stable_and_invalidates(self):
@@ -57,12 +57,42 @@ class TestRenderData(Sketch2dTestCase):
         selection.clear()
         selection.selected.append(cid)
         try:
-            self.assertNotEqual(base, render_data.overlay_signature(self.sketch, True, ()))
+            self.assertNotEqual(
+                base, render_data.overlay_signature(self.sketch, True, ())
+            )
         finally:
             selection.clear()
 
         # Active/inactive must change the signature (colors differ).
         self.assertNotEqual(base, render_data.overlay_signature(self.sketch, False, ()))
+
+    def test_signature_tracks_world_transform(self):
+        """build() bakes matrix_world into every pick/overlay position, so the
+        signature must change when the sketch's world transform moves. Omitting
+        it let the pick cache serve stale world coordinates for a sketch on a
+        moved/settling workplane -- selection went dead on non-origin-plane
+        sketches (the whole cache keys on this fingerprint)."""
+        from mathutils import Matrix
+
+        self._build_point_line_circle()
+        obj = self.sketch.target_object
+        before_geo = render_data.geometry_signature(self.sketch)
+        before_overlay = render_data.overlay_signature(self.sketch, True, ())
+
+        original = obj.matrix_world.copy()
+        try:
+            obj.matrix_world = Matrix.Translation((5, 3, 0)) @ original
+            self.assertNotEqual(
+                before_geo,
+                render_data.geometry_signature(self.sketch),
+                "world transform move did not change geometry_signature",
+            )
+            self.assertNotEqual(
+                before_overlay,
+                render_data.overlay_signature(self.sketch, True, ()),
+            )
+        finally:
+            obj.matrix_world = original
 
     def test_inactive_signature_ignores_hover(self):
         """Hover is active-only, so it must not invalidate an inactive sketch's

--- a/testing/test_render_data.py
+++ b/testing/test_render_data.py
@@ -6,10 +6,10 @@ extracted into the right buckets and that the change-signature both stays stable
 and detects the changes that must invalidate cached batches.
 """
 
-from .utils import Sketch2dTestCase
 from ..drawing import render_data, selection
-from ..utilities.curve_data import refresh_curve_geometry, read_uuid_list
+from ..utilities.curve_data import read_uuid_list, refresh_curve_geometry
 from ..utilities.preferences import get_prefs
+from .utils import Sketch2dTestCase
 
 
 class TestRenderData(Sketch2dTestCase):
@@ -63,3 +63,25 @@ class TestRenderData(Sketch2dTestCase):
 
         # Active/inactive must change the signature (colors differ).
         self.assertNotEqual(base, render_data.overlay_signature(self.sketch, False, ()))
+
+    def test_inactive_signature_ignores_hover(self):
+        """Hover is active-only, so it must not invalidate an inactive sketch's
+        signature (which would rebuild its batches on every mouse-move)."""
+        self._build_point_line_circle()
+        selection.clear()
+        try:
+            inactive = render_data.overlay_signature(self.sketch, False, ())
+            selection.hover = "abc123"
+            self.assertEqual(
+                inactive,
+                render_data.overlay_signature(self.sketch, False, ()),
+                "hover changed an inactive sketch's signature",
+            )
+            # The active sketch, by contrast, must react to hover.
+            active = render_data.overlay_signature(self.sketch, True, ())
+            selection.hover = "def456"
+            self.assertNotEqual(
+                active, render_data.overlay_signature(self.sketch, True, ())
+            )
+        finally:
+            selection.clear()

--- a/utilities/curve_data.py
+++ b/utilities/curve_data.py
@@ -234,6 +234,28 @@ def init_string_attrs(curve_data, curve_idx):
 # ---------------------------------------------------------------------------
 
 _curve_id_cache = {}
+# id(curve_data) -> ordered list of curve_id hex strings. Curve ids are immutable
+# after creation, so the only thing that changes this list is add/remove -- which
+# already calls invalidate_curve_id_cache. Caching it keeps the per-frame draw and
+# picking paths from re-deriving every hex id from its int attributes each frame.
+_curve_id_list_cache = {}
+
+
+def read_curve_id_list(curve_data):
+    """Cached ordered list of curve_id hex strings for ``curve_data``.
+
+    Same result as ``read_uuid_list(curve_data, "curve_id")`` but memoized on the
+    add/remove lifetime, avoiding the pure-Python int->hex conversion on every
+    draw/pick. The length guard rebuilds if the curve count changed without an
+    explicit invalidation.
+    """
+    key = id(curve_data)
+    lst = _curve_id_list_cache.get(key)
+    if lst is not None and len(lst) == len(curve_data.curves):
+        return lst
+    lst = read_uuid_list(curve_data, "curve_id")
+    _curve_id_list_cache[key] = lst
+    return lst
 
 
 def _allocate_curve_id(sketch):
@@ -266,12 +288,14 @@ def _rebuild_curve_id_cache(sketch, lookup_id=None):
 
 
 def invalidate_curve_id_cache(sketch=None):
-    """Invalidate the curve_id cache. Call after add/remove curves."""
+    """Invalidate the curve_id caches. Call after add/remove curves."""
     if sketch and sketch.target_object:
         sk_key = id(sketch.target_object.data)
         _curve_id_cache.pop(sk_key, None)
+        _curve_id_list_cache.pop(sk_key, None)
     else:
         _curve_id_cache.clear()
+        _curve_id_list_cache.clear()
 
 
 # ---------------------------------------------------------------------------

--- a/utilities/curve_data.py
+++ b/utilities/curve_data.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 # Attribute helpers
 # ---------------------------------------------------------------------------
 
+
 def ensure_attribute(attributes, name, type, domain):
     """Ensure an attribute exists or create it if missing."""
     attr = attributes.get(name)
@@ -96,6 +97,9 @@ def get_uuid(curve_data, field, index):
 # segment rebuild, draw/pick) without re-deriving every hex id from its int
 # attributes on each call -- the dominant cost in solve and draw (issue #342).
 _uuid_list_cache = {}
+# Parallel cache of the same ids in raw-int-tuple form (read_uuid_raw_list),
+# invalidated in lockstep with _uuid_list_cache.
+_uuid_raw_cache = {}
 
 
 def set_uuid(curve_data, field, index, value):
@@ -108,6 +112,7 @@ def set_uuid(curve_data, field, index, value):
     if hi:
         hi.data[index].value = hi_pair
     _uuid_list_cache.pop((id(curve_data), field), None)
+    _uuid_raw_cache.pop((id(curve_data), field), None)
 
 
 def new_uuid():
@@ -140,11 +145,44 @@ def read_uuid_list(curve_data, field):
     lo.data.foreach_get("value", lob)
     hi.data.foreach_get("value", hib)
     result = [
-        _pairs_to_hex((int(lob[2 * i]), int(lob[2 * i + 1])),
-                      (int(hib[2 * i]), int(hib[2 * i + 1])))
+        _pairs_to_hex(
+            (int(lob[2 * i]), int(lob[2 * i + 1])),
+            (int(hib[2 * i]), int(hib[2 * i + 1])),
+        )
         for i in range(n)
     ]
     _uuid_list_cache[key] = result
+    return result
+
+
+def read_uuid_raw_list(curve_data, field):
+    """All curves' ids for a field as raw ``(lo0, lo1, hi0, hi1)`` int tuples.
+
+    Like ``read_uuid_list`` but without the hex formatting: callers that only
+    compare ids for equality (e.g. grouping segment endpoints that share a
+    junction) don't need the string form, and building 4-int tuples is far
+    cheaper than ``_pairs_to_hex`` per curve. An all-zero tuple is the unset id
+    (falsy via ``any``).
+    """
+    n = len(curve_data.curves)
+    key = (id(curve_data), field)
+    cached = _uuid_raw_cache.get(key)
+    if cached is not None and len(cached) == n:
+        return cached
+
+    lo = curve_data.attributes.get(f".{field}_lo")
+    hi = curve_data.attributes.get(f".{field}_hi")
+    if n == 0 or not lo or not hi:
+        return [(0, 0, 0, 0)] * n
+    lob = np.zeros(n * 2, dtype=np.int32)
+    hib = np.zeros(n * 2, dtype=np.int32)
+    lo.data.foreach_get("value", lob)
+    hi.data.foreach_get("value", hib)
+    result = [
+        (int(lob[2 * i]), int(lob[2 * i + 1]), int(hib[2 * i]), int(hib[2 * i + 1]))
+        for i in range(n)
+    ]
+    _uuid_raw_cache[key] = result
     return result
 
 
@@ -296,21 +334,24 @@ def invalidate_curve_id_cache(sketch=None):
         _curve_id_cache.pop(sk_key, None)
         for field in UUID_FIELDS:
             _uuid_list_cache.pop((sk_key, field), None)
+            _uuid_raw_cache.pop((sk_key, field), None)
     else:
         _curve_id_cache.clear()
         _uuid_list_cache.clear()
+        _uuid_raw_cache.clear()
 
 
 # ---------------------------------------------------------------------------
 # Curve data access
 # ---------------------------------------------------------------------------
 
+
 def _get_original_data(sketch):
     """Get the original (non-evaluated) Curves data for a sketch."""
     obj = sketch.target_object
     if not obj or not obj.data:
         return None
-    if hasattr(obj, 'original') and obj.original and obj.original.data:
+    if hasattr(obj, "original") and obj.original and obj.original.data:
         return obj.original.data
     return obj.data
 
@@ -434,7 +475,7 @@ def ensure_sketch_curve_object(sketch):
     assert sketch is not None, "ensure_sketch_curve_object: sketch is None"
 
     wp_obj = sketch.workplane_object
-    if not wp_obj and hasattr(sketch, 'wp') and not sketch.wp:
+    if not wp_obj and hasattr(sketch, "wp") and not sketch.wp:
         logger.warning("ensure_sketch_curve_object: no workplane empty or entity")
         return None
 
@@ -448,7 +489,7 @@ def ensure_sketch_curve_object(sketch):
 
         if wp_obj:
             ob.matrix_world = wp_obj.matrix_world
-        elif hasattr(sketch, 'wp') and sketch.wp:
+        elif hasattr(sketch, "wp") and sketch.wp:
             ob.matrix_world = sketch.wp.matrix_basis
 
         scene = bpy.context.scene
@@ -460,6 +501,7 @@ def ensure_sketch_curve_object(sketch):
 
         # Stamp sketch custom properties
         from ..model.sketch_ref import stamp_sketch_props
+
         stamp_sketch_props(ob)
 
     assert sketch.target_object is not None, "target_object should exist after ensure"
@@ -535,6 +577,7 @@ class batch_update:
 
     Pass ``point_ids`` to rebuild only the segments referencing those points.
     """
+
     def __init__(self, sketch, point_ids=None):
         self.sketch = sketch
         self.point_ids = point_ids
@@ -622,8 +665,10 @@ def _resegment_arcs(sketch, cd, point_ids=None):
 
     # Arcs to consider (all, or only those touching a changed point).
     arc_indices = [
-        i for i in range(n)
-        if types[i] == SketchCurveType.ARC and (
+        i
+        for i in range(n)
+        if types[i] == SketchCurveType.ARC
+        and (
             point_ids is None
             or sp_ids[i] in point_ids
             or ep_ids[i] in point_ids
@@ -703,8 +748,10 @@ def compute_merge_ids(sketch):
     if n_points == 0 or not type_attr:
         return False
 
-    sp_ids = read_uuid_list(cd, "start_point_id")
-    ep_ids = read_uuid_list(cd, "end_point_id")
+    # Only equality of endpoint ids matters here (shared junction -> shared weld
+    # id), so read the raw id tuples and skip the per-curve hex formatting.
+    sp_ids = read_uuid_raw_list(cd, "start_point_id")
+    ep_ids = read_uuid_raw_list(cd, "end_point_id")
 
     ids = np.zeros(n_points, dtype=np.int32)
     dense = {}
@@ -721,9 +768,9 @@ def compute_merge_ids(sketch):
         npt = cv.points_length
         if npt < 2:
             continue
-        if sp_ids[i]:
+        if any(sp_ids[i]):
             ids[cv.points[0].index] = junction(sp_ids[i])
-        if ep_ids[i]:
+        if any(ep_ids[i]):
             ids[cv.points[npt - 1].index] = junction(ep_ids[i])
 
     attr = cd.attributes.get("merge_id")
@@ -784,6 +831,11 @@ def rebuild_segments(sketch, point_ids=None):
                 p = cd.points[cs.points[0].index].position
                 point_co[cid_list[i]] = Vector((p[0], p[1]))
 
+    # Handle attributes are the same collection for every segment; fetch once
+    # rather than re-resolving them by name inside the per-segment loop below.
+    handle_left = cd.attributes.get("handle_left")
+    handle_right = cd.attributes.get("handle_right")
+
     for i in range(n):
         ctype = type_attr.data[i].value
         if ctype == SketchCurveType.POINT:
@@ -791,9 +843,7 @@ def rebuild_segments(sketch, point_ids=None):
 
         # Scoped rebuild: skip segments that don't touch a changed point.
         if point_ids is not None and not (
-            sp_ids[i] in point_ids
-            or ep_ids[i] in point_ids
-            or cp_ids[i] in point_ids
+            sp_ids[i] in point_ids or ep_ids[i] in point_ids or cp_ids[i] in point_ids
         ):
             continue
 
@@ -809,20 +859,24 @@ def rebuild_segments(sketch, point_ids=None):
         if ctype == SketchCurveType.LINE:
             sp_co = point_co.get(sp_ids[i])
             ep_co = point_co.get(ep_ids[i])
-            hl = cd.attributes.get("handle_left")
-            hr = cd.attributes.get("handle_right")
+            hl = handle_left
+            hr = handle_right
             if sp_co is not None:
                 pos = (sp_co.x, sp_co.y, 0.0)
                 idx = curve_slice.points[0].index
                 cd.points[idx].position = pos
-                if hl: hl.data[idx].vector = pos
-                if hr: hr.data[idx].vector = pos
+                if hl:
+                    hl.data[idx].vector = pos
+                if hr:
+                    hr.data[idx].vector = pos
             if ep_co is not None:
                 pos = (ep_co.x, ep_co.y, 0.0)
                 idx = curve_slice.points[1].index
                 cd.points[idx].position = pos
-                if hl: hl.data[idx].vector = pos
-                if hr: hr.data[idx].vector = pos
+                if hl:
+                    hl.data[idx].vector = pos
+                if hr:
+                    hr.data[idx].vector = pos
 
         elif ctype in (SketchCurveType.ARC, SketchCurveType.CIRCLE):
             ct_co = point_co.get(cp_ids[i])
@@ -876,28 +930,30 @@ def refresh_curve_geometry(sketch):
     for attr in curve_data.attributes:
         if attr.name == "position":
             continue
-        domain_len = n_points if attr.domain == 'POINT' else n_curves
-        if attr.data_type == 'FLOAT_VECTOR':
+        domain_len = n_points if attr.domain == "POINT" else n_curves
+        if attr.data_type == "FLOAT_VECTOR":
             data = np.zeros(domain_len * 3, dtype=np.float32)
             attr.data.foreach_get("vector", data)
-        elif attr.data_type == 'BOOLEAN':
+        elif attr.data_type == "BOOLEAN":
             data = np.zeros(domain_len, dtype=np.bool_)
             attr.data.foreach_get("value", data)
-        elif attr.data_type in ('INT', 'INT8'):
+        elif attr.data_type in ("INT", "INT8"):
             data = np.zeros(domain_len, dtype=np.int32)
             attr.data.foreach_get("value", data)
-        elif attr.data_type in ('INT32_2D', 'INT16_2D'):
+        elif attr.data_type in ("INT32_2D", "INT16_2D"):
             data = np.zeros(domain_len * 2, dtype=np.int32)
             attr.data.foreach_get("value", data)
-        elif attr.data_type == 'FLOAT':
+        elif attr.data_type == "FLOAT":
             data = np.zeros(domain_len, dtype=np.float32)
             attr.data.foreach_get("value", data)
-        elif attr.data_type == 'STRING':
+        elif attr.data_type == "STRING":
             data = [attr.data[i].value for i in range(domain_len)]
         else:
             continue
         saved_attrs[attr.name] = {
-            "data": data, "type": attr.data_type, "domain": attr.domain,
+            "data": data,
+            "type": attr.data_type,
+            "domain": attr.domain,
         }
 
     curve_data.remove_curves()
@@ -909,11 +965,13 @@ def refresh_curve_geometry(sketch):
     for name, info in saved_attrs.items():
         attr = curve_data.attributes.get(name)
         if not attr:
-            attr = curve_data.attributes.new(name, type=info["type"], domain=info["domain"])
-        if info["type"] == 'STRING':
+            attr = curve_data.attributes.new(
+                name, type=info["type"], domain=info["domain"]
+            )
+        if info["type"] == "STRING":
             for i, v in enumerate(info["data"]):
                 attr.data[i].value = v
-        elif info["type"] == 'FLOAT_VECTOR':
+        elif info["type"] == "FLOAT_VECTOR":
             attr.data.foreach_set("vector", info["data"])
         else:
             attr.data.foreach_set("value", info["data"])

--- a/utilities/curve_data.py
+++ b/utilities/curve_data.py
@@ -90,6 +90,14 @@ def get_uuid(curve_data, field, index):
     return _pairs_to_hex(lo_v, hi_v)
 
 
+# (id(curve_data), field) -> list of hex ids. Identity fields are immutable after
+# creation, so this is invalidated only by set_uuid (a value write) and by
+# add/remove via invalidate_curve_id_cache. Serves the hot read paths (solver,
+# segment rebuild, draw/pick) without re-deriving every hex id from its int
+# attributes on each call -- the dominant cost in solve and draw (issue #342).
+_uuid_list_cache = {}
+
+
 def set_uuid(curve_data, field, index, value):
     """Write a hex-string identity field into its 2 INT32_2D sub-attributes."""
     lo_pair, hi_pair = _hex_to_pairs(value)
@@ -99,6 +107,7 @@ def set_uuid(curve_data, field, index, value):
         lo.data[index].value = lo_pair
     if hi:
         hi.data[index].value = hi_pair
+    _uuid_list_cache.pop((id(curve_data), field), None)
 
 
 def new_uuid():
@@ -107,13 +116,21 @@ def new_uuid():
 
 
 def read_uuid_list(curve_data, field):
-    """All curves' ids for a field as hex strings, read in bulk.
+    """All curves' ids for a field as hex strings, read in bulk (cached).
 
     Uses foreach_get on the 2 INT32_2D sub-attributes — far cheaper than calling
-    get_uuid() per curve in hot loops (attribute lookup happens twice total
-    instead of twice per curve).
+    get_uuid() per curve in hot loops. Memoized per (curve_data, field): identity
+    fields don't change except through set_uuid / add / remove, all of which
+    invalidate the entry, so repeated reads within a solve or across frames are
+    free. The length guard rebuilds if the curve count changed without an
+    explicit invalidation.
     """
     n = len(curve_data.curves)
+    key = (id(curve_data), field)
+    cached = _uuid_list_cache.get(key)
+    if cached is not None and len(cached) == n:
+        return cached
+
     lo = curve_data.attributes.get(f".{field}_lo")
     hi = curve_data.attributes.get(f".{field}_hi")
     if n == 0 or not lo or not hi:
@@ -122,11 +139,13 @@ def read_uuid_list(curve_data, field):
     hib = np.zeros(n * 2, dtype=np.int32)
     lo.data.foreach_get("value", lob)
     hi.data.foreach_get("value", hib)
-    return [
+    result = [
         _pairs_to_hex((int(lob[2 * i]), int(lob[2 * i + 1])),
                       (int(hib[2 * i]), int(hib[2 * i + 1])))
         for i in range(n)
     ]
+    _uuid_list_cache[key] = result
+    return result
 
 
 def default_curve_name(curve_data, ctype):
@@ -234,28 +253,11 @@ def init_string_attrs(curve_data, curve_idx):
 # ---------------------------------------------------------------------------
 
 _curve_id_cache = {}
-# id(curve_data) -> ordered list of curve_id hex strings. Curve ids are immutable
-# after creation, so the only thing that changes this list is add/remove -- which
-# already calls invalidate_curve_id_cache. Caching it keeps the per-frame draw and
-# picking paths from re-deriving every hex id from its int attributes each frame.
-_curve_id_list_cache = {}
 
 
 def read_curve_id_list(curve_data):
-    """Cached ordered list of curve_id hex strings for ``curve_data``.
-
-    Same result as ``read_uuid_list(curve_data, "curve_id")`` but memoized on the
-    add/remove lifetime, avoiding the pure-Python int->hex conversion on every
-    draw/pick. The length guard rebuilds if the curve count changed without an
-    explicit invalidation.
-    """
-    key = id(curve_data)
-    lst = _curve_id_list_cache.get(key)
-    if lst is not None and len(lst) == len(curve_data.curves):
-        return lst
-    lst = read_uuid_list(curve_data, "curve_id")
-    _curve_id_list_cache[key] = lst
-    return lst
+    """Cached ordered list of curve_id hex strings (see read_uuid_list)."""
+    return read_uuid_list(curve_data, "curve_id")
 
 
 def _allocate_curve_id(sketch):
@@ -292,10 +294,11 @@ def invalidate_curve_id_cache(sketch=None):
     if sketch and sketch.target_object:
         sk_key = id(sketch.target_object.data)
         _curve_id_cache.pop(sk_key, None)
-        _curve_id_list_cache.pop(sk_key, None)
+        for field in UUID_FIELDS:
+            _uuid_list_cache.pop((sk_key, field), None)
     else:
         _curve_id_cache.clear()
-        _curve_id_list_cache.clear()
+        _uuid_list_cache.clear()
 
 
 # ---------------------------------------------------------------------------

--- a/utilities/curve_data.py
+++ b/utilities/curve_data.py
@@ -747,7 +747,7 @@ def rebuild_segments(sketch, point_ids=None):
     from mathutils import Vector
 
     from ..model.constants import SketchCurveType
-    from ..model.curve_ref import PointRef, _build_arc_bezier
+    from ..model.curve_ref import _build_arc_bezier
 
     if not sketch or not sketch.target_object or not sketch.target_object.data:
         return
@@ -772,6 +772,18 @@ def rebuild_segments(sketch, point_ids=None):
     ep_ids = read_uuid_list(cd, "end_point_id")
     cp_ids = read_uuid_list(cd, "center_point_id")
 
+    # Map point curve_id -> local 2D position once, so segment endpoints resolve
+    # by dict lookup instead of a PointRef per endpoint (each of which re-resolved
+    # curve data twice). This is the bulk of solve's per-edit cost (issue #342).
+    cid_list = read_uuid_list(cd, "curve_id")
+    point_co = {}
+    for i in range(n):
+        if type_attr.data[i].value == SketchCurveType.POINT:
+            cs = cd.curves[i]
+            if cs.points_length:
+                p = cd.points[cs.points[0].index].position
+                point_co[cid_list[i]] = Vector((p[0], p[1]))
+
     for i in range(n):
         ctype = type_attr.data[i].value
         if ctype == SketchCurveType.POINT:
@@ -795,46 +807,36 @@ def rebuild_segments(sketch, point_ids=None):
             continue
 
         if ctype == SketchCurveType.LINE:
-            sp_cid = sp_ids[i]
-            ep_cid = ep_ids[i]
-            if sp_cid:
-                p1 = PointRef(sketch, sp_cid)
-                if p1.valid:
-                    pos = (*p1.co, 0.0)
-                    cd.points[curve_slice.points[0].index].position = pos
-                    hl = cd.attributes.get("handle_left")
-                    hr = cd.attributes.get("handle_right")
-                    if hl: hl.data[curve_slice.points[0].index].vector = pos
-                    if hr: hr.data[curve_slice.points[0].index].vector = pos
-            if ep_cid:
-                p2 = PointRef(sketch, ep_cid)
-                if p2.valid:
-                    pos = (*p2.co, 0.0)
-                    cd.points[curve_slice.points[1].index].position = pos
-                    hl = cd.attributes.get("handle_left")
-                    hr = cd.attributes.get("handle_right")
-                    if hl: hl.data[curve_slice.points[1].index].vector = pos
-                    if hr: hr.data[curve_slice.points[1].index].vector = pos
+            sp_co = point_co.get(sp_ids[i])
+            ep_co = point_co.get(ep_ids[i])
+            hl = cd.attributes.get("handle_left")
+            hr = cd.attributes.get("handle_right")
+            if sp_co is not None:
+                pos = (sp_co.x, sp_co.y, 0.0)
+                idx = curve_slice.points[0].index
+                cd.points[idx].position = pos
+                if hl: hl.data[idx].vector = pos
+                if hr: hr.data[idx].vector = pos
+            if ep_co is not None:
+                pos = (ep_co.x, ep_co.y, 0.0)
+                idx = curve_slice.points[1].index
+                cd.points[idx].position = pos
+                if hl: hl.data[idx].vector = pos
+                if hr: hr.data[idx].vector = pos
 
         elif ctype in (SketchCurveType.ARC, SketchCurveType.CIRCLE):
-            cp_cid = cp_ids[i]
-            if not cp_cid:
-                continue
-            ct = PointRef(sketch, cp_cid)
-            if not ct.valid:
+            ct_co = point_co.get(cp_ids[i])
+            if ct_co is None:
                 continue
             is_cyclic = ctype == SketchCurveType.CIRCLE
             if is_cyclic:
                 edge = Vector(cd.points[curve_slice.points[0].index].position[:2])
-                _build_arc_bezier(cd, i, ct.co, edge, edge, is_cyclic=True)
+                _build_arc_bezier(cd, i, ct_co, edge, edge, is_cyclic=True)
             else:
-                sp_cid = sp_ids[i]
-                ep_cid = ep_ids[i]
-                if sp_cid and ep_cid:
-                    s = PointRef(sketch, sp_cid)
-                    e = PointRef(sketch, ep_cid)
-                    if s.valid and e.valid:
-                        _build_arc_bezier(cd, i, ct.co, s.co, e.co)
+                s_co = point_co.get(sp_ids[i])
+                e_co = point_co.get(ep_ids[i])
+                if s_co is not None and e_co is not None:
+                    _build_arc_bezier(cd, i, ct_co, s_co, e_co)
 
     # Weld ids depend on connectivity (start/end_point_id), not positions, so
     # only recompute on a full rebuild -- a scoped move leaves topology intact.


### PR DESCRIPTION
Addresses the #342 slowdown. All the cost had one root cause: the same work redone every frame / every edit, scaling with file size — 128-bit int→hex UUID conversion, whole-scene snapshotting, and rebuilding unchanged sketches. Measured with a new headless harness (`scripts/perf_harness.py`).

## Results (synthetic, N=200 curves)
- **solve ~70% faster** (22ms → 6.4ms) — fires on every edit
- **build ~40% faster** and **hover-picking ~19×** (1.26ms → 0.07ms) — the per-mouse-move path
- The two biggest interaction-lag sources eliminated: inactive-sketch overlay rebuild on hover, and full-scene undo snapshot on every draw mouse-move (~15ms → ~4ms)

## Commits
- **Cache curve_id hex list** — draw/pick stop re-deriving hex ids each frame
- **Perf harness** (`scripts/perf_harness.py`) — the measurement tool
- **Cache picking extraction across hover** — hovering unchanged geometry no longer rebuilds
- **Bulk-read uuids in solver** — `_init_geometry`/`_write_results` read id lists once, not per-curve
- **Cache `read_uuid_list` for all id fields** — reused across a solve; invalidated on any id write
- **`rebuild_segments` position map** — endpoints via dict lookup, not a PointRef (double resolve) each
- **Cache dimensional gizmo shape** — stop rebuilding the GPU batch every redraw (long-standing NOTE)
- **Don't rebuild inactive sketch overlays on hover** — global hover was in every sketch's cache signature
- **Scope 2D draw undo snapshot to the active sketch** — skip whole-scene serialization each mouse-move

Every cache is invalidated on the events that change its inputs (add/remove/id-write/geometry/selection), each with a length or signature guard. Full suite green throughout (211 tests, +regression tests for each cache). The GPU-draw and viewport-bound parts (gizmo shape, snapshot) are noted for in-viewport confirmation.

Note: this makes the addon itself realtime; the remaining #342 slowness on `Transparent.001` is the C solvespace solver thrashing on an *inconsistent* constraint system (94% of that solve is in the C solver, <6% Python) — separate and not fixable in Python.