### PR TITLE
Place dimension label and set value in one step

### DIFF
--- a/operators/add_angle.py
+++ b/operators/add_angle.py
@@ -47,7 +47,7 @@ class VIEW3D_OT_slvs_add_angle(Operator, GenericConstraintOp):
     )
     type = "ANGLE"
     property_keys = ("value", "setting")
-    has_value_state = True
+    has_value_state = False
 
     def main(self, context):
         if not self.exists(context, SlvsAngle):
@@ -61,9 +61,12 @@ class VIEW3D_OT_slvs_add_angle(Operator, GenericConstraintOp):
         return super().main(context)
 
     def fini(self, context: Context, succeede: bool):
-        super().fini(context, succeede)
+        # Set the default offset before super().fini() (which hands off to the
+        # placement modal), so the interactive placement writes over the default
+        # rather than the default clobbering the placement.
         if hasattr(self, "target"):
             self.target.draw_offset = 0.1 * context.region_data.view_distance
+        super().fini(context, succeede)
 
 
 register, unregister = register_stateops_factory((VIEW3D_OT_slvs_add_angle,))

--- a/operators/add_diameter.py
+++ b/operators/add_diameter.py
@@ -29,7 +29,7 @@ class VIEW3D_OT_slvs_add_diameter(Operator, GenericConstraintOp):
     setting: BoolProperty(name="Use Radius")
     type = "DIAMETER"
     property_keys = ("value", "setting")
-    has_value_state = True
+    has_value_state = False
 
     def main(self, context):
         if not self.exists(context, SlvsDiameter):

--- a/operators/add_distance.py
+++ b/operators/add_distance.py
@@ -31,7 +31,7 @@ class VIEW3D_OT_slvs_add_distance(Operator, GenericConstraintOp):
     flip: BoolProperty(name="Flip")
     type = "DISTANCE"
     property_keys = ("value", "align", "flip")
-    has_value_state = True
+    has_value_state = False
 
     def main(self, context):
         e1, e2 = self.entity1, self.entity2
@@ -69,9 +69,12 @@ class VIEW3D_OT_slvs_add_distance(Operator, GenericConstraintOp):
         return super().main(context)
 
     def fini(self, context: Context, succeede: bool):
-        super().fini(context, succeede)
+        # Set the default offset before super().fini() (which hands off to the
+        # placement modal), so the interactive placement writes over the default
+        # rather than the default clobbering the placement.
         if hasattr(self, "target"):
             self.target.draw_offset = 0.05 * context.region_data.view_distance
+        super().fini(context, succeede)
 
     def draw(self, context: Context):
         if not hasattr(self, "target"):

--- a/operators/base_constraint.py
+++ b/operators/base_constraint.py
@@ -136,6 +136,40 @@ class GenericConstraintOp(Operator2d):
         if hasattr(self, "target"):
             logger.debug("Add: {}".format(self.target))
 
+        # Placement of the dimension label is a display-only concern (draw_offset),
+        # so it does not belong in this stateful creation operator's snapshot/solve
+        # loop. Instead, hand a freshly created dimensional constraint off to the
+        # dedicated tweak operator, which lets the user drag the label into place
+        # (and enter a value) right after creation, as a plain modal with no
+        # per-move solve.
+        if succeede:
+            self._handoff_placement(context)
+
+    def _handoff_placement(self, context: Context):
+        """Start the label-placement/value modal for a new dimensional constraint.
+
+        The modal is started directly here: it comes up live and the creation
+        click's leftover release is swallowed by the tweak operator's ``handoff``
+        mode (rather than immediately confirming), after which mouse-moves place
+        the label and a click confirms.
+        """
+        target = getattr(self, "target", None)
+        if not target or not hasattr(target, "update_draw_offset"):
+            return
+
+        constraints = get_active_constraints(context)
+        if not constraints:
+            return
+        index = constraints.get_index(target)
+        if index < 0:
+            return
+
+        import bpy
+
+        bpy.ops.view3d.slvs_tweak_constraint_value_pos(
+            "INVOKE_DEFAULT", type=target.type, index=index, handoff=True
+        )
+
     def draw(self, context: Context):
         layout = self.layout
 

--- a/operators/tweak_constraint.py
+++ b/operators/tweak_constraint.py
@@ -1,13 +1,19 @@
 import bpy
-from ..model.sketch_ref import get_active_constraints
+from bpy.props import BoolProperty, IntProperty, StringProperty
+from bpy.types import Context, Event, Operator
 from bpy.utils import register_classes_factory
