### PR TITLE
Support distance constraints on 3D entities

### DIFF
--- a/gizmos/base.py
+++ b/gizmos/base.py
@@ -6,12 +6,12 @@ from .utilities import get_color, get_constraint_color_type, set_gizmo_colors
 
 class ConstraintGizmo:
     def _get_constraint(self, context):
-        from ..model.sketch_ref import get_active_sketch
+        from ..model.sketch_ref import get_active_constraints
 
-        sketch = get_active_sketch(context)
-        if not sketch:
+        constraints = get_active_constraints(context)
+        if not constraints:
             return None
-        return sketch.constraints.get_from_type_index(self.type, self.index)
+        return constraints.get_from_type_index(self.type, self.index)
 
     def get_constraint_color(self, constraint: GenericConstraint):
         is_highlight = constraint == selection.highlight_constraint or self.is_highlight
@@ -96,14 +96,14 @@ class ConstraintGenericGGT:
     bl_options = {"PERSISTENT", "SCALE", "3D"}
 
     def setup(self, context):
-        from ..model.sketch_ref import get_active_sketch
+        from ..model.sketch_ref import get_active_constraints
 
-        active_sketch = get_active_sketch(context)
-        if not active_sketch:
+        constraints = get_active_constraints(context)
+        if not constraints:
             return
-        for c in active_sketch.constraints.get_list(self.type):
+        for c in constraints.get_list(self.type):
             gz = self.gizmos.new(self.gizmo_type)
-            gz.index = active_sketch.constraints.get_index(c)
+            gz.index = constraints.get_index(c)
 
             set_gizmo_colors(gz, c)
 

--- a/gizmos/distance.py
+++ b/gizmos/distance.py
@@ -2,13 +2,20 @@ import math
 
 from bpy.types import Gizmo, GizmoGroup
 from mathutils import Vector
-from mathutils.geometry import intersect_point_line
+from mathutils.geometry import distance_point_to_plane, intersect_point_line
 
 from ..declarations import GizmoGroups, Gizmos
 from ..model.types import SlvsDistance
+from ..model.workplane import SlvsWorkplane
 from ..utilities.view import get_scale_from_pos
 from .base import ConstraintGenericGGT, ConstraintGizmoGeneric
 from .utilities import draw_arrow_shape, get_arrow_size, get_overshoot
+
+
+def _position(entity):
+    if hasattr(entity, "co"):
+        return Vector(entity.co)
+    return Vector(entity.location)
 
 
 class VIEW3D_GGT_slvs_distance(GizmoGroup, ConstraintGenericGGT):
@@ -39,18 +46,24 @@ class VIEW3D_GT_slvs_distance(Gizmo, ConstraintGizmoGeneric):
         ui_scale = context.preferences.system.ui_scale
         dist = constr.value / 2 / ui_scale
         offset = self.target_get_value("offset")
-        entity1, entity2 = constr.ref(1), constr.ref(2)
-        if entity1 is None or entity2 is None:
-            return ((0,0,0),) * 4
+        entity1 = constr._resolved_entity(1)
+        entity2 = constr._resolved_entity(2)
+        if entity1 is None:
+            return ((0, 0, 0),) * 4
         if entity1.is_line():
             entity1, entity2 = entity1.p1, entity1.p2
+        if entity2 is None:
+            return ((0, 0, 0),) * 4
 
         # Get constraints points in local space and adjust helplines
         # based on their position
         mat_inv = constr.matrix_basis().inverted()
 
         def get_local(point):
-            return (mat_inv @ point.to_3d()) / ui_scale
+            point = Vector(point)
+            if len(point) == 2:
+                point = point.to_3d()
+            return (mat_inv @ point) / ui_scale
 
         # Store the two endpoints of the helplines in local space
         points_local = []
@@ -66,25 +79,26 @@ class VIEW3D_GT_slvs_distance(Gizmo, ConstraintGizmoGeneric):
                     centerpoint, entity2.p1.co, entity2.p2.co
                 )
             else:
-                # TODO: Handle the case for SlvsWorkplane
-                pass
+                return ((0, 0, 0),) * 4
 
             targetvec = targetpoint - centerpoint
-            points_local.append(get_local(
-                centerpoint + entity1.radius * targetvec / targetvec.length
-            ))
+            if targetvec.length == 0:
+                return ((0, 0, 0),) * 4
+            points_local.append(
+                get_local(centerpoint + entity1.radius * targetvec / targetvec.length)
+            )
 
         else:
-            points_local.append(get_local(entity1.location))
+            points_local.append(get_local(_position(entity1)))
 
         # Add endpoint for entity2 helpline
         if entity2.is_point():
-            points_local.append(get_local(entity2.location))
+            points_local.append(get_local(_position(entity2)))
 
         elif entity2.is_line():
             line_points = (
-                get_local(entity2.p1.location),
-                get_local(entity2.p2.location),
+                get_local(_position(entity2.p1)),
+                get_local(_position(entity2.p2)),
             )
             line_points_side = [pos.y - offset > 0 for pos in line_points]
 
@@ -101,9 +115,17 @@ class VIEW3D_GT_slvs_distance(Gizmo, ConstraintGizmoGeneric):
                 y = line_points[i].y
             points_local.append(Vector((x, y, 0.0)))
 
+        elif isinstance(entity2, SlvsWorkplane):
+            p1 = _position(entity1)
+            normal = Vector(entity2.normal).normalized()
+            signed_distance = distance_point_to_plane(
+                p1, entity2.p1.location, normal
+            )
+            points_local.append(get_local(p1 - normal * signed_distance))
+
         # Pick the points based on their x location
         if len(points_local) < 2:
-            return ((0,0,0),) * 4
+            return ((0, 0, 0),) * 4
         if points_local[0].x > points_local[1].x:
             point_right, point_left = points_local
         else:
@@ -166,9 +188,7 @@ class VIEW3D_GT_slvs_distance(Gizmo, ConstraintGizmoGeneric):
                 # jitter back and forth to extend leader line for
                 # text_outside case but it is unnecessary work for
                 # text_inside case
