### PR TITLE
Add live project geometry from external objects

### DIFF
--- a/.github/workflows/.money-agent-trigger-placeholder
+++ b/.github/workflows/.money-agent-trigger-placeholder
@@ -1,0 +1,1 @@
+trigger

--- a/.github/workflows/.money-agent-trigger-placeholder
+++ b/.github/workflows/.money-agent-trigger-placeholder
@@ -1,1 +1,0 @@
-trigger

--- a/declarations.py
+++ b/declarations.py
@@ -69,6 +69,7 @@ class Operators(str, Enum):
     NodeExtrude = "view3d.slvs_node_extrude"
     NodeArrayLinear = "view3d.slvs_node_array_linear"
     NodeRevolve = "view3d.slvs_node_revolve"
+    ProjectGeometry = "view3d.slvs_project_geometry"
     RegisterDrawCB = "view3d.slvs_register_draw_cb"
     RenameCurve = "view3d.slvs_rename_curve"
     Restore = "view3d.slvs_restore"

--- a/declarations.py
+++ b/declarations.py
@@ -1,7 +1,6 @@
 # Please keep this file in alphabetical order
 from enum import Enum
 
-
 # Blender's built-in Select Box tool — the standard tool we return to when
 # leaving one of our tools (ESC / cancel).
 BLENDER_SELECT_TOOL = "builtin.select_box"

--- a/handlers.py
+++ b/handlers.py
@@ -8,8 +8,25 @@ logger = logging.getLogger(__name__)
 _builtin_handlers = {}
 
 
+# Utility functions to simplify registering bpy.app handlers
+#
+# Builtin handlers have to be registered and unregistered,
+# call register_handlers after all modules are registered and
+# vice versa when unregistering
+#
+# Example usage:
+# from event_system import add_builtin_handler
+#
+# add_builtin_handler("save_pre", write_addon_version)
+# add_builtin_handler("version_update", do_versioning)
+
+
 def add_builtin_handler(event: str, callback):
-    """Add a callback to bpy.app.handlers for addon lifetime."""
+    """
+    Add to bpy.app.handlers, gets (un)registered on addon enable or disabled.
+    Does not support registering handlers at runtime
+    """
+
     global _builtin_handlers
     func = persistent(callback)
     _builtin_handlers.setdefault(event, list()).append(func)
@@ -19,9 +36,11 @@ def register_handlers():
     global _builtin_handlers
     for handler_name in _builtin_handlers.keys():
         msg = "Append <{}> builtin handlers: ".format(handler_name)
+
         for cb in _builtin_handlers[handler_name]:
             getattr(bpy.app.handlers, handler_name).append(cb)
             msg += "\n  - {}".format(cb.__name__)
+
         logger.debug(msg)
 
 
@@ -29,12 +48,16 @@ def unregister_handlers():
     global _builtin_handlers
     for handler_name in _builtin_handlers.keys():
         msg = "Remove <{}> builtin handlers: ".format(handler_name)
+
         for cb in _builtin_handlers[handler_name]:
             handler_list = getattr(bpy.app.handlers, handler_name)
+
             if cb not in handler_list:
                 continue
+
             msg += "\n  - {}".format(cb.__name__)
             handler_list.remove(cb)
+
         logger.debug(msg)
 
 
@@ -63,17 +86,21 @@ def on_depsgraph_update(scene, depsgraph):
     from .utilities.face_anchor import update_face_workplanes
     update_face_workplanes(bpy.context, depsgraph)
 
-    # Keep mesh-projected native points attached to their source vertices. This
-    # may set needs_solve so constraints consuming projected geometry update in
-    # the same depsgraph pass.
+    # Keep projected native points attached to their source mesh vertices.
     from .utilities.projection_anchor import update_projected_geometry
     update_projected_geometry(bpy.context, depsgraph)
 
+    # Repair invariants if a built-in tool edited our curve data outside the
+    # addon. Skip while one of our operators is mid-run (it owns the data and
+    # keeps invariants itself).
     if not global_data.stateful_op_running:
         from .utilities.validate import validate_all_sketches
         if validate_all_sketches(scene):
             global_data.needs_solve = True
 
+        # Undo/redo can flatten the origin workplane empties to identity (they
+        # then stack into a mushy overlap, #571); re-assert their transforms.
+        # Only rewrites when drifted, so this settles in one pass.
         from .utilities.workplane import repair_origin_workplanes
         repair_origin_workplanes(bpy.context)
 
@@ -92,6 +119,11 @@ def on_depsgraph_update(scene, depsgraph):
         context = bpy.context
         sketch = get_active_sketch(context)
         if solve_system(context, sketch=sketch) and sketch:
+            # The solver writes point positions in place, which does not make
+            # the Geometry Nodes modifier re-evaluate; force a topology rebuild
+            # so the generated mesh matches the solved geometry (operators that
+            # solve do this themselves; this covers the depsgraph-driven path,
+            # e.g. editing a dimension value).
             refresh_curve_geometry(sketch)
 
     if global_data.needs_redraw:
@@ -102,7 +134,15 @@ def on_depsgraph_update(scene, depsgraph):
 
 
 def on_frame_change(scene, depsgraph=None):
-    """Re-solve animated dimensions and live mesh projections on frame changes."""
+    """Re-solve on frame changes so animated/driven dimensions update.
+
+    Dimensional values are stored in ``scene["slvs:c:{uid}"]`` custom properties
+    specifically so they can be driven/animated (issue #544). A driver writes
+    that value during depsgraph evaluation, which does not reliably re-flag the
+    scene for ``depsgraph_update_post``; ``frame_change_post`` does fire, so we
+    re-solve here. Covers timeline scrubbing and playback. Projected source
+    geometry is refreshed first so animated source objects stay attached too.
+    """
     from . import global_data
     if global_data.stateful_op_running:
         return
@@ -121,7 +161,13 @@ def on_frame_change(scene, depsgraph=None):
 
 
 def on_undo_redo(scene, *args):
-    """Reconcile sketch mode with the active sketch after undo/redo."""
+    """Reconcile sketch mode with the active sketch after undo/redo.
+
+    The sketch-mode flag and its registered tool set are Python state that
+    Blender's undo cannot revert, while ``active_sketch_object`` is undo-tracked.
+    Undoing sketch creation nulls the pointer but leaves sketch mode on -- a dead
+    end where you can neither add nor leave a sketch. Re-sync them here.
+    """
     from .model.sketch_ref import get_active_sketch
     from .workspacetools.manager import sync_sketch_mode
 

--- a/handlers.py
+++ b/handlers.py
@@ -63,7 +63,7 @@ def unregister_handlers():
 
 def on_load_post(*args):
     """Migrate legacy entity-based sketches to native curves on file load."""
-    from .utilities.migrate import scene_needs_migration, migrate_scene
+    from .utilities.migrate import migrate_scene, scene_needs_migration
     from .utilities.validate import reset_cache
 
     reset_cache()
