### PR TITLE
Perf: headless harness + PR-delta CI (issue #342)

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,86 @@
+name: perf
+
+# Informational performance delta on each PR (issue #342). Runs the headless
+# harness (scripts/perf_harness.py --json) on the PR head and its base, then
+# comments the diff. Never fails the PR -- the op-count metrics are deterministic
+# and flagged on regression, while the _ms metrics are runner-noisy trend only.
+# See scripts/perf_harness.py / scripts/perf_compare.py.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  perf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: moguri/setup-blender@v1
+        with:
+          blender-version: latest
+
+      - name: Checkout head
+        uses: actions/checkout@v4
+        with:
+          path: head
+
+      - name: Bench head
+        run: |
+          cd head
+          blender --background --command extension build --output-filepath ./cs.zip
+          blender --background --command extension install-file --repo user_default --enable ./cs.zip
+          blender --background --python ./scripts/perf_harness.py -- --json "$GITHUB_WORKSPACE/head.json" || true
+          test -f "$GITHUB_WORKSPACE/head.json" && echo "head metrics captured" || echo "head bench produced no json"
+
+      - name: Checkout base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+
+      - name: Bench base
+        # The base commit may predate the harness; skip cleanly if so. Overwrites
+        # the installed extension (same id) -- head.json is already captured.
+        run: |
+          cd base
+          if [ -f scripts/perf_harness.py ]; then
+            blender --background --command extension build --output-filepath ./cs.zip
+            blender --background --command extension install-file --repo user_default --enable ./cs.zip
+            blender --background --python ./scripts/perf_harness.py -- --json "$GITHUB_WORKSPACE/base.json" || true
+          else
+            echo "base has no perf harness; head-only comparison"
+          fi
+
+      - name: Compare
+        run: |
+          python3 head/scripts/perf_compare.py "$GITHUB_WORKSPACE/base.json" "$GITHUB_WORKSPACE/head.json" > "$GITHUB_WORKSPACE/perf.md" || echo "compare failed" > "$GITHUB_WORKSPACE/perf.md"
+          cat "$GITHUB_WORKSPACE/perf.md"
+          cat "$GITHUB_WORKSPACE/perf.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- cad-sketcher-perf -->';
+            let body = marker + '\n';
+            try { body += fs.readFileSync('perf.md', 'utf8'); }
+            catch (e) { body += 'Perf harness produced no output.'; }
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo, issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo, issue_number: context.issue.number, body,
+              });
+            }

