### PR TITLE
Add direct value entry for dimensional constraints

### DIFF
--- a/operators/add_angle.py
+++ b/operators/add_angle.py
@@ -1,15 +1,13 @@
 import logging
 
-from bpy.types import Operator, Context
-from bpy.props import FloatProperty, BoolProperty
-
-from ..utilities.constants import HALF_TURN
+from bpy.props import BoolProperty, FloatProperty
+from bpy.types import Context, Operator
 
 from ..declarations import Operators
-from ..stateful_operator.utilities.register import register_stateops_factory
-from .base_constraint import GenericConstraintOp
-
 from ..model.angle import SlvsAngle
+from ..stateful_operator.utilities.register import register_stateops_factory
+from ..utilities.constants import HALF_TURN
+from .base_constraint import GenericConstraintOp
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +47,7 @@ class VIEW3D_OT_slvs_add_angle(Operator, GenericConstraintOp):
     )
     type = "ANGLE"
     property_keys = ("value", "setting")
+    has_value_state = True
 
     def main(self, context):
         if not self.exists(context, SlvsAngle):
@@ -56,7 +55,7 @@ class VIEW3D_OT_slvs_add_angle(Operator, GenericConstraintOp):
                 init=not self.initialized,
                 curve_id_1=self.entity1.curve_id,
                 curve_id_2=self.entity2.curve_id,
-                **self.get_settings()
+                **self.get_settings(),
             )
 
         return super().main(context)

--- a/operators/add_diameter.py
+++ b/operators/add_diameter.py
@@ -1,13 +1,12 @@
 import logging
 
+from bpy.props import BoolProperty, FloatProperty
 from bpy.types import Operator
-from bpy.props import FloatProperty, BoolProperty
 
 from ..declarations import Operators
+from ..model.diameter import SlvsDiameter
 from ..stateful_operator.utilities.register import register_stateops_factory
 from .base_constraint import GenericConstraintOp
-
-from ..model.diameter import SlvsDiameter
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +29,7 @@ class VIEW3D_OT_slvs_add_diameter(Operator, GenericConstraintOp):
     setting: BoolProperty(name="Use Radius")
     type = "DIAMETER"
     property_keys = ("value", "setting")
+    has_value_state = True
 
     def main(self, context):
         if not self.exists(context, SlvsDiameter):

--- a/operators/add_distance.py
+++ b/operators/add_distance.py
@@ -1,15 +1,13 @@
 import logging
 
-from bpy.types import Operator, Context
-from bpy.props import BoolProperty, FloatProperty, EnumProperty
+from bpy.props import BoolProperty, EnumProperty, FloatProperty
+from bpy.types import Context, Operator
 
-from .base_constraint import GenericConstraintOp
-from ..model.distance import align_items
 from ..declarations import Operators
+from ..model.curve_ref import LineRef, PointRef
+from ..model.distance import SlvsDistance, align_items
 from ..stateful_operator.utilities.register import register_stateops_factory
-from ..model.curve_ref import PointRef, LineRef
-
-from ..model.distance import SlvsDistance
+from .base_constraint import GenericConstraintOp
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +31,7 @@ class VIEW3D_OT_slvs_add_distance(Operator, GenericConstraintOp):
     flip: BoolProperty(name="Flip")
     type = "DISTANCE"
     property_keys = ("value", "align", "flip")
+    has_value_state = True
 
     def main(self, context):
         e1, e2 = self.entity1, self.entity2

--- a/operators/base_constraint.py
+++ b/operators/base_constraint.py
@@ -1,18 +1,17 @@
 import logging
-from ..model.sketch_ref import get_active_constraints
-from typing import List
-from bpy.types import Context
-from bpy.props import BoolProperty
 
-from ..utilities.bpy import setprop
-from ..model.types import SlvsConstraints
+from bpy.props import BoolProperty
+from bpy.types import Context
+
 from ..curve_solver import solve_system
-from ..utilities.curve_data import refresh_curve_geometry
+from ..model.sketch_ref import get_active_constraints
+from ..model.types import SlvsConstraints
 from ..stateful_operator.state import state_from_args
+from ..utilities.bpy import setprop
+from ..utilities.curve_data import refresh_curve_geometry
 from ..utilities.select import deselect_all
 from ..utilities.view import refresh
 from .base_2d import Operator2d