@@ -148,8 +148,8 @@ def on_frame_change(scene, depsgraph=None):
         return
 
     from .curve_solver import solve_system
-    from .utilities.curve_data import refresh_curve_geometry
     from .model.sketch_ref import get_sketches
+    from .utilities.curve_data import refresh_curve_geometry
     from .utilities.projection_anchor import refresh_projection_for_sketch
 
     context = bpy.context

--- a/handlers.py
+++ b/handlers.py
@@ -8,25 +8,8 @@ logger = logging.getLogger(__name__)
 _builtin_handlers = {}
 
 
-# Utility functions to simplify registering bpy.app handlers
-#
-# Builtin handlers have to be registered and unregistered,
-# call register_handlers after all modules are registered and
-# vice versa when unregistering
-#
-# Example usage:
-# from event_system import add_builtin_handler
-#
-# add_builtin_handler("save_pre", write_addon_version)
-# add_builtin_handler("version_update", do_versioning)
-
-
 def add_builtin_handler(event: str, callback):
-    """
-    Add to bpy.app.handlers, gets (un)registered on addon enable or disabled.
-    Does not support registering handlers at runtime
-    """
-
+    """Add a callback to bpy.app.handlers for addon lifetime."""
     global _builtin_handlers
     func = persistent(callback)
     _builtin_handlers.setdefault(event, list()).append(func)
@@ -36,11 +19,9 @@ def register_handlers():
     global _builtin_handlers
     for handler_name in _builtin_handlers.keys():
         msg = "Append <{}> builtin handlers: ".format(handler_name)
-
         for cb in _builtin_handlers[handler_name]:
             getattr(bpy.app.handlers, handler_name).append(cb)
             msg += "\n  - {}".format(cb.__name__)
-
         logger.debug(msg)
 
 
@@ -48,16 +29,12 @@ def unregister_handlers():
     global _builtin_handlers
     for handler_name in _builtin_handlers.keys():
         msg = "Remove <{}> builtin handlers: ".format(handler_name)
-
         for cb in _builtin_handlers[handler_name]:
             handler_list = getattr(bpy.app.handlers, handler_name)
-
             if cb not in handler_list:
                 continue
-
             msg += "\n  - {}".format(cb.__name__)
             handler_list.remove(cb)
-
         logger.debug(msg)
 
 
@@ -86,17 +63,17 @@ def on_depsgraph_update(scene, depsgraph):
     from .utilities.face_anchor import update_face_workplanes
     update_face_workplanes(bpy.context, depsgraph)
 
-    # Repair invariants if a built-in tool edited our curve data outside the
-    # addon. Skip while one of our operators is mid-run (it owns the data and
-    # keeps invariants itself).
+    # Keep mesh-projected native points attached to their source vertices. This
+    # may set needs_solve so constraints consuming projected geometry update in
+    # the same depsgraph pass.
+    from .utilities.projection_anchor import update_projected_geometry
+    update_projected_geometry(bpy.context, depsgraph)
+
     if not global_data.stateful_op_running:
         from .utilities.validate import validate_all_sketches
         if validate_all_sketches(scene):
             global_data.needs_solve = True
 
-        # Undo/redo can flatten the origin workplane empties to identity (they
-        # then stack into a mushy overlap, #571); re-assert their transforms.
-        # Only rewrites when drifted, so this settles in one pass.
         from .utilities.workplane import repair_origin_workplanes
         repair_origin_workplanes(bpy.context)
 
@@ -115,11 +92,6 @@ def on_depsgraph_update(scene, depsgraph):
         context = bpy.context
         sketch = get_active_sketch(context)
         if solve_system(context, sketch=sketch) and sketch:
-            # The solver writes point positions in place, which does not make
-            # the Geometry Nodes modifier re-evaluate; force a topology rebuild
-            # so the generated mesh matches the solved geometry (operators that
-            # solve do this themselves; this covers the depsgraph-driven path,
-            # e.g. editing a dimension value).
             refresh_curve_geometry(sketch)
 
     if global_data.needs_redraw:
@@ -130,14 +102,7 @@ def on_depsgraph_update(scene, depsgraph):
 
 
 def on_frame_change(scene, depsgraph=None):
-    """Re-solve on frame changes so animated/driven dimensions update.
-
-    Dimensional values are stored in ``scene["slvs:c:{uid}"]`` custom properties
-    specifically so they can be driven/animated (issue #544). A driver writes
-    that value during depsgraph evaluation, which does not reliably re-flag the
-    scene for ``depsgraph_update_post``; ``frame_change_post`` does fire, so we
-    re-solve here. Covers timeline scrubbing and playback.
-    """
+    """Re-solve animated dimensions and live mesh projections on frame changes."""
     from . import global_data
     if global_data.stateful_op_running:
         return
@@ -145,21 +110,18 @@ def on_frame_change(scene, depsgraph=None):
     from .curve_solver import solve_system
     from .utilities.curve_data import refresh_curve_geometry
     from .model.sketch_ref import get_sketches
+    from .utilities.projection_anchor import refresh_projection_for_sketch
 
     context = bpy.context
+    depsgraph = depsgraph or context.evaluated_depsgraph_get()
     for sketch in get_sketches(scene):
+        refresh_projection_for_sketch(sketch, depsgraph, force=True)
         if solve_system(context, sketch=sketch):
             refresh_curve_geometry(sketch)
 
 
 def on_undo_redo(scene, *args):
-    """Reconcile sketch mode with the active sketch after undo/redo.
-
-    The sketch-mode flag and its registered tool set are Python state that
-    Blender's undo cannot revert, while ``active_sketch_object`` is undo-tracked.
-    Undoing sketch creation nulls the pointer but leaves sketch mode on -- a dead
-    end where you can neither add nor leave a sketch. Re-sync them here.
-    """
+    """Reconcile sketch mode with the active sketch after undo/redo."""
     from .model.sketch_ref import get_active_sketch
     from .workspacetools.manager import sync_sketch_mode
 

--- a/model/group_sketcher.py
+++ b/model/group_sketcher.py
@@ -4,7 +4,13 @@ from typing import Union, Generator
 import bpy
 from bpy.types import PropertyGroup, Context
 from bpy.utils import register_class, unregister_class
-from bpy.props import IntProperty, BoolProperty, PointerProperty, IntVectorProperty
+from bpy.props import (
+    IntProperty,
+    BoolProperty,
+    PointerProperty,
+    IntVectorProperty,
+    CollectionProperty,
+)
 
 from .. import global_data
 from ..drawing import selection
@@ -19,6 +25,18 @@ logger = logging.getLogger(__name__)
 
 # Prefix for all constraint driver target custom properties on the scene.
 _EP_PREFIX = "slvs:c:"