-from bpy.props import IntProperty, StringProperty
-from bpy.types import Operator, Context, Event
 from mathutils import Vector
 from mathutils.geometry import intersect_line_plane
 
 from ..declarations import Operators
+from ..model.sketch_ref import get_active_constraints, get_active_sketch
+from ..stateful_operator.utilities.keymap import is_numeric_input, is_unit_input
+from ..stateful_operator.utilities.numeric import NumericInput
 from ..utilities.view import get_picking_origin_end
+
+# Confirm / cancel the placement modal.
+_CONFIRM = {"RET", "NUMPAD_ENTER"}
+_CANCEL = {"ESC", "RIGHTMOUSE"}
 
 
 class View3D_OT_slvs_tweak_constraint_value_pos(Operator):
@@ -18,10 +24,22 @@ class View3D_OT_slvs_tweak_constraint_value_pos(Operator):
 
     type: StringProperty(name="Type")
     index: IntProperty(default=-1)
+    # Transient per-invocation flag: must not persist to the next call, or a
+    # gizmo drag (which invokes without it) would inherit the creation handoff's
+    # True and swallow its own release, becoming sticky. SKIP_SAVE resets it.
+    handoff: BoolProperty(default=False, options={"SKIP_SAVE"})
 
     def invoke(self, context: Context, event: Event):
         self.tweak = False
+        self._seen_press = False
+        self._numeric = NumericInput()
         self.init_mouse_pos = Vector((event.mouse_region_x, event.mouse_region_y))
+        # Handed off right after creation: place the label under the cursor at
+        # once, so there is no frame at the default offset (and no jump) before
+        # the first mouse-move.
+        if self.handoff:
+            self.tweak = True
+            self._place(context, self.init_mouse_pos)
         context.window_manager.modal_handler_add(self)
         return {"RUNNING_MODAL"}
 
@@ -29,6 +47,32 @@ class View3D_OT_slvs_tweak_constraint_value_pos(Operator):
         delta = (
             self.init_mouse_pos - Vector((event.mouse_region_x, event.mouse_region_y))
         ).length
+
+        if self.handoff:
+            # Optional value entry lives in this placement step: typing a number
+            # sets the dimension value (with units), independent of the label drag.
+            if event.value == "PRESS" and (
+                is_numeric_input(event) or is_unit_input(event)
+            ):
+                self._numeric.is_active = True
+                self._numeric.evaluate_event(event)
+                self._apply_value(context)
+                return {"RUNNING_MODAL"}
+
+            self.tweak = True
+            if event.type in _CANCEL and event.value == "PRESS":
+                return {"FINISHED"}
+            if event.type in _CONFIRM and event.value == "PRESS":
+                return {"FINISHED"}
+            if event.type == "LEFTMOUSE":
+                if event.value == "PRESS":
+                    self._seen_press = True
+                # The creation click's leftover release has no matching press in
+                # this modal -- ignore just that one so it does not confirm before
+                # the user places the label.
+                elif event.value == "RELEASE" and not self._seen_press:
+                    return {"RUNNING_MODAL"}
+
         if not self.tweak and delta > 6:
             self.tweak = True
 
@@ -40,20 +84,66 @@ class View3D_OT_slvs_tweak_constraint_value_pos(Operator):
         if not self.tweak:
             return {"RUNNING_MODAL"}
 
-        coords = event.mouse_region_x, event.mouse_region_y
+        self._place(context, (event.mouse_region_x, event.mouse_region_y))
+        return {"RUNNING_MODAL"}
 
+    def _constraint(self, context: Context):
         constraints = get_active_constraints(context)
-        constr = constraints.get_from_type_index(self.type, self.index)
+        if not constraints:
+            return None
+        return constraints.get_from_type_index(self.type, self.index)
+
+    def _place(self, context: Context, coords):
+        """Project the cursor onto the constraint's draw plane and offset it there."""
+        constr = self._constraint(context)
+        if constr is None:
+            return
 
         origin, end_point = get_picking_origin_end(context, coords)
         pos = intersect_line_plane(origin, end_point, *constr.draw_plane())
+        if pos is None:
+            return
 
-        mat = constr.matrix_basis()
-        pos = mat.inverted() @ pos
-
+        pos = constr.matrix_basis().inverted() @ pos
         constr.update_draw_offset(pos, context.preferences.system.ui_scale)