-                Vector(
-                    (outset, offset, 0)
-                ),
+                Vector((outset, offset, 0)),
                 p1,
                 p2,
                 *draw_arrow_shape(

--- a/handlers.py
+++ b/handlers.py
@@ -108,19 +108,25 @@ def on_depsgraph_update(scene, depsgraph):
             return
 
         global_data.needs_solve = False
-        from .curve_solver import solve_system
         from .model.sketch_ref import get_active_sketch
-        from .utilities.curve_data import refresh_curve_geometry
 
         context = bpy.context
         sketch = get_active_sketch(context)
-        if solve_system(context, sketch=sketch) and sketch:
-            # The solver writes point positions in place, which does not make
-            # the Geometry Nodes modifier re-evaluate; force a topology rebuild
-            # so the generated mesh matches the solved geometry (operators that
-            # solve do this themselves; this covers the depsgraph-driven path,
-            # e.g. editing a dimension value).
-            refresh_curve_geometry(sketch)
+        if sketch:
+            from .curve_solver import solve_system
+            from .utilities.curve_data import refresh_curve_geometry
+
+            if solve_system(context, sketch=sketch):
+                # The solver writes point positions in place, which does not make
+                # the Geometry Nodes modifier re-evaluate; force a topology rebuild
+                # so the generated mesh matches the solved geometry (operators that
+                # solve do this themselves; this covers the depsgraph-driven path,
+                # e.g. editing a dimension value).
+                refresh_curve_geometry(sketch)
+        else:
+            from .solver_3d import solve_system_3d
+
+            solve_system_3d(context)
 
     if global_data.needs_redraw:
         global_data.needs_redraw = False
@@ -145,8 +151,10 @@ def on_frame_change(scene, depsgraph=None):
     from .curve_solver import solve_system
     from .utilities.curve_data import refresh_curve_geometry
     from .model.sketch_ref import get_sketches
+    from .solver_3d import solve_system_3d
 
     context = bpy.context
+    solve_system_3d(context)
     for sketch in get_sketches(scene):
         if solve_system(context, sketch=sketch):
             refresh_curve_geometry(sketch)

--- a/handlers.py
+++ b/handlers.py
@@ -63,7 +63,7 @@ def unregister_handlers():
 
 def on_load_post(*args):
     """Migrate legacy entity-based sketches to native curves on file load."""
-    from .utilities.migrate import scene_needs_migration, migrate_scene
+    from .utilities.migrate import migrate_scene, scene_needs_migration
     from .utilities.validate import reset_cache
 
     reset_cache()
@@ -149,9 +149,9 @@ def on_frame_change(scene, depsgraph=None):
         return
 
     from .curve_solver import solve_system
-    from .utilities.curve_data import refresh_curve_geometry
     from .model.sketch_ref import get_sketches
     from .solver_3d import solve_system_3d
+    from .utilities.curve_data import refresh_curve_geometry
 
     context = bpy.context
     solve_system_3d(context)

--- a/model/base_constraint.py
+++ b/model/base_constraint.py
@@ -150,7 +150,19 @@ class GenericConstraint:
             if wp:
                 return wp.p1.location, wp.normal
 
-        # TODO: return drawing plane for constraints in 3d
+        # Scene-level 3D dimensions are drawn in the local XY plane produced by
+        # their matrix_basis(). Reuse that plane for label dragging so the gizmo
+        # remains editable outside sketch mode as well.
+        matrix_func = getattr(self, "matrix_basis", None)
+        if callable(matrix_func):
+            try:
+                mat = matrix_func()
+                normal = Vector(mat.col[2][:3])
+                if normal.length:
+                    return mat.translation.copy(), normal.normalized()
+            except Exception:
+                logger.debug("Could not resolve 3D constraint draw plane", exc_info=True)
+
         return None, None
 
     def copy(self, context, entities):
@@ -173,11 +185,9 @@ class GenericConstraint:
         is_experimental = preferences.is_experimental()
 
         layout.prop(self, "name", text="")
-
         if self.failed:
             layout.label(text="Failed", icon="ERROR")
 
-        # Info block
         layout.separator()
         if is_experimental:
             sub = layout.column()
@@ -186,32 +196,18 @@ class GenericConstraint:
             for e in self.dependencies():
                 sub.label(text=str(e))
 
-        # General props
         layout.separator()
         layout.prop(self, "visible")
-
-        # Specific props
         layout.separator()
-
         return layout
 
     def index(self):
-        """Return elements index inside its collection"""
-        # HACK: Elements of collectionproperties currently don't expose an index
-        # method, path_from_id writes the index however, use this hack instead
-        # of looping over elements
         return int(self.path_from_id().split("[")[1].split("]")[0])
 
     def placements(self):
-        """Return the entities where the constraint should be displayed"""
         return []
 
     def curve_id_placements(self):
-        """Return curve_ids where the constraint should be displayed.
-
-        Default: returns curve_id_1 (and curve_id_2/3 if set).
-        Override for constraints with special placement logic.
-        """
         ids = []
         if getattr(self, 'curve_id_1', ""):
             ids.append(self.curve_id_1)
@@ -222,20 +218,12 @@ class GenericConstraint:
         return ids
 
     def marker_position(self, sketch):
-        """World position for a single constraint marker, or None.
-
-        Override to place the gizmo icon at a computed point (e.g. a tangent
-        point) instead of a curve's default placement. Returning None makes the
-        gizmo fall back to ``curve_id_placements``.
-        """
         return None
 
     def _get_sketch(self):
-        """Resolve the Sketch accessor for this constraint."""
         sketch = self.sketch if hasattr(self, "sketch") and self.sketch else None
         if sketch:
             return sketch
-        # Resolve from Curves id_data (native curves path)
         import bpy
         id_data = getattr(self, "id_data", None)
         if id_data and hasattr(id_data, "sketch_constraints"):
@@ -243,17 +231,14 @@ class GenericConstraint:
                 if obj.data is id_data:
                     from .sketch_ref import Sketch
                     return Sketch(obj)
-            # Fallback: match by name (evaluated data has different identity)
             for obj in bpy.data.objects:
                 if obj.data and obj.data.name == id_data.name:
                     from .sketch_ref import Sketch
                     return Sketch(obj)
-        # Last resort: use active sketch from context
         from .sketch_ref import get_active_sketch
         return get_active_sketch(bpy.context)
 
     def ref(self, n=1):
-        """Return a typed CurveRef for curve_id_N, or None if unset."""
         cid = getattr(self, f"curve_id_{n}", "")
         if not cid:
             return None
@@ -276,9 +261,6 @@ class DimensionalConstraint(GenericConstraint):
     setting: BoolProperty
 
     def _set_value(self, displayed_value: float):
-        # NOTE: function signature _set_value(self, val: float, force=False)
-        #       will fail when bpy tries to register the value property.
-        #       See `_set_value_force()`
         if not self.is_reference:
             self._set_value_force(self.from_displayed_value(displayed_value))
 
@@ -309,24 +291,15 @@ class DimensionalConstraint(GenericConstraint):
         for key, value in settings.items():
             if value is None:
                 continue
-
-            # "value" has a custom RNA getter that may call assign_init_props,
-            # so never read it back — just write unconditionally.
             if key == "value":
                 setprop(self, key, value)
                 continue
-
-            # For all other keys (e.g. "setting", "flip", "align") skip the
-            # write when the value is unchanged so we don't fire update
-            # callbacks that would re-enter assign_init_props and recurse.
             try:
                 current = getattr(self, key)
             except Exception:
                 current = object()
-
             if current == value:
                 continue
-
             setprop(self, key, value)
 
     def assign_init_props(self, context: Context = None, **kwargs):
@@ -335,55 +308,4 @@ class DimensionalConstraint(GenericConstraint):
     def on_reference_checked(self, context: Context = None):
         update_system_cb(self, context)
         self.assign_init_props()
-        # Refresh the gizmos as we are changing the colors.
         refresh(context)
-
-    is_reference: BoolProperty(
-        name="Only measure",
-        default=False,
-        update=on_reference_checked,
-    )
-
-    def init_props(self, **kwargs):
-        raise NotImplementedError()
-
-    def to_displayed_value(self, value):
-        """
-        Overwrite this function to convert the property value into
-        something to display on the user interface.
-        NOTE: If the value is writeable, do not forget to change
-              ``from_displayed_value()`` to apply the reverse operation.
-        """
-        return value
-
-    def from_displayed_value(self, displayed_value):
-        """
-        Convert the displayed value of the property into
-        a variable to store.
-        NOTE: See ``to_displayed_value()``
-        """
-        return displayed_value
-
-    def py_data(self, solvesys, **kwargs):
-        if self.is_reference:
-            return []
-        return self.create_slvs_data(solvesys, **kwargs)
-
-    def draw_props(self, layout: UILayout):
-        sub = GenericConstraint.draw_props(self, layout)
-        sub.prop(self, "is_reference")
-        if hasattr(self, "value"):
-            col = sub.column()
-            col.enabled = not self.is_reference
-            import bpy
-            scene = bpy.context.scene
-            uid = getattr(self, "constraint_uid", "")
-            key = None
-            if scene and uid:
-                key = scene.sketcher.get_constraint_value_endpoint(self)
-            if key:
-                col.prop(scene, f'["{key}"]', text="Value")
-        if hasattr(self, "setting"):
-            row = sub.row()
-            row.prop(self, "setting")
-        return sub

--- a/model/base_constraint.py
+++ b/model/base_constraint.py
@@ -2,17 +2,16 @@ import logging
 from typing import List
 
 import bpy
-from bpy.props import StringProperty, BoolProperty
-from bpy.types import UILayout, Property, Context
+from bpy.props import BoolProperty, StringProperty
+from bpy.types import Context, Property, UILayout
 
 from ..global_data import WpReq
 from ..utilities import preferences
-from ..declarations import Operators
-from .constants import ENTITY_PROP_NAMES
-from .base_entity import SlvsGenericEntity
-from ..utilities.view import update_cb, refresh
-from ..utilities.solver import update_system_cb
 from ..utilities.bpy import setprop
+from ..utilities.solver import update_system_cb
+from ..utilities.view import refresh, update_cb
+from .base_entity import SlvsGenericEntity
+from .constants import ENTITY_PROP_NAMES
 
 logger = logging.getLogger(__name__)
 

--- a/model/base_constraint.py
+++ b/model/base_constraint.py
@@ -151,8 +151,7 @@ class GenericConstraint:
                 return wp.p1.location, wp.normal
 
         # Scene-level 3D dimensions are drawn in the local XY plane produced by
-        # their matrix_basis(). Reuse that plane for label dragging so the gizmo
-        # remains editable outside sketch mode as well.
+        # their matrix_basis(). Reuse that plane for label dragging as well.
         matrix_func = getattr(self, "matrix_basis", None)
         if callable(matrix_func):
             try:
@@ -185,9 +184,11 @@ class GenericConstraint:
         is_experimental = preferences.is_experimental()
 
         layout.prop(self, "name", text="")
+
         if self.failed:
             layout.label(text="Failed", icon="ERROR")
 
+        # Info block
         layout.separator()
         if is_experimental:
             sub = layout.column()
@@ -196,18 +197,32 @@ class GenericConstraint:
             for e in self.dependencies():
                 sub.label(text=str(e))
 
+        # General props
         layout.separator()
         layout.prop(self, "visible")
+
+        # Specific props
         layout.separator()
+
         return layout
 
     def index(self):
+        """Return elements index inside its collection"""
+        # HACK: Elements of collectionproperties currently don't expose an index
+        # method, path_from_id writes the index however, use this hack instead
+        # of looping over elements
         return int(self.path_from_id().split("[")[1].split("]")[0])
 
     def placements(self):
+        """Return the entities where the constraint should be displayed"""
         return []
 
     def curve_id_placements(self):
+        """Return curve_ids where the constraint should be displayed.
+
+        Default: returns curve_id_1 (and curve_id_2/3 if set).
+        Override for constraints with special placement logic.
+        """
         ids = []
         if getattr(self, 'curve_id_1', ""):
             ids.append(self.curve_id_1)
@@ -218,12 +233,20 @@ class GenericConstraint:
         return ids
 
     def marker_position(self, sketch):
+        """World position for a single constraint marker, or None.
+
+        Override to place the gizmo icon at a computed point (e.g. a tangent
+        point) instead of a curve's default placement. Returning None makes the
+        gizmo fall back to ``curve_id_placements``.
+        """
         return None
 
     def _get_sketch(self):
+        """Resolve the Sketch accessor for this constraint."""
         sketch = self.sketch if hasattr(self, "sketch") and self.sketch else None
         if sketch:
             return sketch
+        # Resolve from Curves id_data (native curves path)
         import bpy
         id_data = getattr(self, "id_data", None)
         if id_data and hasattr(id_data, "sketch_constraints"):
@@ -231,14 +254,17 @@ class GenericConstraint:
                 if obj.data is id_data:
                     from .sketch_ref import Sketch
                     return Sketch(obj)
+            # Fallback: match by name (evaluated data has different identity)
             for obj in bpy.data.objects:
                 if obj.data and obj.data.name == id_data.name:
                     from .sketch_ref import Sketch
                     return Sketch(obj)
+        # Last resort: use active sketch from context
         from .sketch_ref import get_active_sketch
         return get_active_sketch(bpy.context)
 
     def ref(self, n=1):
+        """Return a typed CurveRef for curve_id_N, or None if unset."""
         cid = getattr(self, f"curve_id_{n}", "")
         if not cid:
             return None
@@ -261,6 +287,9 @@ class DimensionalConstraint(GenericConstraint):
     setting: BoolProperty
 
     def _set_value(self, displayed_value: float):
+        # NOTE: function signature _set_value(self, val: float, force=False)
+        #       will fail when bpy tries to register the value property.
+        #       See `_set_value_force()`
         if not self.is_reference:
             self._set_value_force(self.from_displayed_value(displayed_value))
 
@@ -291,15 +320,24 @@ class DimensionalConstraint(GenericConstraint):
         for key, value in settings.items():
             if value is None:
                 continue
+
+            # "value" has a custom RNA getter that may call assign_init_props,
+            # so never read it back — just write unconditionally.
             if key == "value":
                 setprop(self, key, value)
                 continue
+
+            # For all other keys (e.g. "setting", "flip", "align") skip the
+            # write when the value is unchanged so we don't fire update
+            # callbacks that would re-enter assign_init_props and recurse.
             try:
                 current = getattr(self, key)
             except Exception:
                 current = object()
+
             if current == value:
                 continue
+
             setprop(self, key, value)
 
     def assign_init_props(self, context: Context = None, **kwargs):
@@ -308,4 +346,55 @@ class DimensionalConstraint(GenericConstraint):
     def on_reference_checked(self, context: Context = None):
         update_system_cb(self, context)
         self.assign_init_props()
+        # Refresh the gizmos as we are changing the colors.
         refresh(context)
+
+    is_reference: BoolProperty(
+        name="Only measure",
+        default=False,
+        update=on_reference_checked,
+    )
+
+    def init_props(self, **kwargs):
+        raise NotImplementedError()
+
+    def to_displayed_value(self, value):
+        """
+        Overwrite this function to convert the property value into
+        something to display on the user interface.
+        NOTE: If the value is writeable, do not forget to change
+              ``from_displayed_value()`` to apply the reverse operation.
+        """
+        return value
+
+    def from_displayed_value(self, displayed_value):
+        """
+        Convert the displayed value of the property into
+        a variable to store.
+        NOTE: See ``to_displayed_value()``
+        """
+        return displayed_value
+
+    def py_data(self, solvesys, **kwargs):
+        if self.is_reference:
+            return []
+        return self.create_slvs_data(solvesys, **kwargs)
+
+    def draw_props(self, layout: UILayout):
+        sub = GenericConstraint.draw_props(self, layout)
+        sub.prop(self, "is_reference")
+        if hasattr(self, "value"):
+            col = sub.column()
+            col.enabled = not self.is_reference
+            import bpy
+            scene = bpy.context.scene
+            uid = getattr(self, "constraint_uid", "")
+            key = None
+            if scene and uid:
+                key = scene.sketcher.get_constraint_value_endpoint(self)
+            if key:
+                col.prop(scene, f'["{key}"]', text="Value")
+        if hasattr(self, "setting"):
+            row = sub.row()
+            row.prop(self, "setting")
+        return sub

--- a/model/distance.py
+++ b/model/distance.py
@@ -39,12 +39,26 @@ def get_side_of_line(line_start, line_end, point):
     )
 
 