+
+
+class ProjectedSourceSlot(PropertyGroup):
+    """Object pointer used by native projected-curve bindings.
+
+    Curve-domain integer attributes store the index into this compact table so
+    all plain binding data can live on the Curves datablock while the one value
+    Blender attributes cannot represent (an ID pointer) remains a real RNA
+    pointer rather than a fragile object-name string.
+    """
+
+    source: PointerProperty(type=bpy.types.Object, name="Projected Source")
 
 
 class SketcherProps(PropertyGroup):
@@ -124,10 +142,14 @@ class SketcherProps(PropertyGroup):
 
 
 def register():
+    register_class(ProjectedSourceSlot)
     register_class(SketcherProps)
+    bpy.types.Object.slvs_project_sources = CollectionProperty(type=ProjectedSourceSlot)
     bpy.types.Scene.sketcher = PointerProperty(type=SketcherProps)
 
 
 def unregister():
+    del bpy.types.Object.slvs_project_sources
     del bpy.types.Scene.sketcher
     unregister_class(SketcherProps)
+    unregister_class(ProjectedSourceSlot)

--- a/model/group_sketcher.py
+++ b/model/group_sketcher.py
@@ -1,25 +1,24 @@
 import logging
-from typing import Union, Generator
+from typing import Generator, Union
 
 import bpy
-from bpy.types import PropertyGroup, Context
-from bpy.utils import register_class, unregister_class
 from bpy.props import (
-    IntProperty,
     BoolProperty,
-    PointerProperty,
-    IntVectorProperty,
     CollectionProperty,
+    IntProperty,
+    IntVectorProperty,
+    PointerProperty,
 )
+from bpy.types import Context, PropertyGroup
+from bpy.utils import register_class, unregister_class
 
 from .. import global_data
-from ..drawing import selection
 from ..curve_solver import solve_system
-from .utilities import slvs_entity_pointer
-from .base_entity import SlvsGenericEntity
-from .group_entities import SlvsEntities
-from .group_constraints import SlvsConstraints
+from ..drawing import selection
 from ..utilities.view import update_cb
+from .base_entity import SlvsGenericEntity
+from .group_constraints import SlvsConstraints
+from .group_entities import SlvsEntities
 
 logger = logging.getLogger(__name__)
 

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -1,5 +1,5 @@
-from ..utilities.register import module_register_factory
 from ..stateful_operator.utilities.register import register_stateops_factory
