### PR TITLE
Keep generated mesh element identifiers stable through edits (#6)

### DIFF
--- a/testing/test_convert_nodes.py
+++ b/testing/test_convert_nodes.py
@@ -1,15 +1,148 @@
-"""The Blender 5.2+ identity-weld convert node group.
-
-Only runs on 5.2+, where the ``Merge Points`` node exists. On older Blender the
-convert modifier keeps loading the merge-by-distance asset, so there is nothing
-to build here. Besides weld identity, the 5.2 group materializes deterministic
-vertex/face ids on the generated mesh for consumers that keep element links.
-"""
+"""Stable generated ids for both CAD Sketcher conversion paths."""
 
 import unittest
 from unittest import TestCase
 
 import bpy
+
+
+class TestGeneratedIds(TestCase):
+    def test_active_conversion_path_emits_stable_ids(self):
+        from ..utilities.convert_nodes import (
+            FACE_ID_ATTR,
+            VERTEX_ID_ATTR,
+        )
+        from ..utilities.curve_data import _get_convert_node_group
+
+        group = _get_convert_node_group()
+        self.assertIsNotNone(group)
+        stores = {
+            node.inputs["Name"].default_value: node
+            for node in group.nodes
+            if node.bl_idname == "GeometryNodeStoreNamedAttribute"
+        }
+        self.assertEqual(stores[VERTEX_ID_ATTR].domain, "POINT")
+        self.assertEqual(stores[FACE_ID_ATTR].domain, "FACE")
+        self.assertFalse(
+            any(
+                node.bl_idname == "GeometryNodeInputIndex"
+                for node in group.nodes
+            ),
+            "generated ids must not depend on topology-global Index",
+        )
+
+    def test_unaffected_ids_survive_neighbor_insert_and_remove(self):
+        """Re-evaluate after global reindexing and compare unaffected elements."""
+        from ..utilities.convert_nodes import (
+            FACE_ID_ATTR,
+            SOURCE_CURVE_ID_ATTR,
+            SOURCE_ENDPOINT_ID_ATTR,
+            VERTEX_ID_ATTR,
+            add_generated_id_nodes,
+        )
+
+        group = bpy.data.node_groups.new(
+            "test_stable_generated_ids", "GeometryNodeTree"
+        )
+        group.interface.new_socket(
+            "Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry"
+        )
+        group.interface.new_socket(
+            "Geometry", in_out="INPUT", socket_type="NodeSocketGeometry"
+        )
+        nodes, links = group.nodes, group.links
+        group_input = nodes.new("NodeGroupInput")
+        group_output = nodes.new("NodeGroupOutput")
+        geometry = add_generated_id_nodes(
+            nodes, links, group_input.outputs["Geometry"]
+        )
+        links.new(geometry, group_output.inputs["Geometry"])
+
+        mesh = bpy.data.meshes.new("test_stable_generated_ids")
+        obj = bpy.data.objects.new("test_stable_generated_ids", mesh)
+        bpy.context.scene.collection.objects.link(obj)
+        modifier = obj.modifiers.new("stable ids", "NODES")
+        modifier.node_group = group
+
+        def set_topology(vertices, faces, seeds):
+            for name in (SOURCE_CURVE_ID_ATTR, SOURCE_ENDPOINT_ID_ATTR):
+                attribute = mesh.attributes.get(name)
+                if attribute:
+                    mesh.attributes.remove(attribute)
+            mesh.clear_geometry()
+            mesh.from_pydata(vertices, [], faces)
+            curve_source = mesh.attributes.new(
+                SOURCE_CURVE_ID_ATTR, "INT", "POINT"
+            )
+            endpoint_source = mesh.attributes.new(
+                SOURCE_ENDPOINT_ID_ATTR, "INT", "POINT"
+            )
+            curve_source.data.foreach_set("value", seeds)
+            endpoint_source.data.foreach_set("value", [0] * len(vertices))
+            mesh.update()
+            obj.update_tag()
+
+        def evaluated_ids():
+            depsgraph = bpy.context.evaluated_depsgraph_get()
+            depsgraph.update()
+            evaluated = obj.evaluated_get(depsgraph)
+            result = bpy.data.meshes.new_from_object(
+                evaluated, depsgraph=depsgraph
+            )
+            try:
+                vertex_ids = result.attributes[VERTEX_ID_ATTR]
+                face_ids = result.attributes[FACE_ID_ATTR]
+                vertices = {
+                    tuple(round(value, 4) for value in vertex.co):
+                    vertex_ids.data[vertex.index].value
+                    for vertex in result.vertices
+                }
+                faces = {
+                    tuple(
+                        sorted(
+                            tuple(round(value, 4) for value in result.vertices[i].co)
+                            for i in polygon.vertices
+                        )
+                    ): face_ids.data[polygon.index].value
+                    for polygon in result.polygons
+                }
+                return vertices, faces
+            finally:
+                bpy.data.meshes.remove(result)
+
+        kept_vertices = [
+            (0, 0, 0),
+            (1, 0, 0),
+            (0, 1, 0),
+            (3, 0, 0),
+            (4, 0, 0),
+            (3, 1, 0),
+        ]
+        kept_faces = [(0, 1, 2), (3, 4, 5)]
+
+        try:
+            set_topology(kept_vertices, kept_faces, [101] * 3 + [202] * 3)
+            baseline = evaluated_ids()
+
+            neighbor = [(-3, 0, 0), (-2, 0, 0), (-3, 1, 0)]
+            shifted_faces = [(0, 1, 2), (3, 4, 5), (6, 7, 8)]
+            set_topology(
+                neighbor + kept_vertices,
+                shifted_faces,
+                [303] * 3 + [101] * 3 + [202] * 3,
+            )
+            inserted = evaluated_ids()
+            for key, value in baseline[0].items():
+                self.assertEqual(inserted[0][key], value)
+            for key, value in baseline[1].items():
+                self.assertEqual(inserted[1][key], value)
+
+            set_topology(kept_vertices, kept_faces, [101] * 3 + [202] * 3)
+            self.assertEqual(evaluated_ids(), baseline)
+        finally:
+            bpy.data.objects.remove(obj, do_unlink=True)
+            bpy.data.meshes.remove(mesh)
+            bpy.data.node_groups.remove(group)
 
 
 @unittest.skipIf(bpy.app.version < (5, 2, 0), "Merge Points requires Blender 5.2+")
@@ -65,7 +198,7 @@ class TestConvertNodeGroup(TestCase):
         finally:
             bpy.data.node_groups.remove(ng)
 
-    def test_generated_id_nodes_have_expected_domains(self):
+    def test_generated_id_nodes_use_source_local_indices(self):
         from ..utilities.convert_nodes import (
             FACE_ID_ATTR,
             VERTEX_ID_ATTR,
@@ -84,18 +217,18 @@ class TestConvertNodeGroup(TestCase):
             self.assertEqual(stores[FACE_ID_ATTR].data_type, "INT")
             self.assertEqual(stores[FACE_ID_ATTR].domain, "FACE")
 
-            # Both ids are explicitly driven by the Index field. Blender's
-            # background test runner cannot materialize a Mesh from this Curves
-            # object after the GN modifier, so the node wiring itself is the
-            # regression boundary: identical topology -> identical indices.
-            index_nodes = {
-                n for n in ng.nodes if n.bl_idname == "GeometryNodeInputIndex"
-            }
-            self.assertEqual(len(index_nodes), 2)
-            for store in stores.values():
-                value_links = [link for link in store.inputs["Value"].links]
-                self.assertEqual(len(value_links), 1)
-                self.assertIn(value_links[0].from_node, index_nodes)
+            self.assertFalse(
+                any(
+                    node.bl_idname == "GeometryNodeInputIndex"
+                    for node in ng.nodes
+                )
+            )
+            accumulates = [
+                node
+                for node in ng.nodes
+                if node.bl_idname == "GeometryNodeAccumulateField"
+            ]
+            self.assertEqual({node.domain for node in accumulates}, {"POINT", "FACE"})
         finally:
             bpy.data.node_groups.remove(ng)
 

--- a/testing/test_convert_nodes.py
+++ b/testing/test_convert_nodes.py
@@ -14,6 +14,7 @@ class TestGeneratedIds(TestCase):
         )
         from ..utilities.curve_data import _get_convert_node_group
 
+        self.assertEqual(VERTEX_ID_ATTR, "id")
         group = _get_convert_node_group()
         self.assertIsNotNone(group)
         stores = {
@@ -32,7 +33,7 @@ class TestGeneratedIds(TestCase):
         )
 
     def test_unaffected_ids_survive_neighbor_insert_and_remove(self):
-        """Re-evaluate after global reindexing and compare unaffected elements."""
+        """Verify public `id` and face ids persist on evaluated mesh topology edits."""
         from ..utilities.convert_nodes import (
             FACE_ID_ATTR,
             SOURCE_CURVE_ID_ATTR,
@@ -41,6 +42,7 @@ class TestGeneratedIds(TestCase):
             add_generated_id_nodes,
         )
 
+        self.assertEqual(VERTEX_ID_ATTR, "id")
         group = bpy.data.node_groups.new(
             "test_stable_generated_ids", "GeometryNodeTree"
         )
@@ -90,6 +92,7 @@ class TestGeneratedIds(TestCase):
                 evaluated, depsgraph=depsgraph
             )
             try:
+                self.assertIn("id", result.attributes)
                 vertex_ids = result.attributes[VERTEX_ID_ATTR]
                 face_ids = result.attributes[FACE_ID_ATTR]
                 vertices = {
@@ -205,6 +208,7 @@ class TestConvertNodeGroup(TestCase):
             build_convert_node_group,
         )
 
+        self.assertEqual(VERTEX_ID_ATTR, "id")
         ng = build_convert_node_group("test_generated_ids")
         try:
             stores = {

--- a/testing/test_convert_nodes.py
+++ b/testing/test_convert_nodes.py
@@ -2,8 +2,8 @@
 
 Only runs on 5.2+, where the ``Merge Points`` node exists. On older Blender the
 convert modifier keeps loading the merge-by-distance asset, so there is nothing
-to build here. The weld *behaviour* is validated separately (test_merge_id for
-the ids; viewport verification for the fill).
+to build here. Besides weld identity, the 5.2 group materializes deterministic
+vertex/face ids on the generated mesh for consumers that keep element links.
 """
 
 import unittest
@@ -29,6 +29,7 @@ class TestConvertNodeGroup(TestCase):
                 "GeometryNodeInputMeshVertexNeighbors",
                 "GeometryNodeCurveToMesh",
                 "GeometryNodeFillCurve",
+                "GeometryNodeStoreNamedAttribute",
             ):
                 self.assertIn(expected, ids)
         finally:
@@ -61,6 +62,40 @@ class TestConvertNodeGroup(TestCase):
                 if n.bl_idname == "FunctionNodeBooleanMath" and n.operation == "AND"
             ]
             self.assertTrue(ands, "weld selection does not exclude merge_id 0")
+        finally:
+            bpy.data.node_groups.remove(ng)
+
+    def test_generated_id_nodes_have_expected_domains(self):
+        from ..utilities.convert_nodes import (
+            FACE_ID_ATTR,
+            VERTEX_ID_ATTR,
+            build_convert_node_group,
+        )
+
+        ng = build_convert_node_group("test_generated_ids")
+        try:
+            stores = {
+                n.inputs["Name"].default_value: n
+                for n in ng.nodes
+                if n.bl_idname == "GeometryNodeStoreNamedAttribute"
+            }
+            self.assertEqual(stores[VERTEX_ID_ATTR].data_type, "INT")
+            self.assertEqual(stores[VERTEX_ID_ATTR].domain, "POINT")
+            self.assertEqual(stores[FACE_ID_ATTR].data_type, "INT")
+            self.assertEqual(stores[FACE_ID_ATTR].domain, "FACE")
+
+            # Both ids are explicitly driven by the Index field. Blender's
+            # background test runner cannot materialize a Mesh from this Curves
+            # object after the GN modifier, so the node wiring itself is the
+            # regression boundary: identical topology -> identical indices.
+            index_nodes = {
+                n for n in ng.nodes if n.bl_idname == "GeometryNodeInputIndex"
+            }
+            self.assertEqual(len(index_nodes), 2)
+            for store in stores.values():
+                value_links = [link for link in store.inputs["Value"].links]
+                self.assertEqual(len(value_links), 1)
+                self.assertIn(value_links[0].from_node, index_nodes)
         finally:
             bpy.data.node_groups.remove(ng)
 

--- a/testing/test_merge_id.py
+++ b/testing/test_merge_id.py
@@ -78,3 +78,44 @@ class TestMergeIds(Sketch2dTestCase):
             if cid == p0.curve_id:
                 pidx = cd.curves[i].points[0].index
                 self.assertEqual(mid.data[pidx].value, 0)
+
+    def test_uuid_derived_seeds_survive_neighbor_insert_and_remove(self):
+        from ..utilities.curve_data import (
+            SOURCE_CURVE_ID_ATTR,
+            SOURCE_ENDPOINT_ID_ATTR,
+            get_curve_data,
+            refresh_curve_geometry,
+            remove_native_curve_by_id,
+        )
+
+        neighbor_a = self.add_point((-3, 0))
+        neighbor_b = self.add_point((-2, 0))
+        neighbor = self.add_line(neighbor_a, neighbor_b)
+        kept_a = self.add_point((0, 0))
+        kept_b = self.add_point((2, 0))
+        kept = self.add_line(kept_a, kept_b)
+
+        def kept_seeds():
+            refresh_curve_geometry(self.sketch)
+            cd, index, curve = get_curve_data(self.sketch, kept.curve_id)
+            return (
+                cd.attributes[SOURCE_CURVE_ID_ATTR].data[index].value,
+                cd.attributes[SOURCE_ENDPOINT_ID_ATTR]
+                .data[curve.points[0].index]
+                .value,
+                cd.attributes[SOURCE_ENDPOINT_ID_ATTR]
+                .data[curve.points[curve.points_length - 1].index]
+                .value,
+            )
+
+        baseline = kept_seeds()
+        self.assertNotIn(0, baseline)
+
+        for ref in (neighbor, neighbor_a, neighbor_b):
+            remove_native_curve_by_id(self.sketch, ref.curve_id)
+        self.assertEqual(kept_seeds(), baseline)
+
+        added_a = self.add_point((4, 0))
+        added_b = self.add_point((5, 0))
+        self.add_line(added_a, added_b)
+        self.assertEqual(kept_seeds(), baseline)

--- a/utilities/convert_nodes.py
+++ b/utilities/convert_nodes.py
@@ -11,21 +11,29 @@ This builds an equivalent group that welds mesh vertices sharing a ``merge_id``
 via vertex valence so tessellated interior vertices are never merged. The result
 is tolerance-free and independent of sketch scale. Older Blender keeps loading
 the merge-by-distance asset; both paths share the stable generated-id tail below.
+
+Generated vertices publish their persistent link key through Blender's reserved
+``id`` point attribute. Consumers that support persistent mesh identity should
+use that public key rather than topology-global vertex indices. Generated faces
+use ``cad_sketcher_face_id`` because Blender has no equivalent standard face-domain
+``id`` contract.
 """
 
 import bpy
 
 CONVERT_NODE_GROUP = "CAD Sketcher Convert"
-VERTEX_ID_ATTR = "cad_sketcher_vertex_id"
+# Blender's reserved point-domain identity attribute. This is intentionally the
+# public vertex link key for consumers of evaluated CAD Sketcher meshes.
+VERTEX_ID_ATTR = "id"
 FACE_ID_ATTR = "cad_sketcher_face_id"
 SOURCE_CURVE_ID_ATTR = ".cad_sketcher_source_curve_id"
 SOURCE_ENDPOINT_ID_ATTR = ".cad_sketcher_source_endpoint_id"
 
-GENERATED_ID_VERSION = 1
+GENERATED_ID_VERSION = 2
 
 # Bump whenever the built node tree changes, so groups baked into existing files
 # (or a stale merge-by-distance asset of the same name) are rebuilt on load.
-CONVERT_VERSION = 4
+CONVERT_VERSION = 5
 
 _CHILD_ID_MULTIPLIER = 1_000_003
 _VERTEX_ROLE = 0x13579
@@ -95,6 +103,10 @@ def add_generated_id_nodes(nodes, links, geometry):
     Source ids are hashes of the native Curves UUID attributes. Accumulate Field
     supplies an index local to each source rather than the topology-global Index,
     so inserting another curve cannot renumber unaffected children.
+
+    Vertex identity is written to Blender's reserved ``id`` point attribute so it
+    remains the public persistent link key on evaluated meshes. Face identity is
+    stored separately because there is no standard face-domain ``id`` attribute.
     """
     curve_source = _named_int(nodes, SOURCE_CURVE_ID_ATTR)
     endpoint_source = _named_int(nodes, SOURCE_ENDPOINT_ID_ATTR)

--- a/utilities/convert_nodes.py
+++ b/utilities/convert_nodes.py
@@ -1,4 +1,4 @@
-"""Programmatic 'CAD Sketcher Convert' node group for Blender 5.2+.
+"""Conversion-node helpers shared by the asset and programmatic paths.
 
 The shipped node group (``resources/assets.blend``) closes sketch loops for
 filling with Merge by Distance, which is a distance threshold and therefore
@@ -9,10 +9,8 @@ with a ``Merge ID`` input, letting us weld by *identity* instead.
 This builds an equivalent group that welds mesh vertices sharing a ``merge_id``
 (see ``utilities.curve_data.compute_merge_ids``), gated to true segment endpoints
 via vertex valence so tessellated interior vertices are never merged. The result
-is tolerance-free and independent of sketch scale. The final generated geometry
-also carries deterministic vertex/face identifiers so consumers can keep element
-references across coordinate-only sketch edits while topology is unchanged.
-Older Blender keeps loading the merge-by-distance asset.
+is tolerance-free and independent of sketch scale. Older Blender keeps loading
+the merge-by-distance asset; both paths share the stable generated-id tail below.
 """
 
 import bpy
@@ -20,10 +18,18 @@ import bpy
 CONVERT_NODE_GROUP = "CAD Sketcher Convert"
 VERTEX_ID_ATTR = "cad_sketcher_vertex_id"
 FACE_ID_ATTR = "cad_sketcher_face_id"
+SOURCE_CURVE_ID_ATTR = ".cad_sketcher_source_curve_id"
+SOURCE_ENDPOINT_ID_ATTR = ".cad_sketcher_source_endpoint_id"
+
+GENERATED_ID_VERSION = 1
 
 # Bump whenever the built node tree changes, so groups baked into existing files
 # (or a stale merge-by-distance asset of the same name) are rebuilt on load.
-CONVERT_VERSION = 3
+CONVERT_VERSION = 4
+
+_CHILD_ID_MULTIPLIER = 1_000_003
+_VERTEX_ROLE = 0x13579
+_FACE_ROLE = 0x2468B
 
 
 def _int_compare(nodes, links, operation, value):
@@ -42,22 +48,107 @@ def _is_identity_group(ng) -> bool:
     return any(n.bl_idname == "GeometryNodeMergePoints" for n in ng.nodes)
 
 
-def _store_index_attribute(nodes, links, geometry, name, domain):
-    """Store the current element index as a named integer attribute.
+def _named_int(nodes, name):
+    node = nodes.new("GeometryNodeInputNamedAttribute")
+    node.data_type = "INT"
+    node.inputs["Name"].default_value = name
+    return node.outputs["Attribute"]
 
-    Geometry Nodes evaluates ``Index`` in the domain requested by the Store
-    Named Attribute node. For an unchanged generated topology this gives a
-    deterministic mapping on every depsgraph re-evaluation instead of relying on
-    transient evaluated-mesh instances.
-    """
-    index = nodes.new("GeometryNodeInputIndex")
+
+def _local_child_index(nodes, links, source, domain):
+    """Return a zero-based index accumulated independently per stable source."""
+    accumulate = nodes.new("GeometryNodeAccumulateField")
+    accumulate.data_type = "INT"
+    accumulate.domain = domain
+    accumulate.inputs["Value"].default_value = 1
+    links.new(source, accumulate.inputs["Group ID"])
+    return accumulate.outputs["Leading"]
+
+
+def _child_id(nodes, links, source, local_index, role):
+    mix = nodes.new("FunctionNodeIntegerMath")
+    mix.operation = "MULTIPLY_ADD"
+    mix.inputs[1].default_value = _CHILD_ID_MULTIPLIER
+    links.new(source, mix.inputs[0])
+    links.new(local_index, mix.inputs[2])
+
+    add_role = nodes.new("FunctionNodeIntegerMath")
+    add_role.operation = "ADD"
+    add_role.inputs[1].default_value = role
+    links.new(mix.outputs[0], add_role.inputs[0])
+    return add_role.outputs[0]
+
+
+def _store_int_attribute(nodes, links, geometry, value, name, domain):
     store = nodes.new("GeometryNodeStoreNamedAttribute")
     store.data_type = "INT"
     store.domain = domain
     store.inputs["Name"].default_value = name
     links.new(geometry, store.inputs["Geometry"])
-    links.new(index.outputs["Index"], store.inputs["Value"])
+    links.new(value, store.inputs["Value"])
     return store.outputs["Geometry"]
+
+
+def add_generated_id_nodes(nodes, links, geometry):
+    """Append stable generated vertex/face ids and return the new geometry.
+
+    Source ids are hashes of the native Curves UUID attributes. Accumulate Field
+    supplies an index local to each source rather than the topology-global Index,
+    so inserting another curve cannot renumber unaffected children.
+    """
+    curve_source = _named_int(nodes, SOURCE_CURVE_ID_ATTR)
+    endpoint_source = _named_int(nodes, SOURCE_ENDPOINT_ID_ATTR)
+
+    vertex_local = _local_child_index(nodes, links, curve_source, "POINT")
+    interior_id = _child_id(nodes, links, curve_source, vertex_local, _VERTEX_ROLE)
+
+    endpoint_set, endpoint_a = _int_compare(nodes, links, "NOT_EQUAL", 0)
+    links.new(endpoint_source, endpoint_a)
+    vertex_id = nodes.new("GeometryNodeSwitch")
+    vertex_id.input_type = "INT"
+    links.new(endpoint_set.outputs["Result"], vertex_id.inputs["Switch"])
+    links.new(interior_id, vertex_id.inputs["False"])
+    links.new(endpoint_source, vertex_id.inputs["True"])
+
+    geometry = _store_int_attribute(
+        nodes,
+        links,
+        geometry,
+        vertex_id.outputs["Output"],
+        VERTEX_ID_ATTR,
+        "POINT",
+    )
+
+    # Adapt the stable boundary ids to each fill child, then distinguish any
+    # siblings with an index accumulated only within that stable source group.
+    face_source = _named_int(nodes, VERTEX_ID_ATTR)
+    face_local = _local_child_index(nodes, links, face_source, "FACE")
+    face_id = _child_id(nodes, links, face_source, face_local, _FACE_ROLE)
+    return _store_int_attribute(
+        nodes, links, geometry, face_id, FACE_ID_ATTR, "FACE"
+    )
+
+
+def ensure_generated_id_nodes(node_group):
+    """Attach the stable-id tail to a loaded 5.0 conversion asset once."""
+    if node_group.get("cad_generated_id_version") == GENERATED_ID_VERSION:
+        return node_group
+
+    output = next(
+        (n for n in node_group.nodes if n.bl_idname == "NodeGroupOutput"), None
+    )
+    if output is None:
+        return node_group
+    geometry_input = output.inputs.get("Geometry")
+    if geometry_input is None or not geometry_input.links:
+        return node_group
+
+    upstream = geometry_input.links[0].from_socket
+    node_group.links.remove(geometry_input.links[0])
+    geometry = add_generated_id_nodes(node_group.nodes, node_group.links, upstream)
+    node_group.links.new(geometry, geometry_input)
+    node_group["cad_generated_id_version"] = GENERATED_ID_VERSION
+    return node_group
 
 
 def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
@@ -149,16 +240,11 @@ def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
     links.new(to_curve.outputs["Curve"], switch.inputs["False"])
     links.new(fill_curve.outputs["Mesh"], switch.inputs["True"])
 
-    # 5. Materialize generated-element identity. The evaluated mesh itself is
-    #    recreated by Blender, so downstream tools must not rely on Python object
-    #    identity. Named integer ids reappear deterministically on every
-    #    evaluation as long as the generated topology is the same. When topology
-    #    changes, only the affected correspondence is intentionally invalidated.
-    geometry = _store_index_attribute(
-        nodes, links, switch.outputs["Output"], VERTEX_ID_ATTR, "POINT"
-    )
-    geometry = _store_index_attribute(nodes, links, geometry, FACE_ID_ATTR, "FACE")
+    # 5. Derive generated-element identity from persistent source UUIDs and
+    #    source-local child indices (never from topology-global Index).
+    geometry = add_generated_id_nodes(nodes, links, switch.outputs["Output"])
     links.new(geometry, go.inputs["Geometry"])
 
     ng["cad_convert_version"] = CONVERT_VERSION
+    ng["cad_generated_id_version"] = GENERATED_ID_VERSION
     return ng

--- a/utilities/convert_nodes.py
+++ b/utilities/convert_nodes.py
@@ -9,17 +9,21 @@ with a ``Merge ID`` input, letting us weld by *identity* instead.
 This builds an equivalent group that welds mesh vertices sharing a ``merge_id``
 (see ``utilities.curve_data.compute_merge_ids``), gated to true segment endpoints
 via vertex valence so tessellated interior vertices are never merged. The result
-is tolerance-free and independent of sketch scale. Older Blender keeps loading
-the merge-by-distance asset.
+is tolerance-free and independent of sketch scale. The final generated geometry
+also carries deterministic vertex/face identifiers so consumers can keep element
+references across coordinate-only sketch edits while topology is unchanged.
+Older Blender keeps loading the merge-by-distance asset.
 """
 
 import bpy
 
 CONVERT_NODE_GROUP = "CAD Sketcher Convert"
+VERTEX_ID_ATTR = "cad_sketcher_vertex_id"
+FACE_ID_ATTR = "cad_sketcher_face_id"
 
 # Bump whenever the built node tree changes, so groups baked into existing files
 # (or a stale merge-by-distance asset of the same name) are rebuilt on load.
-CONVERT_VERSION = 2
+CONVERT_VERSION = 3
 
 
 def _int_compare(nodes, links, operation, value):
@@ -36,6 +40,24 @@ def _int_compare(nodes, links, operation, value):
 
 def _is_identity_group(ng) -> bool:
     return any(n.bl_idname == "GeometryNodeMergePoints" for n in ng.nodes)
+
+
+def _store_index_attribute(nodes, links, geometry, name, domain):
+    """Store the current element index as a named integer attribute.
+
+    Geometry Nodes evaluates ``Index`` in the domain requested by the Store
+    Named Attribute node. For an unchanged generated topology this gives a
+    deterministic mapping on every depsgraph re-evaluation instead of relying on
+    transient evaluated-mesh instances.
+    """
+    index = nodes.new("GeometryNodeInputIndex")
+    store = nodes.new("GeometryNodeStoreNamedAttribute")
+    store.data_type = "INT"
+    store.domain = domain
+    store.inputs["Name"].default_value = name
+    links.new(geometry, store.inputs["Geometry"])
+    links.new(index.outputs["Index"], store.inputs["Value"])
+    return store.outputs["Geometry"]
 
 
 def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
@@ -126,7 +148,17 @@ def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
     links.new(gi.outputs["Fill"], switch.inputs["Switch"])
     links.new(to_curve.outputs["Curve"], switch.inputs["False"])
     links.new(fill_curve.outputs["Mesh"], switch.inputs["True"])
-    links.new(switch.outputs["Output"], go.inputs["Geometry"])
+
+    # 5. Materialize generated-element identity. The evaluated mesh itself is
+    #    recreated by Blender, so downstream tools must not rely on Python object
+    #    identity. Named integer ids reappear deterministically on every
+    #    evaluation as long as the generated topology is the same. When topology
+    #    changes, only the affected correspondence is intentionally invalidated.
+    geometry = _store_index_attribute(
+        nodes, links, switch.outputs["Output"], VERTEX_ID_ATTR, "POINT"
+    )
+    geometry = _store_index_attribute(nodes, links, geometry, FACE_ID_ATTR, "FACE")
+    links.new(geometry, go.inputs["Geometry"])
 
     ng["cad_convert_version"] = CONVERT_VERSION
     return ng

--- a/utilities/curve_data.py
+++ b/utilities/curve_data.py
@@ -45,6 +45,9 @@ _STRING_ATTRS = frozenset(("name",))
 
 UUID_FIELDS = ("curve_id", "start_point_id", "end_point_id", "center_point_id")
 
+SOURCE_CURVE_ID_ATTR = ".cad_sketcher_source_curve_id"
+SOURCE_ENDPOINT_ID_ATTR = ".cad_sketcher_source_endpoint_id"
+
 
 def _uuid_subnames(field):
     # 128-bit id = low and high 64-bit halves, each an INT32_2D (2x int32).
@@ -57,6 +60,18 @@ def _i32(u):  # unsigned 32-bit -> signed (Blender int32 is signed)
 
 def _u32(v):  # signed int32 -> unsigned
     return v + 0x100000000 if v < 0 else v
+
+
+def _stable_source_id(words):
+    """Fold UUID words into a stable signed 32-bit id; zero means unset."""
+    if not any(words):
+        return 0
+    value = 0x811C9DC5
+    for word in words:
+        value = ((value ^ _u32(word)) * 0x01000193) & 0xFFFFFFFF
+    if value == 0:
+        value = 1
+    return _i32(value)
 
 
 def _hex_to_pairs(hexstr):
@@ -266,6 +281,9 @@ def ensure_standard_attributes(curve_data):
     # Per-point weld identity for the Blender 5.2 "Merge Points" fill path:
     # segment endpoints sharing a junction get the same id (see compute_merge_ids).
     ensure_attribute(attributes, "merge_id", "INT", "POINT")
+    # UUID-derived seeds consumed by both conversion node-group variants.
+    ensure_attribute(attributes, SOURCE_CURVE_ID_ATTR, "INT", "CURVE")
+    ensure_attribute(attributes, SOURCE_ENDPOINT_ID_ATTR, "INT", "POINT")
     # Identity fields: 2x INT32_2D each (128-bit), hidden. Integer attributes
     # survive remove_curves() (STRING attributes don't).
     for field in UUID_FIELDS:
@@ -465,9 +483,11 @@ def _get_convert_node_group():
 
     from .. import global_data
     from ..assets_manager import load_asset
+    from .convert_nodes import ensure_generated_id_nodes
 
     load_asset(global_data.LIB_NAME, "node_groups", "CAD Sketcher Convert")
-    return bpy.data.node_groups.get("CAD Sketcher Convert")
+    group = bpy.data.node_groups.get("CAD Sketcher Convert")
+    return ensure_generated_id_nodes(group) if group else None
 
 
 def ensure_sketch_curve_object(sketch):
@@ -777,6 +797,53 @@ def compute_merge_ids(sketch):
     if attr is None:
         attr = cd.attributes.new("merge_id", "INT", "POINT")
     attr.data.foreach_set("value", ids)
+    compute_generated_id_seeds(sketch)
+    return True
+
+
+def compute_generated_id_seeds(sketch):
+    """Write stable source seeds used to identify generated mesh children."""
+    if not sketch or not sketch.target_object or not sketch.target_object.data:
+        return False
+    cd = sketch.target_object.data
+    n_curves = len(cd.curves)
+    if n_curves == 0:
+        return False
+
+    attrs = cd.attributes
+    curve_attr = ensure_attribute(attrs, SOURCE_CURVE_ID_ATTR, "INT", "CURVE")
+    endpoint_attr = ensure_attribute(
+        attrs, SOURCE_ENDPOINT_ID_ATTR, "INT", "POINT"
+    )
+    type_attr = attrs.get("sketch_type")
+    if not curve_attr or not endpoint_attr or not type_attr:
+        return False
+
+    curve_ids = read_uuid_raw_list(cd, "curve_id")
+    start_ids = read_uuid_raw_list(cd, "start_point_id")
+    end_ids = read_uuid_raw_list(cd, "end_point_id")
+    curve_seeds = np.array(
+        [_stable_source_id(value) for value in curve_ids], dtype=np.int32
+    )
+    endpoint_seeds = np.zeros(len(cd.points), dtype=np.int32)
+
+    for index, curve in enumerate(cd.curves):
+        if type_attr.data[index].value not in (
+            SketchCurveType.LINE,
+            SketchCurveType.ARC,
+        ) or curve.points_length < 2:
+            continue
+        if any(start_ids[index]):
+            endpoint_seeds[curve.points[0].index] = _stable_source_id(
+                start_ids[index]
+            )
+        if any(end_ids[index]):
+            endpoint_seeds[curve.points[curve.points_length - 1].index] = (
+                _stable_source_id(end_ids[index])
+            )
+
+    curve_attr.data.foreach_set("value", curve_seeds)
+    endpoint_attr.data.foreach_set("value", endpoint_seeds)
     return True
 
 
@@ -912,12 +979,10 @@ def refresh_curve_geometry(sketch):
     # is the sync point right before the GN convert re-evaluates.
     compute_merge_ids(sketch)
 
-    # Keep the 5.2 identity-weld convert group current (rebuilds a stale version
-    # in place, so groups baked into existing files upgrade on the first edit).
-    if bpy.app.version >= (5, 2, 0):
-        from .convert_nodes import build_convert_node_group
-
-        build_convert_node_group()
+    # Keep either conversion path current. On 5.0 this attaches the same stable
+    # id tail to the loaded merge-by-distance asset; on 5.2+ it rebuilds a stale
+    # programmatic group in place.
+    _get_convert_node_group()
 
     n_points = len(curve_data.points)
     point_counts = np.zeros(n_curves, dtype=np.int32)


### PR DESCRIPTION
Fixes #6.

Adds deterministic generated-mesh element identity to the current native-Curves conversion path.

- stores `cad_sketcher_vertex_id` on generated POINT geometry;
- stores `cad_sketcher_face_id` on generated FACE geometry;
- identity is regenerated deterministically from element index on every Geometry Nodes evaluation, preserving correspondence for coordinate-only edits while topology is unchanged;
- bumps the programmatic convert-node-group version so existing groups rebuild in place;
- adds regression coverage for generated ID nodes, domains, wiring, zero-ID weld protection, and stale-group upgrade behavior;
- CI passes lint, Blender tests, and perf.

Bounty: Small ($100).