--- a/scripts/perf_compare.py
+++ b/scripts/perf_compare.py
@@ -1,0 +1,104 @@
+"""Render a Markdown perf-delta table from two ``perf_harness.py --json`` runs.
+
+Used by the perf CI workflow to comment head-vs-base on a PR. Plain Python (no
+Blender), reads two JSON files and writes Markdown to stdout:
+
+    python3 scripts/perf_compare.py base.json head.json
+
+``base.json`` is optional -- if it's missing or unparseable (e.g. the base
+commit predates the harness), only the head numbers are shown.
+
+Two metric kinds, distinguished by the ``_ms`` suffix:
+  * ``*_ms``  wall-clock, machine-dependent -- shown as an informational trend.
+  * others    op-counts, deterministic -- an increase is a real regression and
+              is flagged.
+"""
+
+import json
+import sys
+
+
+def _load(path):
+    try:
+        with open(path) as f:
+            return json.load(f).get("metrics", {})
+    except (OSError, ValueError):
+        return None
+
+
+def _fmt(v):
+    if isinstance(v, float):
+        return f"{v:.3f}"
+    return str(v)
+
+
+def main():
+    base_path, head_path = sys.argv[1], sys.argv[2]
+    base = _load(base_path)
+    head = _load(head_path)
+
+    if not head:
+        print("Perf harness produced no head metrics.")
+        return 0
+
+    lines = ["### ⏱️ Performance", ""]
+    if base is None:
+        lines += [
+            "_No comparable base metrics (the base commit predates the perf "
+            "harness); showing head values only._",
+            "",
+            "| metric | head |",
+            "| --- | ---: |",
+        ]
+        for k in sorted(head):
+            lines.append(f"| `{k}` | {_fmt(head[k])} |")
+        print("\n".join(lines))
+        return 0
+
+    lines += [
+        "| metric | base | head | Δ | |",
+        "| --- | ---: | ---: | ---: | :-- |",
+    ]
+    regressed = []
+    for k in sorted(set(base) | set(head)):
+        b = base.get(k)
+        h = head.get(k)
+        if b is None or h is None:
+            lines.append(
+                f"| `{k}` | {_fmt(b) if b is not None else '—'} "
+                f"| {_fmt(h) if h is not None else '—'} | new/removed | |"
+            )
+            continue
+        is_count = not k.endswith("_ms")
+        if is_count:
+            # Deterministic: any increase is a real regression.
+            delta = h - b
+            flag = "🔴" if delta > 0 else ("🟢" if delta < 0 else "")
+            if delta > 0:
+                regressed.append(k)
+            lines.append(f"| `{k}` | {b} | {h} | {delta:+d} | {flag} |")
+        else:
+            # Wall-clock: informational; big swings are runner noise.
+            pct = (h - b) / b * 100 if b else 0.0
+            flag = "≈ (noisy)"
+            lines.append(f"| `{k}` | {_fmt(b)} | {_fmt(h)} | {pct:+.0f}% | {flag} |")
+
+    lines.append("")
+    if regressed:
+        lines.append(
+            "🔴 **Op-count regression** in "
+            + ", ".join(f"`{k}`" for k in regressed)
+            + " — a cache/fast-path is being bypassed. `_ms` deltas are runner "
+            "noise; the op-counts are the signal."
+        )
+    else:
+        lines.append(
+            "🟢 No op-count regressions. (`_ms` deltas are runner noise — the "
+            "op-counts are the deterministic signal.)"
+        )
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/perf_harness.py
+++ b/scripts/perf_harness.py
@@ -1,0 +1,280 @@
+"""Headless performance harness for the interaction hot paths.
+
+Builds sketches of increasing size and times the work that runs *per user
+interaction* -- the paths behind the slowdown reported in issue #342 ("every
+operation takes seconds, worse over time, fine when the sketch is hidden"):
+
+    render_data.build   the core of both picking (per mouse-move) and the
+                        overlay draw (per redraw); runs twice per frame
+    solve_system        fires on every edit
+    refresh_curve_geometry  rebuilds the generated mesh after a solve
+    validate_all_sketches   the depsgraph self-heal pass
+
+Run:  blender --background --python scripts/perf_harness.py
+  --profile   also cProfile render_data.build at the largest size
+  --json      emit machine-readable metrics (for the perf-delta CI comment)
+              instead of the human table
+
+Two kinds of metric are reported:
+  * wall-clock ms  -- machine-dependent; a useful trend, not a hard gate.
+  * op-counts      -- deterministic (identical on every machine): how many times
+                      a hot function runs in a fixed scenario. These are the real
+                      regression signal -- e.g. a warm build should do ZERO hex
+                      conversions, and 20 hover picks should trigger ONE build.
+"""
+
+import cProfile
+import io
+import json
+import pstats
+import sys
+import time
+
+import addon_utils
+import bpy
+
+SIZES = (10, 25, 50, 100, 200)
+# Size used for the single-number JSON metrics (a mid-size sketch: big enough to
+# be meaningful, small enough to keep the CI job fast).
+JSON_SIZE = 100
+PROFILE = "--profile" in sys.argv
+JSON = "--json" in sys.argv
+
+
+def _enable():
+    for mod in addon_utils.modules():
+        if mod.__name__.split(".")[-1] == "CAD_Sketcher":
+            addon_utils.enable(mod.__name__, default_set=True)
+            return mod.__name__
+    raise SystemExit("CAD_Sketcher not found -- is it installed?")
+
+
+PKG = _enable()
+M = sys.modules[PKG]
+sr = M.model.sketch_ref
+cr = M.model.curve_ref
+cd = M.utilities.curve_data
+rd = M.drawing.render_data
+picking = M.drawing.picking
+solve = M.curve_solver.solve_system
+
+import importlib  # noqa: E402
+
+validate = importlib.import_module(PKG + ".utilities.validate")
+
+
+class _StubTheme:
+    """Colours build() reads; values are irrelevant to timing."""
+
+    default = selected = selected_highlight = highlight = (1, 1, 1, 1)
+    fixed = inactive = inactive_selected = (1, 1, 1, 1)
+
+
+def _clear():
+    for o in list(bpy.data.objects):
+        if o.type in ("CURVES", "EMPTY"):
+            bpy.data.objects.remove(o, do_unlink=True)
+
+
+def _new_sketch():
+    ctx = bpy.context
+    ents = ctx.scene.sketcher.entities
+    ents.ensure_origin_elements(ctx)
+    esk = ents.add_sketch(ents.origin_plane_XY)
+    cd.ensure_sketch_curve_object(esk)
+    sr.stamp_sketch_props(esk.target_object)
+    return sr.Sketch(esk.target_object)
+
+
+def _build_chain(sketch, n):
+    """A connected chain of n distance-constrained segments (real solver work,
+    real shared junctions)."""
+    import math
+
+    sc = sketch.constraints
+    with cd.batch_update(sketch):
+        pts = [cr.PointRef.create(sketch, (0, 0), fixed=True)]
+        for i in range(1, n + 1):
+            pts.append(
+                cr.PointRef.create(
+                    sketch, (math.cos(i) * i * 0.1, math.sin(i) * i * 0.1)
+                )
+            )
+        lines = [cr.LineRef.create(sketch, pts[i], pts[i + 1]) for i in range(n)]
+    for ln in lines:
+        sc.add_distance(init=True, curve_id_1=ln.curve_id)
+    return len(sketch.target_object.data.curves)
+
+
+def _timeit(fn, iters):
+    fn()  # warm
+    t = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    return (time.perf_counter() - t) / iters * 1000  # ms/call
+
+
+def _call_count(fn, iters, func_name):
+    """How many times ``func_name`` runs while calling ``fn`` ``iters`` times.
+
+    Deterministic and machine-independent -- the metric the CI guard relies on.
+    Assumes the relevant caches are already warm (call fn once before this).
+    """
+    pr = cProfile.Profile()
+    pr.enable()
+    for _ in range(iters):
+        fn()
+    pr.disable()
+    total = 0
+    for (_f, _l, name), (_cc, nc, *_rest) in pstats.Stats(pr).stats.items():
+        if name == func_name:
+            total += nc
+    return total
+
+
+def _safe(metrics, key, thunk):
+    """Record ``metrics[key] = thunk()``, but skip the metric if the code path
+    it probes doesn't exist yet.
+
+    The CI benches both the PR head *and* its base with this harness. A base
+    commit may predate the optimization a given metric guards (e.g. the picking
+    cache), so probing it would raise -- we omit the metric there rather than
+    crash, and ``perf_compare.py`` shows it as new on the head side.
+    """
+    try:
+        metrics[key] = thunk()
+    except Exception as exc:  # pragma: no cover - version-robustness only
+        print(f"skip metric {key!r}: {exc}", file=sys.stderr)
+
+
+def _table():
+    ts = _StubTheme()
+    header = f"{'N_seg':>6} {'curves':>7} {'build':>8} {'solve':>8} {'refresh':>8} {'validate':>9}"
+    print(header + "   (ms/call)")
+    last_sketch = None
+    for n in SIZES:
+        _clear()
+        sk = _new_sketch()
+        ncur = _build_chain(sk, n)
+        solve(bpy.context, sketch=sk)
+        scene = bpy.context.scene
+        b = _timeit(lambda: rd.build(sk, ts, True), 30)
+        s = _timeit(lambda: solve(bpy.context, sketch=sk), 10)
+        r = _timeit(lambda: cd.refresh_curve_geometry(sk), 10)
+        v = _timeit(lambda: validate.validate_all_sketches(scene), 10)
+        print(f"{n:>6} {ncur:>7} {b:>8.2f} {s:>8.2f} {r:>8.2f} {v:>9.2f}")
+        last_sketch = sk
+
+    if PROFILE and last_sketch is not None:
+        print(f"\n=== cProfile: render_data.build (N={SIZES[-1]}) ===")
+        pr = cProfile.Profile()
+        pr.enable()
+        for _ in range(50):
+            rd.build(last_sketch, ts, True)
+        pr.disable()
+        buf = io.StringIO()
+        pstats.Stats(pr, stream=buf).sort_stats("tottime").print_stats(12)
+        print("\n".join(buf.getvalue().splitlines()[:20]))
+
+
+def _metrics():
+    """Collect the JSON metrics at a single representative size."""
+    ts = _StubTheme()
+    _clear()
+    sk = _new_sketch()
+    _build_chain(sk, JSON_SIZE)
+    solve(bpy.context, sketch=sk)
+    sr.set_active_sketch(bpy.context, sk.target_object)
+
+    metrics = {}
+
+    # -- wall-clock (informational trend; machine-dependent) --
+    metrics["build_ms"] = round(_timeit(lambda: rd.build(sk, ts, True), 30), 4)
+    metrics["solve_ms"] = round(_timeit(lambda: solve(bpy.context, sketch=sk), 10), 4)
+    metrics["refresh_ms"] = round(_timeit(lambda: cd.refresh_curve_geometry(sk), 10), 4)
+
+    # -- op-counts (deterministic; the real regression signal) --
+    # Each is measured from a warm cache (refresh above invalidated it), so it
+    # reflects steady-state interaction. A warm build/solve must do ZERO hex
+    # conversions -- read_uuid_list caches them; if that breaks, the count jumps
+    # to ~one-per-curve-per-call.
+    rd.build(sk, ts, True)  # warm
+    _safe(
+        metrics,
+        "build_hex_calls",
+        lambda: _call_count(lambda: rd.build(sk, ts, True), 10, "_pairs_to_hex"),
+    )
+    solve(bpy.context, sketch=sk)  # warm
+    _safe(
+        metrics,
+        "solve_hex_calls",
+        lambda: _call_count(lambda: solve(bpy.context, sketch=sk), 5, "_pairs_to_hex"),
+    )
+
+    # 20 hovers on unchanged geometry must trigger ONE extraction (the first),
+    # not 20 -- the picking cache. If it breaks, this jumps to 20. (No cache on a
+    # pre-optimization base: _active_data rebuilds each hover, so it reads ~20.)
+    def _hover20():
+        if hasattr(picking, "_pick_cache"):
+            picking._pick_cache.clear()
+        return _call_count(lambda: picking._active_data(bpy.context), 20, "build")
+
+    _safe(metrics, "hover20_build_calls", _hover20)
+
+    # A solve resolves segment endpoints from a position map, not a PointRef
+    # (double curve-data resolve) each. If rebuild_segments reverts to per-
+    # endpoint PointRefs, get_curve_data calls jump ~2x the segment count.
+    solve(bpy.context, sketch=sk)  # warm
+    _safe(
+        metrics,
+        "solve_curve_lookups",
+        lambda: _call_count(lambda: solve(bpy.context, sketch=sk), 3, "get_curve_data"),
+    )
+
+    # A 2D draw operator's per-mouse-move undo snapshot is scoped to the active
+    # sketch and must NOT re-serialize the whole scene. Add a second sketch so a
+    # regression to the full-scene snapshot is visible, then count scene_to_dict
+    # calls in one snapshot -- 0 when scoped, 1+ if it reverts.
+    def _draw_snapshot_scene_calls():
+        sk2 = _new_sketch()
+        _build_chain(sk2, 20)
+        sr.set_active_sketch(bpy.context, sk.target_object)
+        op2d = importlib.import_module(PKG + ".operators.base_2d")
+        probe = op2d.Operator2d.__new__(op2d.Operator2d)
+        probe.create_snapshot(bpy.context)  # warm
+        return _call_count(
+            lambda: probe.create_snapshot(bpy.context), 5, "scene_to_dict"
+        )
+
+    _safe(metrics, "draw_snapshot_scene_calls", _draw_snapshot_scene_calls)
+
+    return {"size": JSON_SIZE, "metrics": metrics}
+
+
+def _json_out_path():
+    """Optional file path after ``--json`` (Blender/addon logging pollutes
+    stdout, so CI captures the JSON from a file instead)."""
+    args = sys.argv[sys.argv.index("--json") + 1 :]
+    for a in args:
+        if not a.startswith("-"):
+            return a
+    return None
+
+
+def main():
+    if JSON:
+        result = _metrics()
+        out = _json_out_path()
+        if out:
+            with open(out, "w") as f:
+                json.dump(result, f, indent=2)
+            print(f"perf metrics written to {out}")
+        else:
+            json.dump(result, sys.stdout, indent=2)
+            sys.stdout.write("\n")
+    else:
+        _table()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Splits the performance **tooling** out of #599 (which now holds only the runtime optimizations) into its own reviewable PR.