+def _entity_coords(entity):
+    if entity is None:
+        return None
+    if hasattr(entity, "co"):
+        return Vector(entity.co)
+    if hasattr(entity, "location"):
+        return Vector(entity.location)
+    return None
+
+
 def _get_aligned_distance(p_1, p_2, alignment):
+    co_1 = _entity_coords(p_1)
+    co_2 = _entity_coords(p_2)
+    if co_1 is None or co_2 is None:
+        return 0.0
     if alignment == "HORIZONTAL":
-        return abs(p_2.co.x - p_1.co.x)
+        return abs(co_2.x - co_1.x)
     if alignment == "VERTICAL":
-        return abs(p_2.co.y - p_1.co.y)
-    return (p_2.co - p_1.co).length
+        return abs(co_2.y - co_1.y)
+    return (co_2 - co_1).length
 
 
 align_items = [
@@ -53,11 +67,13 @@ align_items = [
     ("VERTICAL", "Vertical", "", 2),
 ]
 
+
 def _get_value(self):
     if self.is_reference:
         val = self.init_props(align=self.align)["value"]
         return self.to_displayed_value(val)
     import bpy
+
     scene = bpy.context.scene
     uid = getattr(self, "constraint_uid", "")
     if scene is not None and uid:
@@ -74,13 +90,20 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
     def _set_value_force(self, value):
         DimensionalConstraint._set_value_force(self, abs(value))
 
+    def _resolved_entity(self, n):
+        """Resolve native-curve references or legacy scene-level 3D entities."""
+        ref = self.ref(n)
+        if ref:
+            return ref
+        return getattr(self, f"entity{n}", None)
+
     def _set_align(self, value):
         if isinstance(value, str):
             alignment = value
         else:
             alignment = bpyEnum(align_items, value).identifier
         self.align_store = alignment
-        r1, r2 = self.ref(1), self.ref(2)
+        r1, r2 = self._resolved_entity(1), self._resolved_entity(2)
         if r1 and r2:
             self._set_value_force(_get_aligned_distance(r1, r2, alignment))
 
@@ -176,6 +199,7 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
             ct_pos = get_curve_position(sketch, ct_id)
             if ct_handle and ct_pos:
                 from mathutils import Vector
+
                 curve_slice = cd.curves[idx1]
                 edge_pos = Vector(cd.points[curve_slice.points[0].index].position)
                 radius = (edge_pos - Vector(ct_pos)).length
@@ -211,17 +235,19 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
 
     def use_flipping(self):
         # Only use flipping for constraint between point and line/workplane
-        r1, r2 = self.ref(1), self.ref(2)
+        r1, r2 = self._resolved_entity(1), self._resolved_entity(2)
         if not r1 or not r2:
             return False
         if r1.is_curve():
             return False
-        return r2.is_line()
+        return r2.is_line() or isinstance(r2, SlvsWorkplane)
 
     def use_align(self):
         """Returns True if constraint's entities allow distance to be aligned"""
-        r1, r2 = self.ref(1), self.ref(2)
+        r1, r2 = self._resolved_entity(1), self._resolved_entity(2)
         if not r1 or not r2:
+            return False
+        if r1.is_3d() or r2.is_3d():
             return False
         if r2.is_line():
             return False
@@ -277,7 +303,6 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
             func = solvesys.distance
         elif type(e2) in POINT:
             if align and all([e.is_2d() for e in (e1, e2)]):
-
                 # Get Point in between
                 p1, p2 = e1.co, e2.co
                 coords = (p2.x, p1.y)
@@ -293,9 +318,7 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
 
                 base_point = e1 if alignment == "VERTICAL" else e2
                 handles.append(
-                    solvesys.distance(
-                        group, p, base_point.py_data, value, wp
-                    )
+                    solvesys.distance(group, p, base_point.py_data, value, wp)
                 )
                 return handles
             else:
@@ -309,10 +332,49 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
         return func(group, e1.py_data, e2.py_data, value, *args)
 
     def matrix_basis(self):
-        r1, r2 = self.ref(1), self.ref(2)
-        if not r1 or not r1.valid:
+        r1, r2 = self._resolved_entity(1), self._resolved_entity(2)
+        if not r1:
             return Matrix()
+        if hasattr(r1, "valid") and not r1.valid:
+            return Matrix()
+        if r1.is_3d():
+            return self._compute_matrix_basis_3d(r1, r2)
         return self._compute_matrix_basis(r1, r2, r1.wp_matrix)
+
+    def _compute_matrix_basis_3d(self, e1, e2):
+        """Place the dimension in world space for 3D entity combinations."""
+        if e1.is_line():
+            p1 = Vector(e1.p1.location)
+            p2 = Vector(e1.p2.location)
+        else:
+            p1 = _entity_coords(e1)
+            if p1 is None or e2 is None:
+                return Matrix.Translation(p1) if p1 is not None else Matrix()
+
+            if e2.is_point():
+                p2 = _entity_coords(e2)
+            elif e2.is_line():
+                p2, _ = intersect_point_line(
+                    p1,
+                    Vector(e2.p1.location),
+                    Vector(e2.p2.location),
+                )
+            elif isinstance(e2, SlvsWorkplane):
+                normal = Vector(e2.normal).normalized()
+                distance = distance_point_to_plane(p1, e2.p1.location, normal)
+                p2 = p1 - normal * distance
+            else:
+                return Matrix.Translation(p1)
+
+        direction = p2 - p1
+        midpoint = (p1 + p2) / 2
+        if direction.length == 0:
+            return Matrix.Translation(midpoint)
+
+        direction.normalize()
+        up_axis = "Y" if abs(direction.z) > 0.999 else "Z"
+        rotation = direction.to_track_quat("X", up_axis).to_matrix().to_4x4()
+        return Matrix.Translation(midpoint) @ rotation
 
     def _compute_matrix_basis(self, e1, e2, wp_mat):
         """Compute matrix_basis from geometry accessors (CurveRef or entity)."""
@@ -382,10 +444,29 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
         return wp_mat @ mat_local
 
     def _get_init_value(self, alignment):
-        r1, r2 = self.ref(1), self.ref(2)
+        r1, r2 = self._resolved_entity(1), self._resolved_entity(2)
         if not r1:
             if self.is_property_set("value_store"):
                 return self.value_store
+            return 0.0
+
+        if r1.is_3d():
+            if r1.is_line():
+                return _get_aligned_distance(r1.p1, r1.p2, alignment)
+            p1 = _entity_coords(r1)
+            if p1 is None or r2 is None:
+                return 0.0
+            if r2.is_point():
+                return (p1 - _entity_coords(r2)).length
+            if r2.is_line():
+                closest, _ = intersect_point_line(
+                    p1,
+                    Vector(r2.p1.location),
+                    Vector(r2.p2.location),
+                )
+                return (p1 - closest).length
+            if isinstance(r2, SlvsWorkplane):
+                return distance_point_to_plane(p1, r2.p1.location, r2.normal)
             return 0.0
 
         if r1.is_line():
@@ -412,7 +493,6 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
         return 0.0
 
     def init_props(self, **kwargs):
-
         # NOTE: Flip is currently ignored when passed in kwargs
         alignment = kwargs.get("align")
         retval = {}

--- a/model/distance.py
+++ b/model/distance.py
@@ -1,31 +1,34 @@
 import logging
 import math
 
+from bpy.props import (
+    BoolProperty,
+    EnumProperty,
+    FloatProperty,
+    StringProperty,
+)
 from bpy.types import PropertyGroup
-from .sketch_ref import get_active_sketch
-from bpy.props import BoolProperty, FloatProperty, EnumProperty, IntProperty, StringProperty
 from bpy.utils import register_classes_factory
-from mathutils import Vector, Matrix
+from mathutils import Matrix, Vector
 from mathutils.geometry import distance_point_to_plane, intersect_point_line
 
 from ..curve_solver import Solver
-from ..utilities import preferences
 from ..global_data import WpReq
-from ..utilities.view import location_3d_to_region_2d
+from ..utilities import preferences
+from ..utilities.bpy import bpyEnum
 from ..utilities.math import range_2pi
-from .base_constraint import DimensionalConstraint
-from .utilities import slvs_entity_pointer
-from .categories import POINT, LINE, POINT2D, CURVE
 from ..utilities.solver import update_system_cb
-from ..utilities.bpy import setprop, bpyEnum
-
-from .workplane import SlvsWorkplane
-from .point_3d import SlvsPoint3D
+from ..utilities.view import location_3d_to_region_2d
+from .arc import SlvsArc
+from .base_constraint import DimensionalConstraint
+from .categories import CURVE, LINE, POINT, POINT2D
+from .circle import SlvsCircle
+from .line_2d import SlvsLine2D
 from .line_3d import SlvsLine3D
 from .point_2d import SlvsPoint2D
-from .line_2d import SlvsLine2D
-from .arc import SlvsArc
-from .circle import SlvsCircle
+from .point_3d import SlvsPoint3D
+from .utilities import slvs_entity_pointer
+from .workplane import SlvsWorkplane
 
 logger = logging.getLogger(__name__)
 
@@ -163,9 +166,9 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
     curve_id_2: StringProperty(name="Curve ID 2", default="")
 
     def create_slvs_data_from_curves(self, solvesys, handle_map, wp, group):
-        from ..utilities.curve_data import get_curve_data, get_curve_position, get_uuid
+
         from ..model.constants import SketchCurveType
-        import bpy
+        from ..utilities.curve_data import get_curve_data, get_curve_position, get_uuid
 
         h1 = handle_map.get(self.curve_id_1)
         h2 = handle_map.get(self.curve_id_2)

--- a/model/sketch_ref.py
+++ b/model/sketch_ref.py
@@ -153,11 +153,11 @@ def get_sketches(context_or_scene):
 
 
 def get_active_constraints(context):
-    """Get constraints for the active sketch, or None."""
+    """Get sketch constraints, or scene-level constraints outside sketch mode."""
     sketch = get_active_sketch(context)
     if sketch:
         return sketch.constraints
-    return None
+    return context.scene.sketcher.constraints
 
 
 def get_active_sketch(context):

--- a/operators/add_distance.py
+++ b/operators/add_distance.py
@@ -33,10 +33,46 @@ class VIEW3D_OT_slvs_add_distance(Operator, GenericConstraintOp):
     property_keys = ("value", "align", "flip")
     has_value_state = True
 
+    def _legacy_constraint_exists(self, constraints, e1, e2):
+        indices = {
+            entity.slvs_index
+            for entity in (e1, e2)
+            if entity is not None and hasattr(entity, "slvs_index")
+        }
+        for constraint in constraints.get_list(SlvsDistance.type):
+            existing = {
+                entity.slvs_index
+                for entity in constraint.entities()
+                if hasattr(entity, "slvs_index")
+            }
+            if existing == indices:
+                return True
+        return False
+
+    def _add_legacy_3d_distance(self, context, e1, e2):
+        constraints = context.scene.sketcher.constraints
+        if self._legacy_constraint_exists(constraints, e1, e2):
+            return None
+
+        constraint = constraints.distance.add()
+        constraint.entity1 = e1
+        if e2 is not None:
+            constraint.entity2 = e2
+        constraints._init_constraint(constraint)
+
+        settings = self.get_settings()
+        if not self.initialized:
+            constraint.assign_init_props(**settings)
+        else:
+            constraint.assign_settings(**settings)
+        return constraint
+
     def main(self, context):
         e1, e2 = self.entity1, self.entity2
 
-        # Line length: expand line to its endpoints
+        # Line length: expand native-curve lines to their endpoints. Legacy 3D
+        # lines are kept as a single entity and SlvsDistance expands them when
+        # creating SolveSpace data.
         if isinstance(e1, LineRef) and e2 is None:
             p1, p2 = e1.p1, e1.p2
             if p1 and p2:
@@ -48,6 +84,13 @@ class VIEW3D_OT_slvs_add_distance(Operator, GenericConstraintOp):
                     state_data["curve_id"] = pt.curve_id
                 self.next_state(context)
                 e1, e2 = self.entity1, self.entity2
+
+        # Native curves and scene-level 3D entities intentionally use different
+        # storage. The native path stays unchanged; 3D constraints live on the
+        # scene so they can exist outside a sketch.
+        if e1 is not None and not hasattr(e1, "curve_id"):
+            self.target = self._add_legacy_3d_distance(context, e1, e2)
+            return super().main(context)
 
         if isinstance(e1, LineRef) and e2 is None:
             max_constraints = 2
@@ -70,11 +113,11 @@ class VIEW3D_OT_slvs_add_distance(Operator, GenericConstraintOp):
 
     def fini(self, context: Context, succeede: bool):
         super().fini(context, succeede)
-        if hasattr(self, "target"):
+        if hasattr(self, "target") and self.target:
             self.target.draw_offset = 0.05 * context.region_data.view_distance
 
     def draw(self, context: Context):
-        if not hasattr(self, "target"):
+        if not hasattr(self, "target") or not self.target:
             return
 
         layout = self.layout

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -3,9 +3,16 @@ from typing import Any, List
 import bpy
 from bpy.types import Context, Event
 
+from ..drawing import selection
 from ..model.curve_ref import CurveRef, PointRef, curve_ref
-from ..model.types import SlvsPoint2D
-from ..utilities.view import get_blender_snap_info, get_pos_2d, get_scale_from_pos
+from ..model.types import SlvsLine3D, SlvsPoint2D, SlvsPoint3D, SlvsWorkplane
+from ..stateful_operator.integration import StatefulOperator
+from ..utilities.view import (
+    get_blender_snap_info,
+    get_placement_pos,
+    get_pos_2d,
+    get_scale_from_pos,
+)
 from .base_stateful import GenericEntityOp
 from .utilities import ignore_hover
 
@@ -20,18 +27,22 @@ class Operator2d(GenericEntityOp):
     def poll(cls, context: Context):
         return context.scene.sketcher.active_sketch_object is not None
 
+    def _is_sketch_mode(self):
+        return bool(self.sketch)
+
     # A 2D draw operator only ever modifies the active sketch's curve data and
     # constraints -- not the entity system (structural workplane/normal/origin
-    # entities). The base snapshot re-serialized and restored the whole scene
-    # (137 entities in the #342 file) plus every sketch's curves on each
-    # mouse-move (~15ms), the draw-time lag. Scope it to the active sketch's curve
-    # data + constraints, skipping the scene serialization entirely.
+    # entities). Outside sketch mode, constraint operators still use the scene
+    # entity system, so fall back to the complete GenericEntityOp snapshot.
     def create_snapshot(self, context: Context):
         from ..model.sketch_ref import get_active_sketch
 
-        scene = context.scene
         sketch = get_active_sketch(context)
-        obj = sketch.target_object if sketch else None
+        if not sketch:
+            return super().create_snapshot(context)
+
+        scene = context.scene
+        obj = sketch.target_object
         snap = {
             "active_name": obj.name if obj else None,
             "constraint_values": {
@@ -46,6 +57,11 @@ class Operator2d(GenericEntityOp):
     def restore_snapshot(self, context: Context, snapshot):
         if not snapshot:
             return
+        # GenericEntityOp snapshots contain the serialized scene. Operator2d's
+        # optimized sketch snapshot intentionally does not.
+        if "scene" in snapshot:
+            return super().restore_snapshot(context, snapshot)
+
         from ..utilities.curve_data import invalidate_curve_id_cache
 
         scene = context.scene
@@ -69,6 +85,13 @@ class Operator2d(GenericEntityOp):
             scene[key] = value
 
     def invoke(self, context: Context, event: Event):
+        from ..model.sketch_ref import get_active_sketch
+
+        if not get_active_sketch(context):
+            self._snap = None
+            self._snap_handle = None
+            return super().invoke(context, event)
+
         # Own a POST_PIXEL marker for the current snap target for the lifetime of
         # the modal (removed in _end), so it can never linger past the draw.
         from ..drawing.snap import draw_snap_marker
@@ -88,11 +111,14 @@ class Operator2d(GenericEntityOp):
 
     def init(self, context: Context, event: Event):
         from ..model.sketch_ref import get_active_sketch
+
         self._active_sketch = get_active_sketch(context)
         return True
 
     @property
     def sketch(self):
+        if not hasattr(self, "_active_sketch"):
+            self._active_sketch = None
         if not self._active_sketch:
             import bpy
 
@@ -102,6 +128,8 @@ class Operator2d(GenericEntityOp):
 
     def _get_wp(self):
         """Get the workplane (empty object or entity) for this sketch."""
+        if not self.sketch:
+            return None
         if self.sketch.workplane_object:
             return self.sketch.workplane_object
         # Fallback: curve object's parent is the workplane empty
@@ -109,8 +137,39 @@ class Operator2d(GenericEntityOp):
             return self.sketch.target_object.parent
         return None
 
+    def pick_element(self, context, coords):
+        if self.sketch:
+            return super().pick_element(context, coords)
+
+        # StatefulOperator handles Blender mesh selections first. Legacy CAD
+        # entities are addressed by their slvs_index in selection.hover.
+        retval = StatefulOperator.pick_element(self, context, coords)
+        if retval is not None:
+            return retval
+
+        state = self.state
+        data = self.state_data
+        hover_id = selection.hover
+        hovered = None
+        if isinstance(hover_id, int):
+            hovered = context.scene.sketcher.entities.get(hover_id)
+        if hovered and not isinstance(hovered, state.types):
+            hovered = None
+        if hovered and self.is_in_previous_states(hovered):
+            hovered = None
+
+        data["hovered"] = hovered.slvs_index if hovered else -1
+        data["type"] = type(hovered) if hovered else None
+        return hovered.slvs_index if hovered else None
+
     def state_func(self, context: Context, coords):
         state = self.state
+        if not self.sketch:
+            pos = get_placement_pos(context, coords)
+            if SlvsPoint3D in state.types:
+                return pos
+            return super().state_func(context, coords)
+
         wp = self._get_wp()
         self._snap = get_blender_snap_info(context, coords)
         pos = get_pos_2d(context, wp, coords, respect_snapping=True)
@@ -148,6 +207,13 @@ class Operator2d(GenericEntityOp):
 
     # create element depending on mode
     def create_element(self, context: Context, values: List[Any], state, state_data):
+        if not self.sketch:
+            loc = values[0]
+            point = context.scene.sketcher.entities.add_point_3d(loc)
+            ignore_hover(point)
+            state_data["type"] = type(point)
+            return point.slvs_index
+
         sketch = self.sketch
         loc = values[0]
 
@@ -167,12 +233,14 @@ class Operator2d(GenericEntityOp):
         return cid
 
     def _check_constrain(self, context: Context, curve_id: int):
-        """Check if a hovered curve_id is a constrainable type (line/arc/circle)."""
+        """Check if a hovered entity should be constrained."""
+        if not self.sketch:
+            entity_type = context.scene.sketcher.entities.type_from_index(curve_id)
+            return entity_type in (SlvsLine3D, SlvsWorkplane)
+
         from ..model.curve_ref import ArcRef, CircleRef, LineRef
-        sketch = self.sketch
-        if not sketch:
-            return False
-        ref = curve_ref(sketch, curve_id)
+
+        ref = curve_ref(self.sketch, curve_id)
         return isinstance(ref, (LineRef, ArcRef, CircleRef))
 
     def get_point(self, context: Context, index: int):
@@ -186,7 +254,12 @@ class Operator2d(GenericEntityOp):
             sse = context.scene.sketcher.entities
             ob_name, v_index = self.get_state_pointer(index=index, implicit=True)
             ob = bpy.data.objects[ob_name]
+            if not sketch:
+                return sse.add_ref_vertex_3d(ob, v_index)
             return sse.add_ref_vertex_2d(ob, v_index, sketch)
+
+        if not sketch:
+            return getattr(self, state.pointer)
 
         # Return CurveRef using the stored type
         cid = data.get("curve_id", "")
@@ -195,5 +268,3 @@ class Operator2d(GenericEntityOp):
         if cid:
             return PointRef(sketch, cid)
         return getattr(self, state.pointer)
-
-

--- a/operators/base_constraint.py
+++ b/operators/base_constraint.py
@@ -125,9 +125,13 @@ class GenericConstraintOp(Operator2d):
         self.sync_settings()
 
         deselect_all(context)
-        solve_system(context, sketch=self.sketch)
         if self.sketch:
+            solve_system(context, sketch=self.sketch)
             refresh_curve_geometry(self.sketch)
+        else:
+            from ..solver_3d import solve_system_3d
+
+            solve_system_3d(context)
         refresh(context)
         self.initialized = True
         return hasattr(self, "target") and bool(self.target)

--- a/operators/solve.py
+++ b/operators/solve.py
@@ -1,10 +1,10 @@
-from bpy.types import Operator, Context
-from ..model.sketch_ref import get_active_sketch, get_sketches
 from bpy.props import BoolProperty
+from bpy.types import Context, Operator
 from bpy.utils import register_classes_factory
 
-from ..declarations import Operators
 from ..curve_solver import solve_system
+from ..declarations import Operators
+from ..model.sketch_ref import get_active_sketch, get_sketches
 from ..solver_3d import solve_system_3d
 
 

--- a/operators/solve.py
+++ b/operators/solve.py
@@ -5,6 +5,7 @@ from bpy.utils import register_classes_factory
 
 from ..declarations import Operators
 from ..curve_solver import solve_system
+from ..solver_3d import solve_system_3d
 
 
 class View3D_OT_slvs_solve(Operator):
@@ -15,11 +16,15 @@ class View3D_OT_slvs_solve(Operator):
 
     def execute(self, context: Context):
         if self.all:
+            ok_3d = solve_system_3d(context)
             sketches = list(get_sketches(context))
-            ok = all(solve_system(context, sketch=s) for s in sketches)
+            ok = ok_3d and all(solve_system(context, sketch=s) for s in sketches)
         else:
             sketch = get_active_sketch(context)
-            ok = solve_system(context, sketch=sketch)
+            if sketch:
+                ok = solve_system(context, sketch=sketch)
+            else:
+                ok = solve_system_3d(context)
 
         # Keep messages simple, sketches are marked with solvestate
         if ok:

--- a/solver_3d.py
+++ b/solver_3d.py
@@ -1,0 +1,111 @@
+"""Solve legacy 3D entities and constraints outside native curve sketches.
+
+The native-curves solver intentionally handles sketch geometry only. 3D points,
+lines and workplanes are still stored in ``scene.sketcher.entities`` and use the
+legacy entity API, so keep a small solver path for those entities rather than
+routing them through the 2D CurveSolver.
+"""
+
+import logging
+
+from .global_data import solver_state_items
+from .utilities.bpy import bpyEnum
+
+logger = logging.getLogger(__name__)
+
+
+class Solver3D:
+    group_fixed = 1
+    group_3d = 2
+
+    def __init__(self, context):
+        self.context = context
+        self.entities = []
+        self.constraints = {}
+        self.ok = True
+        self.result = None
+
+        import slvs
+
+        slvs.clear_sketch()
+        self.solvesys = slvs
+
+    def _init_entities(self):
+        entities = self.context.scene.sketcher.entities
+        for entity in entities.all:
+            if not entity.is_3d():
+                continue
+
+            group = self.group_fixed if entity.fixed else self.group_3d
+            entity.create_slvs_data(self.solvesys, group=group)
+            self.entities.append(entity)
+
+    def _store_constraint(self, constraint, handles):
+        if handles is None:
+            return
+        if not isinstance(handles, (tuple, list)):
+            handles = (handles,)
+
+        for handle in handles:
+            if isinstance(handle, dict):
+                index = handle.get("h")
+            else:
+                index = handle
+            if index:
+                self.constraints[index] = constraint
+
+    def _init_constraints(self):
+        for constraint in self.context.scene.sketcher.constraints.all:
+            # Native-curve constraints carry curve ids and are handled by
+            # CurveSolver. Scene-level 3D constraints use entity pointers.
+            if getattr(constraint, "curve_id_1", ""):
+                continue
+
+            entities = constraint.entities()
+            if not entities or not all(entity.is_3d() for entity in entities):
+                continue
+
+            constraint.failed = False
+            handles = constraint.py_data(self.solvesys, group=self.group_3d)
+            self._store_constraint(constraint, handles)
+
+    def _mark_failed_constraints(self, failed_handles):
+        for handle in failed_handles:
+            constraint = self.constraints.get(handle)
+            if constraint is not None:
+                constraint.failed = True
+
+    def solve(self, report=True):
+        self._init_entities()
+        self._init_constraints()
+
+        result = self.solvesys.solve_sketch(self.group_3d, report)
+        if isinstance(result, dict):
+            retval = result
+            failed_handles = retval.get("failed", ()) or retval.get("bad", ()) or ()
+        else:
+            retval, failed_handles, *_ = result
+
+        result_code = retval["result"]
+        self.ok = result_code in (0, 4)
+        self.result = bpyEnum(
+            solver_state_items,
+            index=5 if result_code > 4 else result_code,
+        )
+
+        if report and failed_handles:
+            if isinstance(failed_handles, int):
+                failed_handles = (failed_handles,)
+            self._mark_failed_constraints(failed_handles)
+
+        if self.ok:
+            for entity in self.entities:
+                entity.update_from_slvs(self.solvesys)
+
+        logger.info("3D solver: %s", self.result.description)
+        return self.ok
+
+
+def solve_system_3d(context):
+    """Solve scene-level 3D entities and constraints."""
+    return Solver3D(context).solve()

--- a/testing/test_distance_3d.py
+++ b/testing/test_distance_3d.py
@@ -2,8 +2,8 @@
 
 from mathutils import Vector
 
-from .utils import BgsTestCase
 from ..solver_3d import solve_system_3d
+from .utils import BgsTestCase
 
 
 class TestDistance3D(BgsTestCase):

--- a/testing/test_distance_3d.py
+++ b/testing/test_distance_3d.py
@@ -1,0 +1,31 @@
+"""Regression coverage for 3D distance constraints (#55)."""
+
+from mathutils import Vector
+
+from .utils import BgsTestCase
+from ..solver_3d import solve_system_3d
+
+
+class TestDistance3D(BgsTestCase):
+    def test_point_distance_solves_and_has_world_space_matrix(self):
+        p1 = self.entities.add_point_3d((0.0, 0.0, 0.0), fixed=True)
+        p2 = self.entities.add_point_3d((3.0, 4.0, 0.0))
+
+        c = self.constraints.distance.add()
+        c.entity1 = p1
+        c.entity2 = p2
+        self.constraints._init_constraint(c)
+        c.assign_init_props()
+
+        self.assertAlmostEqual(c.value, 5.0, places=5)
+
+        matrix = c.matrix_basis()
+        self.assertLess((matrix.translation - Vector((1.5, 2.0, 0.0))).length, 1e-5)
+
+        world_x = (matrix.to_3x3() @ Vector((1.0, 0.0, 0.0))).normalized()
+        expected_x = Vector((3.0, 4.0, 0.0)).normalized()
+        self.assertGreater(world_x.dot(expected_x), 0.9999)
+
+        c.value = 10.0
+        self.assertTrue(solve_system_3d(self.context))
+        self.assertAlmostEqual((p2.location - p1.location).length, 10.0, places=4)


### PR DESCRIPTION
Fixes #55.

Restores support for scene-level 3D distance constraints alongside native 2D curve sketches and makes SlvsDistance render correctly in world space for 3D entities.

Highlights:
- support 3D points, lines and workplanes;
- compute the correct world-space matrix_basis() for 3D dimensions;
- preserve the existing native 2D curve path;
- restore solving outside an active sketch;
- add regression coverage for 3D distance placement, orientation and solving.

Bounty: Small ($100), claimed in #55 before submission.