### PR TITLE
Fix #67: Improve auto-creating constraints

### DIFF
--- a/operators/add_line_2d.py
+++ b/operators/add_line_2d.py
@@ -64,11 +64,17 @@ class View3D_OT_slvs_add_line2d(Operator, Operator2d):
 
             threshold = 0.1
             if angle < threshold or angle > HALF_TURN - threshold:
-                sketch.constraints.add_horizontal(curve_id_1=line_cid)
-                self.has_alignment = True
+                self.has_alignment = bool(
+                    self.add_auto_constraint(
+                        context, sketch.constraints.add_horizontal, curve_id_1=line_cid
+                    )
+                )
             elif (QUARTER_TURN - threshold) < angle < (QUARTER_TURN + threshold):
-                sketch.constraints.add_vertical(curve_id_1=line_cid)
-                self.has_alignment = True
+                self.has_alignment = bool(
+                    self.add_auto_constraint(
+                        context, sketch.constraints.add_vertical, curve_id_1=line_cid
+                    )
+                )
 
         ignore_hover(line_cid)
         return True

--- a/operators/add_rectangle.py
+++ b/operators/add_rectangle.py
@@ -70,14 +70,23 @@ class View3D_OT_slvs_add_rectangle(Operator, Operator2d):
         return True
 
     def fini(self, context: Context, succeede: bool):
-        if hasattr(self, "lines") and self.lines:
+        if succeede and hasattr(self, "lines") and self.lines:
             sc = self.sketch.constraints
             # Auto axis-alignment constraints (inferred) respect the toggle and
             # Shift bypass; the numeric distance constraints below are explicit.
             if self.use_auto_constraints(context):
                 for i, line_ref in enumerate(self.lines):
-                    func = sc.add_horizontal if (i % 2) == 0 else sc.add_vertical
-                    func(curve_id_1=line_ref.curve_id)
+                    # Fetch each bound method immediately before validation.
+                    # Blender's RNA wrapper does not guarantee stable identity
+                    # for bound methods retained across subsequent accesses.
+                    func = (
+                        self.sketch.constraints.add_horizontal
+                        if (i % 2) == 0
+                        else self.sketch.constraints.add_vertical
+                    )
+                    self.add_auto_constraint(
+                        context, func, curve_id_1=line_ref.curve_id
+                    )
 
             data = self._state_data.get(1)
             if data.get("is_numeric_edit", False):

--- a/operators/add_rectangle.py
+++ b/operators/add_rectangle.py
@@ -1,12 +1,12 @@
 import logging
 
-from bpy.types import Operator, Context
+from bpy.types import Context, Operator
 
-from ..declarations import Operators
-from ..stateful_operator.utilities.register import register_stateops_factory
-from ..stateful_operator.state import state_from_args
 from ..curve_solver import solve_system
-from ..model.curve_ref import PointRef, LineRef
+from ..declarations import Operators
+from ..model.curve_ref import LineRef, PointRef
+from ..stateful_operator.state import state_from_args
+from ..stateful_operator.utilities.register import register_stateops_factory
 from .base_2d import Operator2d
 from .constants import types_point_2d
 from .utilities import ignore_hover

--- a/operators/base_stateful.py
+++ b/operators/base_stateful.py
@@ -40,6 +40,22 @@ class GenericEntityOp(StatefulOperator):
             and not state_data.get("skip_auto_constraints", False)
         )
 
+    def add_auto_constraint(self, context: Context, add, state_data=None, **kwargs):
+        """Add an inferred constraint only when the resulting sketch solves."""
+        if not self.use_auto_constraints(context, state_data):
+            return None
+
+        constraint = add(**kwargs)
+        from ..curve_solver import solve_system
+
+        if solve_system(context, sketch=self.sketch):
+            return constraint
+
+        self.sketch.constraints.remove(constraint)
+        # Restore the valid solver state after the rejected trial constraint.
+        solve_system(context, sketch=self.sketch)
+        return None
+
     def pick_element(self, context, coords):
         retval = super().pick_element(context, coords)
         if retval is not None:
@@ -65,15 +81,17 @@ class GenericEntityOp(StatefulOperator):
         return hovered.curve_id if hovered else None
 
     def add_coincident(self, context: Context, point, state, state_data):
-        if not self.use_auto_constraints(context, state_data):
-            return
         hovered_cid = state_data.get("hovered", "")
         if hovered_cid and hasattr(self, "sketch") and self.sketch:
             from ..model.curve_ref import CurveRef
             point_cid = point.curve_id if isinstance(point, CurveRef) else state_data.get("curve_id", "")
 
-            state_data["coincident"] = self.sketch.constraints.add_coincident(
-                curve_id_1=point_cid, curve_id_2=hovered_cid,
+            state_data["coincident"] = self.add_auto_constraint(
+                context,
+                self.sketch.constraints.add_coincident,
+                state_data,
+                curve_id_1=point_cid,
+                curve_id_2=hovered_cid,
             )
 
     def has_coincident(self):

--- a/operators/base_stateful.py
+++ b/operators/base_stateful.py
@@ -1,16 +1,16 @@
-from typing import Optional, Any
+from typing import Any, Optional
 
-import numpy as np
 import bpy
-from bpy.types import Context
+import numpy as np
 from bpy.props import FloatVectorProperty
+from bpy.types import Context
 
 from .. import global_data
 from ..drawing import selection
+from ..model.types import SlvsGenericEntity, SlvsNormal3D, SlvsPoint2D, SlvsPoint3D
+from ..serialize import scene_from_dict, scene_to_dict
 from ..stateful_operator.integration import StatefulOperator
-from ..model.types import SlvsGenericEntity, SlvsPoint3D, SlvsPoint2D, SlvsNormal3D
 from .utilities import get_hovered
-from ..serialize import scene_to_dict, scene_from_dict
 
 
 class GenericEntityOp(StatefulOperator):
@@ -172,7 +172,6 @@ class GenericEntityOp(StatefulOperator):
         if index is None:
             index = self.state_index
 
-        state = self.get_states_definition()[index]
         data = self._state_data.get(index, {})
         if "type" not in data.keys():
             return None
@@ -209,7 +208,6 @@ class GenericEntityOp(StatefulOperator):
         if index is None:
             index = self.state_index
 
-        state = self.get_states_definition()[index]
         data = self._state_data.get(index, {})
         pointer_type = data.get("type")
         if pointer_type is None:
@@ -426,8 +424,8 @@ class GenericEntityOp(StatefulOperator):
 
     def _restore_all_curves(self, context, curve_snapshots):
         """Restore curve data + constraints for all sketches."""
-        from ..utilities.curve_data import invalidate_curve_id_cache
         from ..model.sketch_ref import get_sketches
+        from ..utilities.curve_data import invalidate_curve_id_cache
         invalidate_curve_id_cache()
 
         if not curve_snapshots:

--- a/testing/test_auto_constraints.py
+++ b/testing/test_auto_constraints.py
@@ -1,0 +1,76 @@
+"""Regression tests for inferred-constraint validation and rollback."""
+
+from unittest.mock import patch
+
+from .utils import Sketch2dTestCase, make_operator_double
+from ..operators.base_2d import Operator2d
+
+
+class TestAutoConstraints(Sketch2dTestCase):
+    def test_rejected_constraint_is_removed_and_failure_flags_are_cleared(self):
+        sc = self.sketch.constraints
+        p0 = self.add_point((0.0, 0.0), fixed=True)
+        p1 = self.add_point((3.0, 0.0))
+        line = self.add_line(p0, p1)
+        existing = sc.add_distance(
+            init=True,
+            value=3.0,
+            curve_id_1=p0.curve_id,
+            curve_id_2=p1.curve_id,
+        )
+        self.assertTrue(self.sketch.solve(self.context))
+
+        op = Operator2d.__new__(Operator2d)
+        op._active_sketch = self.sketch
+        op._state_data = {0: {}}
+        op.state_index = 0
+        self.context.scene.sketcher.auto_axis_constraints = True
+
+        rejected = op.add_auto_constraint(
+            self.context,
+            sc.add_vertical,
+            curve_id_1=line.curve_id,
+        )
+
+        self.assertIsNone(rejected)
+        self.assertEqual(len(list(sc.vertical)), 0)
+        self.assertEqual(self.sketch.solver_state, "OKAY")
+        self.assertFalse(existing.failed)
+        self.assertFalse(any(c.failed for c in sc.all))
+
+    def _rectangle_op(self):
+        from ..operators.add_rectangle import View3D_OT_slvs_add_rectangle
+
+        op = make_operator_double(View3D_OT_slvs_add_rectangle)()
+        op._active_sketch = self.sketch
+        op._state_data = {1: {}}
+        op.state_index = 1
+        op.lines = [type("Line", (), {"curve_id": str(i)})() for i in range(4)]
+        return op
+
+    def test_cancelled_rectangle_does_not_add_auto_constraints(self):
+        op = self._rectangle_op()
+        with patch.object(op, "add_auto_constraint") as add:
+            op.fini(self.context, False)
+        add.assert_not_called()
+
+    def test_rectangle_validates_auto_constraints_sequentially(self):
+        op = self._rectangle_op()
+        sc = self.sketch.constraints
+        calls = []
+
+        def validate(context, add, **kwargs):
+            calls.append((add.__name__, kwargs["curve_id_1"]))
+
+        with patch.object(op, "add_auto_constraint", side_effect=validate):
+            op.fini(self.context, True)
+
+        self.assertEqual(
+            calls,
+            [
+                ("add_horizontal", "0"),
+                ("add_vertical", "1"),
+                ("add_horizontal", "2"),
+                ("add_vertical", "3"),
+            ],
+        )

--- a/testing/test_auto_constraints.py
+++ b/testing/test_auto_constraints.py
@@ -2,8 +2,8 @@
 
 from unittest.mock import patch
 
-from .utils import Sketch2dTestCase, make_operator_double
 from ..operators.base_2d import Operator2d
+from .utils import Sketch2dTestCase, make_operator_double
 
 
 class TestAutoConstraints(Sketch2dTestCase):
@@ -56,7 +56,6 @@ class TestAutoConstraints(Sketch2dTestCase):
 
     def test_rectangle_validates_auto_constraints_sequentially(self):
         op = self._rectangle_op()
-        sc = self.sketch.constraints
         calls = []
 
         def validate(context, add, **kwargs):


### PR DESCRIPTION
## Summary

Resolves the implementation requested in #67.

**Diagnosed cause:** Issue terms concentrate in: docs/content/code_docs.md, operators/base_stateful.py, curve_solver.py, model/base_constraint.py, docs/content/tools.md. Baseline test command passed, so the reported failure is likely narrower than the full suite or needs specific reproduction state.

## Scope

- `operators/add_line_2d.py`
- `operators/add_rectangle.py`
- `operators/base_stateful.py`
- `testing/test_auto_constraints.py`

## Acceptance criteria

- No explicit acceptance checklist was extracted from the issue.

## Verification

- `blender --background --command extension validate` — **PASS**
- `blender --background --command extension build --output-filepath ./.optix_blender_extension.zip` — **PASS**
- `blender --background --command extension install-file --repo user_default --enable ./.optix_blender_extension.zip` — **PASS**
- `blender --background --python ./scripts/ci_run_tests.py` — **PASS**

## OPTIX review gate

- Phase 2 status: `PHASE2_COMPLETE`
- Critic: `PASS` / `PASS`
- Repair loops: `2`

Closes #67