## What this adds
- **`scripts/perf_harness.py`** — headless harness that builds distance-constrained sketch chains and measures the per-interaction hot paths behind #342. Reports two metric kinds:
  - **wall-clock ms** — machine-dependent trend (build/solve/refresh/validate).
  - **op-counts** — deterministic, machine-independent counts of how often a hot function runs in a fixed scenario. These are the real regression signal:
    - `build_hex_calls` / `solve_hex_calls` — UUID→hex conversions in a warm build/solve (**0** when the id-list cache works).
    - `hover20_build_calls` — extractions for 20 hovers on unchanged geometry (**1**, the picking cache).
    - `solve_curve_lookups` — `get_curve_data` calls in a warm solve (**0**, the `rebuild_segments` position map).
    - `draw_snapshot_scene_calls` — whole-scene serializations in one 2D-draw undo snapshot (**0**, the scoped snapshot).
- **`scripts/perf_compare.py`** — renders a Markdown head-vs-base delta table; any op-count **increase** is flagged 🔴, `_ms` deltas are labeled runner-noise.
- **`.github/workflows/perf.yml`** — benches head + base with the harness and posts a sticky per-PR delta comment. **Non-gating** (informational).

## Version-robust by design
The harness runs on a **pre-optimization base** too (each op-count degrades gracefully), so the CI comment shows real deltas rather than head-only numbers. Measured base(main) → head(#599):

| metric | base | head |
| --- | ---: | ---: |
| `build_hex_calls` | 2010 | 0 |
| `solve_hex_calls` | 9545 | 0 |
| `hover20_build_calls` | 20 | 1 |
| `solve_curve_lookups` | 1503 | 0 |
| `draw_snapshot_scene_calls` | 5 | 0 |

Op-counts counted via `cProfile` (`nc` per function) — exact and identical on any machine.

Merging this before #599 lets #599's own perf comment surface those deltas.