-        context.space_data.show_gizmo = True
-        return {"RUNNING_MODAL"}
+        if context.space_data:
+            context.space_data.show_gizmo = True
+        # When driven by the gizmo, its own modal drag redraws the viewport; when
+        # this operator is invoked directly (the handoff right after creating a
+        # dimension) nothing else does, so tag a redraw to keep the label live.
+        if context.area:
+            context.area.tag_redraw()
+
+    def _apply_value(self, context: Context):
+        """Set the dimension value from the numeric buffer, then re-solve."""
+        constr = self._constraint(context)
+        if constr is None:
+            return
+
+        raw = self._numeric.current
+        prop = constr.rna_type.properties.get("value")
+        if not raw or prop is None:
+            return
+        try:
+            value = bpy.utils.units.to_value(
+                context.scene.unit_settings.system, prop.unit, raw
+            )
+        except ValueError:
+            return
+
+        # Route through the property setter (matches the creation-time value
+        # entry: from_displayed_value + the update callback that re-solves).
+        constr.value = value
+
+        sketch = get_active_sketch(context)
+        if sketch:
+            from ..curve_solver import solve_system
+            from ..utilities.curve_data import refresh_curve_geometry
+
+            if solve_system(context, sketch=sketch):
+                refresh_curve_geometry(sketch)
+        if context.area:
+            context.area.tag_redraw()
 
     def execute(self, context: Context):
         bpy.ops.view3d.slvs_context_menu(type=self.type, index=self.index)

--- a/operators/tweak_constraint.py
+++ b/operators/tweak_constraint.py
@@ -8,7 +8,7 @@ from mathutils.geometry import intersect_line_plane
 from ..declarations import Operators
 from ..model.sketch_ref import get_active_constraints, get_active_sketch
 from ..stateful_operator.utilities.keymap import is_numeric_input, is_unit_input
-from ..stateful_operator.utilities.numeric import NumericInput
+from ..stateful_operator.utilities.numeric import NumericInput, parse_numeric
 from ..utilities.view import get_picking_origin_end
 
 # Confirm / cancel the placement modal.
@@ -120,15 +120,14 @@ class View3D_OT_slvs_tweak_constraint_value_pos(Operator):
         if constr is None:
             return
 
-        raw = self._numeric.current
         prop = constr.rna_type.properties.get("value")
-        if not raw or prop is None:
+        if prop is None:
             return
-        try:
-            value = bpy.utils.units.to_value(
-                context.scene.unit_settings.system, prop.unit, raw
-            )
-        except ValueError:
+        value = parse_numeric(
+            prop, self._numeric.current, context.scene.unit_settings.system
+        )
+        if value is None:
+            # Empty or mid-typing/invalid input -- keep the current value.
             return
 
         # Route through the property setter (matches the creation-time value

--- a/stateful_operator/logic.py
+++ b/stateful_operator/logic.py
@@ -1,18 +1,17 @@
 import math
+from typing import Any
 
 import bpy
-from bpy.props import IntProperty, BoolProperty
+from bpy.props import BoolProperty, IntProperty
 from bpy.types import Context, Event
 from mathutils import Vector
 
 from .. import global_data
 from .state_machine import _StateMachineMixin
-from .utilities.generic import to_list
 from .utilities.description import state_desc, stateful_op_desc
+from .utilities.generic import to_list
 from .utilities.keymap import get_key_map_desc, is_numeric_input, is_unit_input
-from .utilities.numeric import NumericInput
-
-from typing import Optional, Any
+from .utilities.numeric import NumericInput, parse_numeric
 
 # Re-export so any `from .logic import _NumericInput` keeps working.
 _NumericInput = NumericInput
@@ -215,25 +214,7 @@ class StatefulOperatorLogic(_StateMachineMixin):
         """Convert the current numeric text buffer to a typed value (or list)."""
         prop_name = self.get_property()[0]
         prop = self.properties.rna_type.properties[prop_name]
-
-        def parse_input(prop, raw):
-            units = context.scene.unit_settings
-            unit = prop.unit
-            value = None
-            if raw == "-":
-                pass
-            elif unit != "NONE":
-                try:
-                    value = bpy.utils.units.to_value(units.system, unit, raw)
-                except ValueError:
-                    return prop.default
-                if prop.type == "INT":
-                    value = int(value)
-            elif prop.type == "FLOAT":
-                value = float(raw)
-            elif prop.type == "INT":
-                value = int(raw)
-            return prop.default if value is None else value
+        unit_system = context.scene.unit_settings.system
 
         def to_iterable(item):
             if hasattr(item, "__iter__") or hasattr(item, "__getitem__"):
@@ -254,7 +235,9 @@ class StatefulOperatorLogic(_StateMachineMixin):
         for sub_index in range(size):
             raw = self._numeric.get(sub_index)
             if raw:
-                num = parse_input(prop, raw)
+                num = parse_numeric(prop, raw, unit_system)
+                if num is None:
+                    num = prop.default
                 result[sub_index] = num
                 storage[sub_index] = num
             elif interactive_val[sub_index] is not None:
@@ -495,7 +478,9 @@ class StatefulOperatorLogic(_StateMachineMixin):
         if self.state_init_coords is None:
             self.state_init_coords = coords
 
-        is_picked, pointer_values = self._pick_hovered(context, coords, state, is_numeric)
+        is_picked, pointer_values = self._pick_hovered(
+            context, coords, state, is_numeric
+        )
         values, ok = self._resolve_values(context, coords, state, is_numeric, is_picked)
 
         # Reflect the live value (property or point placement) in the status bar.

--- a/stateful_operator/utilities/numeric.py
+++ b/stateful_operator/utilities/numeric.py
@@ -1,6 +1,36 @@
 from typing import Optional
 
-from .keymap import is_unit_input, get_unit_value, get_value_from_event
+import bpy
+
+from .keymap import get_unit_value, get_value_from_event, is_unit_input
+
+
+def parse_numeric(prop, raw: str, unit_system: str):
+    """Convert a numeric input string to a value for an RNA property.
+
+    Applies the property's unit (via ``bpy.utils.units``) and type. Returns
+    ``None`` when the string is empty or cannot be parsed, so each caller picks
+    its own fallback (the stateful input uses ``prop.default``; the standalone
+    dimension value entry keeps the current value). Shared so both parse alike.
+    """
+    if not raw or raw == "-":
+        return None
+
+    if prop.unit != "NONE":
+        try:
+            value = bpy.utils.units.to_value(unit_system, prop.unit, raw)
+        except ValueError:
+            return None
+        return int(value) if prop.type == "INT" else value
+
+    try:
+        if prop.type == "FLOAT":
+            return float(raw)
+        if prop.type == "INT":
+            return int(raw)
+    except ValueError:
+        return None
+    return None
 
 
 class NumericInput:
@@ -51,7 +81,9 @@ class NumericInput:
             return
 
         if event_type in ("MINUS", "NUMPAD_MINUS"):
-            self.current = self.current[1:] if self.current.startswith("-") else "-" + self.current
+            self.current = (
+                self.current[1:] if self.current.startswith("-") else "-" + self.current
+            )
             return
 
         if is_unit_input(event):

--- a/testing/test_constraint_ops.py
+++ b/testing/test_constraint_ops.py
@@ -67,7 +67,10 @@ class TestConstraintOperators(Sketch2dTestCase):
         self.assertIsInstance(target, SlvsHorizontal)
         self.assertIn(line.curve_id, target.curve_id_placements())
 
-    def test_dimensional_constraints_expose_numeric_value_state(self):
+    def test_dimensional_constraints_have_no_creation_value_state(self):
+        """Value entry moved out of creation into the placement step (the tweak
+        operator handed off from fini), so the creation operators end at their
+        geometry states and no longer expose a separate 'Value' state."""
         from ..operators.add_angle import VIEW3D_OT_slvs_add_angle
         from ..operators.add_diameter import VIEW3D_OT_slvs_add_diameter
         from ..operators.add_distance import VIEW3D_OT_slvs_add_distance
@@ -80,16 +83,9 @@ class TestConstraintOperators(Sketch2dTestCase):
 
         for operator in operators:
             with self.subTest(operator=operator.__name__):
-                value_state = operator.get_states_definition()[-1]
-
-                self.assertEqual(value_state.name, "Value")
-                self.assertEqual(value_state.property, "value")
-                self.assertTrue(value_state.optional)
-                self.assertFalse(value_state.allow_prefill)
-                self.assertEqual(
-                    value_state.state_func,
-                    "_current_constraint_value",
-                )
+                self.assertFalse(operator.has_value_state)
+                names = [s.name for s in operator.get_states_definition()]
+                self.assertNotIn("Value", names)
 
     # -- wrong type is rejected: a point can't be a parallel operand ---------
     def test_point_rejected_for_parallel(self):


### PR DESCRIPTION
Dimensional constraints now place the label and take the value in a single post-creation step, instead of a separate value-entry state followed by placement.

Flow: pick the geometry, then the label follows the cursor. Drag to place it and optionally type a number to set the value (units supported), then click or Enter to confirm. Existing dimensions still drag via their gizmo as before.

Placement runs as a plain display-only modal (no per-move solve or snapshot), and the numeric parsing is shared with the stateful operator framework rather than duplicated.