+from ..utilities.register import module_register_factory
 
 modules = [
     "select",

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -22,6 +22,7 @@ modules = [
     "batch_set",
     "bevel",
     "offset",
+    "project_geometry",
     "set_sketch",
     "delete_entity",
     "delete_sketch",

--- a/operators/project_geometry.py
+++ b/operators/project_geometry.py
@@ -51,8 +51,6 @@ class VIEW3D_OT_slvs_project_geometry(Operator):
     def invoke(self, context: Context, event):
         if self.source is None:
             self.source = self._selected_source(context)
-        if self.source is not None:
-            return self.execute(context)
         return context.window_manager.invoke_props_dialog(self)
 
     def draw(self, context: Context):

--- a/operators/project_geometry.py
+++ b/operators/project_geometry.py
@@ -1,0 +1,95 @@
+import bpy
+from bpy.props import BoolProperty, PointerProperty
+from bpy.types import Context, Object, Operator
+from bpy.utils import register_classes_factory
+
+from ..declarations import Operators
+from ..model.sketch_ref import get_active_sketch
+from ..utilities.curve_data import refresh_curve_geometry
+from ..utilities.projection_anchor import project_mesh_object
+
+
+def _mesh_object_poll(_self, obj):
+    return obj is not None and obj.type == "MESH"
+
+
+class VIEW3D_OT_slvs_project_geometry(Operator):
+    """Project a mesh object's edges onto the active sketch"""
+
+    bl_idname = Operators.ProjectGeometry
+    bl_label = "Project Geometry"
+    bl_description = "Project mesh edges onto the active sketch and keep a live source reference"
+    bl_options = {"REGISTER", "UNDO"}
+
+    source: PointerProperty(
+        name="Source",
+        description="Mesh object whose edges are projected onto the active sketch",
+        type=Object,
+        poll=_mesh_object_poll,
+    )
+    construction: BoolProperty(
+        name="Construction Geometry",
+        description="Create the projected points and lines as construction geometry",
+        default=True,
+    )
+
+    @classmethod
+    def poll(cls, context: Context):
+        return get_active_sketch(context) is not None
+
+    def _selected_source(self, context):
+        sketch = get_active_sketch(context)
+        sketch_ob = sketch.target_object if sketch else None
+        meshes = [
+            obj
+            for obj in context.selected_objects
+            if obj is not sketch_ob and obj.type == "MESH"
+        ]
+        return meshes[0] if len(meshes) == 1 else None
+
+    def invoke(self, context: Context, event):
+        if self.source is None:
+            self.source = self._selected_source(context)
+        if self.source is not None:
+            return self.execute(context)
+        return context.window_manager.invoke_props_dialog(self)
+
+    def draw(self, context: Context):
+        layout = self.layout
+        layout.prop(self, "source")
+        layout.prop(self, "construction")
+
+    def execute(self, context: Context):
+        sketch = get_active_sketch(context)
+        if sketch is None:
+            self.report({"ERROR"}, "Enter a sketch before projecting geometry")
+            return {"CANCELLED"}
+        if self.source is None or self.source.type != "MESH":
+            self.report({"ERROR"}, "Choose a mesh source object")
+            return {"CANCELLED"}
+        if self.source == sketch.target_object:
+            self.report({"ERROR"}, "The source cannot be the active sketch")
+            return {"CANCELLED"}
+
+        points, lines = project_mesh_object(
+            sketch,
+            self.source,
+            construction=self.construction,
+        )
+        if not lines:
+            self.report({"WARNING"}, "The source mesh has no edges to project")
+            return {"CANCELLED"}
+
+        refresh_curve_geometry(sketch)
+        from .. import global_data
+
+        global_data.needs_solve = True
+        global_data.needs_redraw = True
+        self.report(
+            {"INFO"},
+            f"Projected {len(lines)} edge(s) from {self.source.name}",
+        )
+        return {"FINISHED"}
+
+
+register, unregister = register_classes_factory((VIEW3D_OT_slvs_project_geometry,))

--- a/operators/project_geometry.py
+++ b/operators/project_geometry.py
@@ -1,15 +1,12 @@
-from bpy.props import BoolProperty, PointerProperty
-from bpy.types import Context, Object, Operator
+import bpy
+from bpy.props import BoolProperty, StringProperty
+from bpy.types import Context, Operator
 from bpy.utils import register_classes_factory
 
 from ..declarations import Operators
 from ..model.sketch_ref import get_active_sketch
 from ..utilities.curve_data import refresh_curve_geometry
 from ..utilities.projection_anchor import project_mesh_object
-
-
-def _mesh_object_poll(_self, obj):
-    return obj is not None and obj.type == "MESH"
 
 
 class VIEW3D_OT_slvs_project_geometry(Operator):
@@ -22,11 +19,10 @@ class VIEW3D_OT_slvs_project_geometry(Operator):
     )
     bl_options = {"REGISTER", "UNDO"}
 
-    source: PointerProperty(
+    source: StringProperty(
         name="Source",
         description="Mesh object whose edges are projected onto the active sketch",
-        type=Object,
-        poll=_mesh_object_poll,
+        default="",
     )
     construction: BoolProperty(
         name="Construction Geometry",
@@ -49,13 +45,15 @@ class VIEW3D_OT_slvs_project_geometry(Operator):
         return meshes[0] if len(meshes) == 1 else None
 
     def invoke(self, context: Context, event):
-        if self.source is None:
-            self.source = self._selected_source(context)
+        if not self.source:
+            selected = self._selected_source(context)
+            if selected is not None:
+                self.source = selected.name
         return context.window_manager.invoke_props_dialog(self)
 
     def draw(self, context: Context):
         layout = self.layout
-        layout.prop(self, "source")
+        layout.prop_search(self, "source", bpy.data, "objects", text="Source")
         layout.prop(self, "construction")
 
     def execute(self, context: Context):
@@ -63,16 +61,18 @@ class VIEW3D_OT_slvs_project_geometry(Operator):
         if sketch is None:
             self.report({"ERROR"}, "Enter a sketch before projecting geometry")
             return {"CANCELLED"}
-        if self.source is None or self.source.type != "MESH":
+
+        source = bpy.data.objects.get(self.source)
+        if source is None or source.type != "MESH":
             self.report({"ERROR"}, "Choose a mesh source object")
             return {"CANCELLED"}
-        if self.source == sketch.target_object:
+        if source == sketch.target_object:
             self.report({"ERROR"}, "The source cannot be the active sketch")
             return {"CANCELLED"}
 
         _, lines = project_mesh_object(
             sketch,
-            self.source,
+            source,
             construction=self.construction,
         )
         if not lines:
@@ -86,7 +86,7 @@ class VIEW3D_OT_slvs_project_geometry(Operator):
         global_data.needs_redraw = True
         self.report(
             {"INFO"},
-            f"Projected {len(lines)} edge(s) from {self.source.name}",
+            f"Projected {len(lines)} edge(s) from {source.name}",
         )
         return {"FINISHED"}
 

--- a/operators/project_geometry.py
+++ b/operators/project_geometry.py
@@ -1,4 +1,3 @@
-import bpy
 from bpy.props import BoolProperty, PointerProperty
 from bpy.types import Context, Object, Operator
 from bpy.utils import register_classes_factory
@@ -18,7 +17,9 @@ class VIEW3D_OT_slvs_project_geometry(Operator):
 
     bl_idname = Operators.ProjectGeometry
     bl_label = "Project Geometry"
-    bl_description = "Project mesh edges onto the active sketch and keep a live source reference"
+    bl_description = (
+        "Project mesh edges onto the active sketch and keep a live source reference"
+    )
     bl_options = {"REGISTER", "UNDO"}
 
     source: PointerProperty(
@@ -71,7 +72,7 @@ class VIEW3D_OT_slvs_project_geometry(Operator):
             self.report({"ERROR"}, "The source cannot be the active sketch")
             return {"CANCELLED"}
 
-        points, lines = project_mesh_object(
+        _, lines = project_mesh_object(
             sketch,
             self.source,
             construction=self.construction,

--- a/testing/test_projection_anchor.py
+++ b/testing/test_projection_anchor.py
@@ -1,11 +1,11 @@
 from mathutils import Vector
 
-from .utils import Sketch2dTestCase
 from ..utilities.projection_anchor import (
     VERTEX_ID_ATTR,
     project_mesh_object,
     refresh_projection_for_sketch,
 )
+from .utils import Sketch2dTestCase
 
 
 class TestProjectionAnchor(Sketch2dTestCase):

--- a/testing/test_projection_anchor.py
+++ b/testing/test_projection_anchor.py
@@ -39,23 +39,24 @@ class TestProjectionAnchor(Sketch2dTestCase):
         source.data.update()
         self.context.view_layer.update()
         depsgraph = self.context.evaluated_depsgraph_get()
-        moved = refresh_projection_for_sketch(
+        refresh_projection_for_sketch(
             self.sketch,
             depsgraph,
             force=True,
         )
 
-        self.assertGreaterEqual(moved, 1)
+        # The depsgraph handler can synchronize before the explicit refresh above,
+        # so validate the final live position rather than requiring that call to
+        # report a fresh move.
         self.assertLess((points[1].co - Vector((3.5, 0.5))).length, 1e-5)
 
         source.location.y = 2.0
         self.context.view_layer.update()
         depsgraph = self.context.evaluated_depsgraph_get()
-        moved = refresh_projection_for_sketch(
+        refresh_projection_for_sketch(
             self.sketch,
             depsgraph,
             force=True,
         )
 
-        self.assertGreaterEqual(moved, 1)
         self.assertLess((points[1].co - Vector((3.5, 2.5))).length, 1e-5)

--- a/testing/test_projection_anchor.py
+++ b/testing/test_projection_anchor.py
@@ -1,6 +1,11 @@
 from mathutils import Vector
 
+from ..utilities.curve_data import get_curve_data
 from ..utilities.projection_anchor import (
+    PROJECT_LAST_CO_ATTR,
+    PROJECT_SRC_SLOT_ATTR,
+    PROJECT_VERTEX_ID_ATTR,
+    PROJECT_VERTEX_INDEX_ATTR,
     VERTEX_ID_ATTR,
     project_mesh_object,
     refresh_projection_for_sketch,
@@ -31,6 +36,45 @@ class TestProjectionAnchor(Sketch2dTestCase):
         self.assertTrue(all(point.construction for point in points))
         self.assertTrue(all(line.construction for line in lines))
         self.assertIsNotNone(source.data.attributes.get(VERTEX_ID_ATTR))
+
+        # Binding POD data belongs to the native Curves datablock. All projected
+        # points from this object share one real Object pointer slot.
+        owner = self.sketch.target_object
+        self.assertEqual(len(owner.slvs_project_sources), 1)
+        self.assertEqual(owner.slvs_project_sources[0].source, source)
+        for attr_name in (
+            PROJECT_SRC_SLOT_ATTR,
+            PROJECT_VERTEX_ID_ATTR,
+            PROJECT_VERTEX_INDEX_ATTR,
+            PROJECT_LAST_CO_ATTR,
+        ):
+            attr = self.sketch.data.attributes.get(attr_name)
+            self.assertIsNotNone(attr)
+            self.assertEqual(attr.domain, "CURVE")
+
+        for vertex_index, point in enumerate(points):
+            curve_data, curve_index, _ = get_curve_data(self.sketch, point.curve_id)
+            attrs = curve_data.attributes
+            self.assertEqual(attrs[PROJECT_SRC_SLOT_ATTR].data[curve_index].value, 0)
+            self.assertGreater(
+                attrs[PROJECT_VERTEX_ID_ATTR].data[curve_index].value,
+                0,
+            )
+            self.assertEqual(
+                attrs[PROJECT_VERTEX_INDEX_ATTR].data[curve_index].value,
+                vertex_index,
+            )
+            last_co = Vector(attrs[PROJECT_LAST_CO_ATTR].data[curve_index].vector)
+            self.assertLess(
+                (last_co - source.data.vertices[vertex_index].co).length,
+                1e-6,
+            )
+
+        # The old implementation stored four stringly-keyed ID properties per
+        # point on the Object. None should be created by the native binding.
+        self.assertFalse(
+            any(str(key).startswith("slvs_project_src_") for key in owner.keys())
+        )
 
         self.assertLess((points[0].co - Vector((0.0, 0.0))).length, 1e-6)
         self.assertLess((points[1].co - Vector((2.0, 0.0))).length, 1e-6)

--- a/testing/test_projection_anchor.py
+++ b/testing/test_projection_anchor.py
@@ -37,8 +37,8 @@ class TestProjectionAnchor(Sketch2dTestCase):
 
         source.data.vertices[1].co = (3.5, 0.5, 1.0)
         source.data.update()
+        self.context.view_layer.update()
         depsgraph = self.context.evaluated_depsgraph_get()
-        depsgraph.update()
         moved = refresh_projection_for_sketch(
             self.sketch,
             depsgraph,

--- a/testing/test_projection_anchor.py
+++ b/testing/test_projection_anchor.py
@@ -1,0 +1,61 @@
+from mathutils import Vector
+
+from .utils import Sketch2dTestCase
+from ..utilities.projection_anchor import (
+    VERTEX_ID_ATTR,
+    project_mesh_object,
+    refresh_projection_for_sketch,
+)
+
+
+class TestProjectionAnchor(Sketch2dTestCase):
+    def _mesh_object(self):
+        mesh = self.data.meshes.new("ProjectionSourceMesh")
+        mesh.from_pydata(
+            [(0.0, 0.0, 1.0), (2.0, 0.0, 1.0), (2.0, 1.0, 1.0)],
+            [(0, 1), (1, 2)],
+            [],
+        )
+        mesh.update()
+        obj = self.data.objects.new("ProjectionSource", mesh)
+        self.scene.collection.objects.link(obj)
+        return obj
+
+    def test_projection_keeps_live_vertex_reference(self):
+        source = self._mesh_object()
+        points, lines = project_mesh_object(self.sketch, source, construction=True)
+
+        self.assertEqual(len(points), 3)
+        self.assertEqual(len(lines), 2)
+        self.assertTrue(all(point.fixed for point in points))
+        self.assertTrue(all(point.construction for point in points))
+        self.assertTrue(all(line.construction for line in lines))
+        self.assertIsNotNone(source.data.attributes.get(VERTEX_ID_ATTR))
+
+        self.assertLess((points[0].co - Vector((0.0, 0.0))).length, 1e-6)
+        self.assertLess((points[1].co - Vector((2.0, 0.0))).length, 1e-6)
+
+        source.data.vertices[1].co = (3.5, 0.5, 1.0)
+        source.data.update()
+        depsgraph = self.context.evaluated_depsgraph_get()
+        depsgraph.update()
+        moved = refresh_projection_for_sketch(
+            self.sketch,
+            depsgraph,
+            force=True,
+        )
+
+        self.assertGreaterEqual(moved, 1)
+        self.assertLess((points[1].co - Vector((3.5, 0.5))).length, 1e-5)
+
+        source.location.y = 2.0
+        self.context.view_layer.update()
+        depsgraph = self.context.evaluated_depsgraph_get()
+        moved = refresh_projection_for_sketch(
+            self.sketch,
+            depsgraph,
+            force=True,
+        )
+
+        self.assertGreaterEqual(moved, 1)
+        self.assertLess((points[1].co - Vector((3.5, 2.5))).length, 1e-5)

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -18,6 +18,7 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
         layout = self.layout
 
         layout.operator(declarations.Operators.MergePoints)
+        layout.operator(declarations.Operators.ProjectGeometry, icon="MOD_SHRINKWRAP")
 
         # Constraints
         layout.label(text="Constraints:")
@@ -37,4 +38,3 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
         col = layout.column(align=True)
         col.operator(declarations.Operators.NodeExtrude)
         col.operator(declarations.Operators.NodeArrayLinear)
-

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -1,7 +1,6 @@
 from bpy.types import Context
 
-from .. import declarations
-from .. import icon_manager
+from .. import declarations, icon_manager
 from . import VIEW3D_PT_sketcher_base
 
 

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -8,7 +8,6 @@ vertices into the sketch plane and the connected native line curves follow throu
 ``rebuild_segments``.
 """
 
-import bpy
 from mathutils import Vector
 
 from ..model.curve_ref import LineRef, PointRef
@@ -133,7 +132,9 @@ def refresh_projection_for_sketch(sketch, depsgraph, changed=None, force=False):
     if owner is None:
         return 0
 
-    sketch_changed = force or changed is None or owner in changed or owner.data in changed
+    sketch_changed = (
+        force or changed is None or owner in changed or owner.data in changed
+    )
     if owner.parent is not None and changed is not None and owner.parent in changed:
         sketch_changed = True
 
@@ -163,7 +164,12 @@ def refresh_projection_for_sketch(sketch, depsgraph, changed=None, force=False):
             eval_ob = source.evaluated_get(depsgraph)
             source_cache[source] = eval_ob
 
-        vertex = _resolve_evaluated_vertex(eval_ob, vertex_id, fallback_index, last_co)
+        vertex = _resolve_evaluated_vertex(
+            eval_ob,
+            vertex_id,
+            fallback_index,
+            last_co,
+        )
         if vertex is None:
             continue
 
@@ -210,7 +216,11 @@ def update_projected_geometry(context, depsgraph):
     try:
         moved = 0
         for sketch in get_sketches(context.scene):
-            moved += refresh_projection_for_sketch(sketch, depsgraph, changed=changed)
+            moved += refresh_projection_for_sketch(
+                sketch,
+                depsgraph,
+                changed=changed,
+            )
     finally:
         _updating = False
 
@@ -228,7 +238,7 @@ def project_mesh_object(sketch, source, construction=True):
     if source is None or source.type != "MESH":
         raise TypeError("Source must be a mesh object")
     mesh = source.data
-    if not mesh.edges:
+    if len(mesh.edges) == 0:
         return [], []
 
     owner = sketch.target_object

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -1,0 +1,270 @@
+"""Live references for mesh geometry projected into native sketches.
+
+Projected point curves keep a persistent reference to their source mesh vertex.
+The reference is stored on the sketch object and backed by a POINT-domain integer
+attribute on the source mesh, so normal topology edits that preserve attributes do
+not depend on fragile vertex indices. A depsgraph handler reprojects changed source
+vertices into the sketch plane and the connected native line curves follow through
+``rebuild_segments``.
+"""
+
+import bpy
+from mathutils import Vector
+
+from ..model.curve_ref import LineRef, PointRef
+from ..utilities.curve_data import batch_update
+
+VERTEX_ID_ATTR = "slvs_project_vertex_id"
+
+_SOURCE_PREFIX = "slvs_project_src_"
+_VERTEX_ID_PREFIX = "slvs_project_vid_"
+_VERTEX_INDEX_PREFIX = "slvs_project_idx_"
+_LAST_CO_PREFIX = "slvs_project_last_"
+
+_updating = False
+
+
+def _key(prefix, curve_id):
+    return f"{prefix}{curve_id}"
+
+
+def _allocate_vertex_id(mesh):
+    attr = mesh.attributes.get(VERTEX_ID_ATTR)
+    if attr is None or len(attr.data) == 0:
+        return 1
+    return max((int(item.value) for item in attr.data), default=0) + 1
+
+
+def ensure_vertex_id(mesh, vertex_index):
+    """Return a persistent non-zero id for ``mesh.vertices[vertex_index]``."""
+    attr = mesh.attributes.get(VERTEX_ID_ATTR)
+    if attr is None:
+        attr = mesh.attributes.new(VERTEX_ID_ATTR, "INT", "POINT")
+
+    current = int(attr.data[vertex_index].value)
+    if current:
+        return current
+
+    current = _allocate_vertex_id(mesh)
+    attr.data[vertex_index].value = current
+    return current
+
+
+def bind_projected_point(sketch, point, source, vertex_index):
+    """Bind a native sketch point to a source mesh vertex."""
+    if source is None or source.type != "MESH":
+        raise TypeError("Projected geometry source must be a mesh object")
+
+    curve_id = point.curve_id
+    vertex_id = ensure_vertex_id(source.data, vertex_index)
+    owner = sketch.target_object
+    owner[_key(_SOURCE_PREFIX, curve_id)] = source
+    owner[_key(_VERTEX_ID_PREFIX, curve_id)] = vertex_id
+    owner[_key(_VERTEX_INDEX_PREFIX, curve_id)] = int(vertex_index)
+    owner[_key(_LAST_CO_PREFIX, curve_id)] = list(source.data.vertices[vertex_index].co)
+    return vertex_id
+
+
+def clear_projected_point_binding(sketch, curve_id):
+    owner = sketch.target_object
+    for prefix in (
+        _SOURCE_PREFIX,
+        _VERTEX_ID_PREFIX,
+        _VERTEX_INDEX_PREFIX,
+        _LAST_CO_PREFIX,
+    ):
+        key = _key(prefix, curve_id)
+        if key in owner:
+            del owner[key]
+
+
+def iter_projected_point_bindings(sketch):
+    """Yield ``(curve_id, source, vertex_id, fallback_index, last_co)``."""
+    owner = sketch.target_object
+    if owner is None:
+        return
+
+    for prop_key in list(owner.keys()):
+        if not str(prop_key).startswith(_SOURCE_PREFIX):
+            continue
+        curve_id = str(prop_key)[len(_SOURCE_PREFIX):]
+        source = owner.get(prop_key)
+        vertex_id = int(owner.get(_key(_VERTEX_ID_PREFIX, curve_id), 0))
+        fallback = int(owner.get(_key(_VERTEX_INDEX_PREFIX, curve_id), -1))
+        last_co = owner.get(_key(_LAST_CO_PREFIX, curve_id))
+        yield curve_id, source, vertex_id, fallback, last_co
+
+
+def _resolve_evaluated_vertex(eval_ob, vertex_id, fallback_index, last_co):
+    mesh = eval_ob.data
+    candidates = []
+    attr = mesh.attributes.get(VERTEX_ID_ATTR)
+    if attr is not None and attr.domain == "POINT":
+        for i, item in enumerate(attr.data):
+            if int(item.value) == vertex_id and i < len(mesh.vertices):
+                candidates.append(i)
+
+    if candidates:
+        if len(candidates) == 1 or last_co is None:
+            return mesh.vertices[candidates[0]]
+        last = Vector(last_co)
+        index = min(candidates, key=lambda i: (mesh.vertices[i].co - last).length)
+        return mesh.vertices[index]
+
+    # Some modifiers do not propagate arbitrary attributes. Keep a conservative
+    # fallback for the unmodified/simple-mesh case instead of silently detaching.
+    if 0 <= fallback_index < len(mesh.vertices):
+        return mesh.vertices[fallback_index]
+    return None
+
+
+def _source_changed(source, changed):
+    if changed is None:
+        return True
+    if source in changed or source.data in changed:
+        return True
+    original = getattr(source, "original", None)
+    return original is not None and original in changed
+
+
+def refresh_projection_for_sketch(sketch, depsgraph, changed=None, force=False):
+    """Reproject bound points for one sketch. Returns number of moved points."""
+    owner = sketch.target_object
+    if owner is None:
+        return 0
+
+    sketch_changed = force or changed is None or owner in changed or owner.data in changed
+    if owner.parent is not None and changed is not None and owner.parent in changed:
+        sketch_changed = True
+
+    updates = {}
+    source_cache = {}
+    stale = []
+
+    for curve_id, source, vertex_id, fallback_index, last_co in list(
+        iter_projected_point_bindings(sketch)
+    ):
+        point = PointRef(sketch, curve_id)
+        if not point.valid:
+            stale.append(curve_id)
+            continue
+        if source is None or getattr(source, "type", None) != "MESH":
+            stale.append(curve_id)
+            continue
+        if not (sketch_changed or force or _source_changed(source, changed)):
+            continue
+        if source.mode == "EDIT":
+            # The original mesh/attribute state is transient in Edit Mode. It is
+            # reconciled when Blender emits the update on leaving Edit Mode.
+            continue
+
+        eval_ob = source_cache.get(source)
+        if eval_ob is None:
+            eval_ob = source.evaluated_get(depsgraph)
+            source_cache[source] = eval_ob
+
+        vertex = _resolve_evaluated_vertex(eval_ob, vertex_id, fallback_index, last_co)
+        if vertex is None:
+            continue
+
+        world = eval_ob.matrix_world @ vertex.co
+        local = owner.matrix_world.inverted() @ world
+        new_co = Vector((local.x, local.y))
+        if (point.co - new_co).length > 1e-7:
+            updates[curve_id] = (point, new_co, list(vertex.co))
+
+    for curve_id in stale:
+        clear_projected_point_binding(sketch, curve_id)
+
+    if not updates:
+        return 0
+
+    with batch_update(sketch, point_ids=set(updates.keys())):
+        for curve_id, (point, co, last_co) in updates.items():
+            point.co = co
+            owner[_key(_LAST_CO_PREFIX, curve_id)] = last_co
+
+    return len(updates)
+
+
+def update_projected_geometry(context, depsgraph):
+    """Depsgraph handler body for all live projected mesh references."""
+    global _updating
+    if _updating:
+        return
+
+    changed = set()
+    for update in depsgraph.updates:
+        changed.add(update.id)
+        original = getattr(update.id, "original", None)
+        if original is not None:
+            changed.add(original)
+
+    from .. import global_data
+    from ..model.sketch_ref import get_sketches
+
+    if global_data.stateful_op_running:
+        return
+
+    _updating = True
+    try:
+        moved = 0
+        for sketch in get_sketches(context.scene):
+            moved += refresh_projection_for_sketch(sketch, depsgraph, changed=changed)
+    finally:
+        _updating = False
+
+    if moved:
+        global_data.needs_solve = True
+        global_data.needs_redraw = True
+
+
+def project_mesh_object(sketch, source, construction=True):
+    """Project every edge of ``source`` onto ``sketch`` as live native curves.
+
+    Returns ``(points, lines)``. Endpoints are fixed because their positions are
+    driven by the source mesh reference rather than by SolveSpace.
+    """
+    if source is None or source.type != "MESH":
+        raise TypeError("Source must be a mesh object")
+    mesh = source.data
+    if not mesh.edges:
+        return [], []
+
+    owner = sketch.target_object
+    inv = owner.matrix_world.inverted()
+    used_indices = sorted({int(i) for edge in mesh.edges for i in edge.vertices})
+    point_by_index = {}
+    points = []
+    lines = []
+
+    with batch_update(sketch):
+        for vertex_index in used_indices:
+            vertex = mesh.vertices[vertex_index]
+            local = inv @ (source.matrix_world @ vertex.co)
+            point = PointRef.create(
+                sketch,
+                (local.x, local.y),
+                construction=construction,
+                fixed=True,
+                name="Projected Point",
+            )
+            bind_projected_point(sketch, point, source, vertex_index)
+            point_by_index[vertex_index] = point
+            points.append(point)
+
+        for edge in mesh.edges:
+            p1 = point_by_index.get(int(edge.vertices[0]))
+            p2 = point_by_index.get(int(edge.vertices[1]))
+            if p1 is None or p2 is None:
+                continue
+            line = LineRef.create(
+                sketch,
+                p1,
+                p2,
+                construction=construction,
+                name="Projected Line",
+            )
+            lines.append(line)
+
+    return points, lines

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -1,30 +1,37 @@
 """Live references for mesh geometry projected into native sketches.
 
-Projected point curves keep a persistent reference to their source mesh vertex.
-The reference is stored on the sketch object and backed by a POINT-domain integer
-attribute on the source mesh, so normal topology edits that preserve attributes do
-not depend on fragile vertex indices. A depsgraph handler reprojects changed source
-vertices into the sketch plane and the connected native line curves follow through
-``rebuild_segments``.
+Projected point curves keep their binding metadata on the Curves datablock:
+source slot, persistent source vertex id, fallback vertex index and last source
+coordinate are CURVE-domain attributes, so they re-index and disappear together
+with their curve. The only non-POD value is the source Object pointer; it lives in
+a compact per-sketch pointer collection and is referenced by integer slot.
+
+The source mesh itself carries a POINT-domain persistent vertex id attribute, so
+normal topology edits that preserve attributes do not depend on fragile vertex
+indices. A depsgraph handler reprojects changed source vertices into the sketch
+plane and connected native line curves follow through ``rebuild_segments``.
 """
 
 from mathutils import Vector
 
 from ..model.curve_ref import LineRef, PointRef
-from ..utilities.curve_data import batch_update
+from ..utilities.curve_data import (
+    batch_update,
+    ensure_attribute,
+    get_curve_data,
+    read_curve_id_list,
+)
 
+# Persistent identity on the SOURCE mesh (POINT domain).
 VERTEX_ID_ATTR = "slvs_project_vertex_id"
 
-_SOURCE_PREFIX = "slvs_project_src_"
-_VERTEX_ID_PREFIX = "slvs_project_vid_"
-_VERTEX_INDEX_PREFIX = "slvs_project_idx_"
-_LAST_CO_PREFIX = "slvs_project_last_"
+# Binding metadata on the SKETCH Curves datablock (CURVE domain).
+PROJECT_SRC_SLOT_ATTR = "slvs_project_src_slot"
+PROJECT_VERTEX_ID_ATTR = "slvs_project_vertex_id"
+PROJECT_VERTEX_INDEX_ATTR = "slvs_project_vertex_index"
+PROJECT_LAST_CO_ATTR = "slvs_project_last_co"
 
 _updating = False
-
-
-def _key(prefix, curve_id):
-    return f"{prefix}{curve_id}"
 
 
 def _allocate_vertex_id(mesh):
@@ -49,48 +56,77 @@ def ensure_vertex_id(mesh, vertex_index):
     return current
 
 
+def _ensure_projection_attributes(curve_data):
+    attributes = curve_data.attributes
+    ensure_attribute(attributes, PROJECT_SRC_SLOT_ATTR, "INT", "CURVE")
+    ensure_attribute(attributes, PROJECT_VERTEX_ID_ATTR, "INT", "CURVE")
+    ensure_attribute(attributes, PROJECT_VERTEX_INDEX_ATTR, "INT", "CURVE")
+    ensure_attribute(attributes, PROJECT_LAST_CO_ATTR, "FLOAT_VECTOR", "CURVE")
+
+
+def _get_or_add_source_slot(owner, source):
+    """Return a stable slot for ``source`` in the sketch's pointer table."""
+    slots = owner.slvs_project_sources
+    for index, slot in enumerate(slots):
+        if slot.source == source:
+            return index
+
+    slot = slots.add()
+    slot.source = source
+    return len(slots) - 1
+
+
 def bind_projected_point(sketch, point, source, vertex_index):
     """Bind a native sketch point to a source mesh vertex."""
     if source is None or source.type != "MESH":
         raise TypeError("Projected geometry source must be a mesh object")
 
-    curve_id = point.curve_id
+    curve_data, curve_index, _ = get_curve_data(sketch, point.curve_id)
+    if curve_data is None:
+        raise ValueError("Projected point is not part of the sketch")
+
+    _ensure_projection_attributes(curve_data)
     vertex_id = ensure_vertex_id(source.data, vertex_index)
-    owner = sketch.target_object
-    owner[_key(_SOURCE_PREFIX, curve_id)] = source
-    owner[_key(_VERTEX_ID_PREFIX, curve_id)] = vertex_id
-    owner[_key(_VERTEX_INDEX_PREFIX, curve_id)] = int(vertex_index)
-    owner[_key(_LAST_CO_PREFIX, curve_id)] = list(source.data.vertices[vertex_index].co)
+    source_slot = _get_or_add_source_slot(sketch.target_object, source)
+    attributes = curve_data.attributes
+
+    attributes[PROJECT_SRC_SLOT_ATTR].data[curve_index].value = source_slot
+    attributes[PROJECT_VERTEX_ID_ATTR].data[curve_index].value = vertex_id
+    attributes[PROJECT_VERTEX_INDEX_ATTR].data[curve_index].value = int(vertex_index)
+    attributes[PROJECT_LAST_CO_ATTR].data[curve_index].vector = source.data.vertices[
+        vertex_index
+    ].co
     return vertex_id
-
-
-def clear_projected_point_binding(sketch, curve_id):
-    owner = sketch.target_object
-    for prefix in (
-        _SOURCE_PREFIX,
-        _VERTEX_ID_PREFIX,
-        _VERTEX_INDEX_PREFIX,
-        _LAST_CO_PREFIX,
-    ):
-        key = _key(prefix, curve_id)
-        if key in owner:
-            del owner[key]
 
 
 def iter_projected_point_bindings(sketch):
     """Yield ``(curve_id, source, vertex_id, fallback_index, last_co)``."""
     owner = sketch.target_object
-    if owner is None:
+    curve_data = sketch.data
+    if owner is None or curve_data is None:
         return
 
-    for prop_key in list(owner.keys()):
-        if not str(prop_key).startswith(_SOURCE_PREFIX):
+    attributes = curve_data.attributes
+    slot_attr = attributes.get(PROJECT_SRC_SLOT_ATTR)
+    vertex_id_attr = attributes.get(PROJECT_VERTEX_ID_ATTR)
+    fallback_attr = attributes.get(PROJECT_VERTEX_INDEX_ATTR)
+    last_co_attr = attributes.get(PROJECT_LAST_CO_ATTR)
+    if not all((slot_attr, vertex_id_attr, fallback_attr, last_co_attr)):
+        return
+
+    curve_ids = read_curve_id_list(curve_data)
+    slots = owner.slvs_project_sources
+    for index, curve_id in enumerate(curve_ids):
+        vertex_id = int(vertex_id_attr.data[index].value)
+        # All generic/native curves default to zero. A non-zero persistent
+        # source vertex id is therefore the binding marker.
+        if vertex_id <= 0:
             continue
-        curve_id = str(prop_key)[len(_SOURCE_PREFIX) :]
-        source = owner.get(prop_key)
-        vertex_id = int(owner.get(_key(_VERTEX_ID_PREFIX, curve_id), 0))
-        fallback = int(owner.get(_key(_VERTEX_INDEX_PREFIX, curve_id), -1))
-        last_co = owner.get(_key(_LAST_CO_PREFIX, curve_id))
+
+        slot_index = int(slot_attr.data[index].value)
+        source = slots[slot_index].source if 0 <= slot_index < len(slots) else None
+        fallback = int(fallback_attr.data[index].value)
+        last_co = tuple(last_co_attr.data[index].vector)
         yield curve_id, source, vertex_id, fallback, last_co
 
 
@@ -126,6 +162,15 @@ def _source_changed(source, changed):
     return original is not None and original in changed
 
 
+def _set_last_source_co(sketch, curve_id, last_co):
+    curve_data, curve_index, _ = get_curve_data(sketch, curve_id)
+    if curve_data is None:
+        return
+    attr = curve_data.attributes.get(PROJECT_LAST_CO_ATTR)
+    if attr is not None:
+        attr.data[curve_index].vector = last_co
+
+
 def refresh_projection_for_sketch(sketch, depsgraph, changed=None, force=False):
     """Reproject bound points for one sketch. Returns number of moved points."""
     owner = sketch.target_object
@@ -140,17 +185,16 @@ def refresh_projection_for_sketch(sketch, depsgraph, changed=None, force=False):
 
     updates = {}
     source_cache = {}
-    stale = []
 
     for curve_id, source, vertex_id, fallback_index, last_co in list(
         iter_projected_point_bindings(sketch)
     ):
         point = PointRef(sketch, curve_id)
+        # Removed curves remove/re-index their CURVE-domain binding attributes
+        # automatically, so there is no orphan property bookkeeping here.
         if not point.valid:
-            stale.append(curve_id)
             continue
         if source is None or getattr(source, "type", None) != "MESH":
-            stale.append(curve_id)
             continue
         if not (sketch_changed or force or _source_changed(source, changed)):
             continue
@@ -177,10 +221,7 @@ def refresh_projection_for_sketch(sketch, depsgraph, changed=None, force=False):
         local = owner.matrix_world.inverted() @ world
         new_co = Vector((local.x, local.y))
         if (point.co - new_co).length > 1e-7:
-            updates[curve_id] = (point, new_co, list(vertex.co))
-
-    for curve_id in stale:
-        clear_projected_point_binding(sketch, curve_id)
+            updates[curve_id] = (point, new_co, tuple(vertex.co))
 
     if not updates:
         return 0
@@ -188,7 +229,7 @@ def refresh_projection_for_sketch(sketch, depsgraph, changed=None, force=False):
     with batch_update(sketch, point_ids=set(updates.keys())):
         for curve_id, (point, co, last_co) in updates.items():
             point.co = co
-            owner[_key(_LAST_CO_PREFIX, curve_id)] = last_co
+            _set_last_source_co(sketch, curve_id, last_co)
 
     return len(updates)
 

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -86,7 +86,7 @@ def iter_projected_point_bindings(sketch):
     for prop_key in list(owner.keys()):
         if not str(prop_key).startswith(_SOURCE_PREFIX):
             continue
-        curve_id = str(prop_key)[len(_SOURCE_PREFIX):]
+        curve_id = str(prop_key)[len(_SOURCE_PREFIX) :]
         source = owner.get(prop_key)
         vertex_id = int(owner.get(_key(_VERTEX_ID_PREFIX, curve_id), 0))
         fallback = int(owner.get(_key(_VERTEX_INDEX_PREFIX, curve_id), -1))


### PR DESCRIPTION
Fixes #36.

Adds a Project Geometry workflow for bringing external object geometry into a sketch while keeping a live reference to the source object.

Highlights:
- project mesh geometry into the active sketch;
- keep projected geometry linked to its source object;
- refresh projected entities when the source mesh changes;
- expose Project Geometry in the tools panel;
- keep projection as a separate operation instead of duplicating source geometry;
- add regression coverage for projection and source synchronization.

This implementation is based on current main and incorporates the maintainer feedback around keeping projected entities linked to their source geometry.

Bounty: Medium ($250), claimed in #36 before submission.