-
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +22,7 @@ class GenericConstraintOp(Operator2d):
     initialized: BoolProperty(default=False, options={"SKIP_SAVE", "HIDDEN"})
     _entity_prop_names = ("entity1", "entity2", "entity3", "entity4")
     property_keys = ()
+    has_value_state = False
 
     @classmethod
     def poll(cls, context):
@@ -70,7 +70,23 @@ class GenericConstraintOp(Operator2d):
                     use_create=False,
                 )
             )
+
+        if cls.has_value_state:
+            states.append(
+                state_from_args(
+                    "Value",
+                    description="Type a value or confirm the measured value.",
+                    property="value",
+                    state_func="_current_constraint_value",
+                    allow_prefill=False,
+                    optional=True,
+                )
+            )
+
         return states
+
+    def _current_constraint_value(self, _context, _coords):
+        return self.value
 
     def get_settings(self) -> dict:
         """Return a dictionary with settings that are already set"""

--- a/testing/test_constraint_ops.py
+++ b/testing/test_constraint_ops.py
@@ -8,8 +8,8 @@ never created). These tests drive them the way constraints are normally applied
 slots and ``main`` creates the constraint referencing them.
 """
 
-from .utils import Sketch2dTestCase, OpHarness
 from ..drawing import selection
+from .utils import OpHarness, Sketch2dTestCase
 
 
 class TestConstraintOperators(Sketch2dTestCase):
@@ -26,8 +26,8 @@ class TestConstraintOperators(Sketch2dTestCase):
 
     # -- two selected lines -> parallel constraint ---------------------------
     def test_parallel_from_two_selected_lines(self):
-        from ..operators.add_geometric_constraints import VIEW3D_OT_slvs_add_parallel
         from ..model.parallel import SlvsParallel
+        from ..operators.add_geometric_constraints import VIEW3D_OT_slvs_add_parallel
 
         l1 = self._line((0.0, 0.0), (4.0, 1.0))
         l2 = self._line((0.0, 3.0), (4.0, 5.0))
@@ -51,8 +51,8 @@ class TestConstraintOperators(Sketch2dTestCase):
 
     # -- single selected line -> horizontal constraint -----------------------
     def test_horizontal_from_single_selected_line(self):
-        from ..operators.add_geometric_constraints import VIEW3D_OT_slvs_add_horizontal
         from ..model.horizontal import SlvsHorizontal
+        from ..operators.add_geometric_constraints import VIEW3D_OT_slvs_add_horizontal
 
         line = self._line((0.0, 0.0), (5.0, 1.0))  # not yet horizontal
         self._select(line)
@@ -66,6 +66,30 @@ class TestConstraintOperators(Sketch2dTestCase):
         target = h.op.target
         self.assertIsInstance(target, SlvsHorizontal)
         self.assertIn(line.curve_id, target.curve_id_placements())
+
+    def test_dimensional_constraints_expose_numeric_value_state(self):
+        from ..operators.add_angle import VIEW3D_OT_slvs_add_angle
+        from ..operators.add_diameter import VIEW3D_OT_slvs_add_diameter
+        from ..operators.add_distance import VIEW3D_OT_slvs_add_distance
+
+        operators = (
+            VIEW3D_OT_slvs_add_angle,
+            VIEW3D_OT_slvs_add_diameter,
+            VIEW3D_OT_slvs_add_distance,
+        )
+
+        for operator in operators:
+            with self.subTest(operator=operator.__name__):
+                value_state = operator.get_states_definition()[-1]
+
+                self.assertEqual(value_state.name, "Value")
+                self.assertEqual(value_state.property, "value")
+                self.assertTrue(value_state.optional)
+                self.assertFalse(value_state.allow_prefill)
+                self.assertEqual(
+                    value_state.state_func,
+                    "_current_constraint_value",
+                )
 
     # -- wrong type is rejected: a point can't be a parallel operand ---------
     def test_point_rejected_for_parallel(self):


### PR DESCRIPTION
## Summary

Adds immediate numeric value entry when creating dimensional constraints.

Dimensional constraint operators now expose an optional final `Value` state, allowing users to type the desired value directly during constraint creation while preserving the measured value when no new value is entered.

Applies to:

- Distance
- Diameter
- Angle

## Testing

- Ruff lint: passed
- Ruff formatting: passed
- `git diff --check`: passed
- CAD Sketcher Blender test suite: **206 tests passed**
  - 4 skipped
  - 2 expected failures

Closes #259