### PR TITLE
Cycle selection through overlapping entities

### DIFF
--- a/declarations.py
+++ b/declarations.py
@@ -72,6 +72,7 @@ class Operators(str, Enum):
     RegisterDrawCB = "view3d.slvs_register_draw_cb"
     RenameCurve = "view3d.slvs_rename_curve"
     Restore = "view3d.slvs_restore"
+    HoverCycle = "view3d.slvs_hover_cycle"
     Select = "view3d.slvs_select"
     SelectAll = "view3d.slvs_select_all"
     SelectBox = "view3d.slvs_select_box"

--- a/drawing/picking.py
+++ b/drawing/picking.py
@@ -74,19 +74,22 @@ def _dist_to_segment(a, b, px, py):
     return ((px - cx) ** 2 + (py - cy) ** 2) ** 0.5
 
 
-def pick(context, coords):
-    """curve_id of the active sketch's element under ``coords``, or ``""``.
+def pick_ranked(context, coords):
+    """curve_ids of every active-sketch element under ``coords``, nearest first.
 
-    Points take priority over edges (a vertex on a line is still grabbable)."""
+    Points take priority over edges (a vertex on a line is still grabbable), then
+    by screen distance. Unlike ``pick`` this keeps *all* candidates within the hit
+    radius, so overlapping entities can be cycled through instead of only ever
+    getting the topmost one (issue #50)."""
     data = _active_data(context)
     region, rv3d = context.region, context.region_data
     if data is None or region is None or rv3d is None:
-        return ""
+        return []
 
     ignore = selection.ignore_list
     scale = get_scale()
     cx, cy = float(coords[0]), float(coords[1])
-    best = None  # (priority, distance, cid)
+    hits = []  # (priority, distance, cid)
 
     pts = [(cid, p) for cid, p in data.point_ids if cid not in ignore]
     if pts:
@@ -94,8 +97,8 @@ def pick(context, coords):
         d = np.hypot(screen[:, 0] - cx, screen[:, 1] - cy)
         r = _POINT_RADIUS * scale
         for i, cid in enumerate(cids):
-            if valid[i] and d[i] <= r and (best is None or (0, d[i]) < best[:2]):
-                best = (0, float(d[i]), cid)
+            if valid[i] and d[i] <= r:
+                hits.append((0, float(d[i]), cid))
 
     segs = [(cid, a, b) for cid, a, b in data.segment_ids if cid not in ignore]
     if segs:
@@ -105,10 +108,36 @@ def pick(context, coords):
             if not (valid[i, 0] and valid[i, 1]):
                 continue
             dist = _dist_to_segment(screen[i, 0], screen[i, 1], cx, cy)
-            if dist <= r and (best is None or (1, dist) < best[:2]):
-                best = (1, float(dist), cid)
+            if dist <= r:
+                hits.append((1, float(dist), cid))
 
-    return best[2] if best else ""
+    hits.sort(key=lambda h: (h[0], h[1]))
+    ranked, seen = [], set()
+    for _, _, cid in hits:
+        if cid not in seen:
+            seen.add(cid)
+            ranked.append(cid)
+    return ranked
+
+
+def pick(context, coords):
+    """curve_id of the active sketch's nearest element under ``coords``, or ``""``."""
+    ranked = pick_ranked(context, coords)
+    return ranked[0] if ranked else ""
+
+
+def update_hover(context, coords):
+    """Cycle-aware hover resolution shared by the preselection gizmo and picking.
+
+    Stores the ranked candidate list on ``selection.hover_candidates`` and returns
+    the curve_id to hover: the current hover is kept if it is still under the
+    cursor (so a cycled choice survives small mouse moves), otherwise the nearest.
+    """
+    ranked = pick_ranked(context, coords)
+    selection.hover_candidates = ranked
+    if selection.hover in ranked:
+        return selection.hover
+    return ranked[0] if ranked else ""
 
 
 def _seg_intersects_box(a, b, x0, y0, x1, y1):
@@ -150,8 +179,13 @@ def pick_box(context, min_co, max_co):
     pts = [(cid, p) for cid, p in data.point_ids if cid not in ignore]
     if pts:
         cids, screen, valid = _points_screen(pts, region, rv3d)
-        inside = valid & (screen[:, 0] >= x0) & (screen[:, 0] <= x1) \
-            & (screen[:, 1] >= y0) & (screen[:, 1] <= y1)
+        inside = (
+            valid
+            & (screen[:, 0] >= x0)
+            & (screen[:, 0] <= x1)
+            & (screen[:, 1] >= y0)
+            & (screen[:, 1] <= y1)
+        )
         for i, cid in enumerate(cids):
             if inside[i] and cid not in seen:
                 seen.add(cid)

--- a/drawing/picking.py
+++ b/drawing/picking.py
@@ -137,6 +137,8 @@ def update_hover(context, coords):
     selection.hover_candidates = ranked
     if selection.hover in ranked:
         return selection.hover
+    # Moved to a different element (or off geometry): drop any wheel-set lock.
+    selection.hover_locked = False
     return ranked[0] if ranked else ""
 
 

--- a/drawing/selection.py
+++ b/drawing/selection.py
@@ -14,6 +14,10 @@ selected = []
 # The single curve_id under the cursor ("" = nothing hovered).
 hover = ""
 
+# curve_ids of every element under the cursor, nearest first, so overlapping
+# entities can be cycled. Rebuilt on each hover update; ``hover`` is one of these.
+hover_candidates = []
+
 # curve_ids to render highlighted in addition to hover -- e.g. the geometry a
 # hovered constraint acts on. Cleared by the preselection gizmo.
 highlight_curve_ids = []
@@ -28,12 +32,32 @@ highlight_entities = []
 ignore_list = []
 
 
+def cycle_hover(direction=1):
+    """Advance ``hover`` to the next overlapping candidate under the cursor.
+
+    Steps through ``hover_candidates`` (nearest first). Returns True if the hover
+    moved, False when fewer than two entities are stacked. Shared by the select
+    tool's cycle operator and the stateful draw modal so both behave the same.
+    """
+    global hover
+    if len(hover_candidates) < 2:
+        return False
+    try:
+        index = hover_candidates.index(hover)
+    except ValueError:
+        index = 0
+    step = 1 if direction >= 0 else -1
+    hover = hover_candidates[(index + step) % len(hover_candidates)]
+    return True
+
+
 def clear():
     """Reset all interactive state (e.g. on file load)."""
     selected.clear()
     highlight_curve_ids.clear()
     highlight_entities.clear()
     ignore_list.clear()
+    hover_candidates.clear()
     global hover, highlight_constraint
     hover = ""
     highlight_constraint = None

--- a/drawing/selection.py
+++ b/drawing/selection.py
@@ -18,6 +18,12 @@ hover = ""
 # entities can be cycled. Rebuilt on each hover update; ``hover`` is one of these.
 hover_candidates = []
 
+# True once the hover has been explicitly positioned within the stack (Alt+wheel).
+# While locked, an Alt+click commits the current hover instead of advancing again,
+# so wheel-to-preview then click (with Alt still held) does not overshoot. Reset
+# when the cursor moves to a different element.
+hover_locked = False
+
 # curve_ids to render highlighted in addition to hover -- e.g. the geometry a
 # hovered constraint acts on. Cleared by the preselection gizmo.
 highlight_curve_ids = []
@@ -32,14 +38,17 @@ highlight_entities = []
 ignore_list = []
 
 
-def cycle_hover(direction=1):
+def cycle_hover(direction=1, lock=False):
     """Advance ``hover`` to the next overlapping candidate under the cursor.
 
     Steps through ``hover_candidates`` (nearest first). Returns True if the hover
     moved, False when fewer than two entities are stacked. Shared by the select
     tool's cycle operator and the stateful draw modal so both behave the same.
+
+    ``lock`` marks the hover as explicitly positioned (used by the Alt+wheel
+    preview), so a following Alt+click commits it rather than advancing past it.
     """
-    global hover
+    global hover, hover_locked
     if len(hover_candidates) < 2:
         return False
     try:
@@ -48,7 +57,18 @@ def cycle_hover(direction=1):
         index = 0
     step = 1 if direction >= 0 else -1
     hover = hover_candidates[(index + step) % len(hover_candidates)]
+    if lock:
+        hover_locked = True
     return True
+
+
+def take_hover_lock():
+    """Consume the hover lock. Returns True if it was set (hover positioned by
+    Alt+wheel), so the caller commits the current hover instead of advancing."""
+    global hover_locked
+    was_locked = hover_locked
+    hover_locked = False
+    return was_locked
 
 
 def clear():
@@ -58,6 +78,7 @@ def clear():
     highlight_entities.clear()
     ignore_list.clear()
     hover_candidates.clear()
-    global hover, highlight_constraint
+    global hover, highlight_constraint, hover_locked
     hover = ""
+    hover_locked = False
     highlight_constraint = None

--- a/gizmos/preselection.py
+++ b/gizmos/preselection.py
@@ -66,7 +66,10 @@ class VIEW3D_GT_slvs_preselection(Gizmo):
             context.area.tag_redraw()
 
         # CPU screen-space pick of the active sketch's geometry under the cursor.
-        cid = picking.pick(context, location)
+        # Cycle-aware: keeps the ranked candidate stack so overlapping entities
+        # can be stepped through (see the hover-cycle operator), and preserves a
+        # cycled choice across small mouse moves.
+        cid = picking.update_hover(context, location)
         if cid != selection.hover:
             selection.hover = cid
             context.area.tag_redraw()

--- a/keymaps.py
+++ b/keymaps.py
@@ -172,11 +172,7 @@ tool_access = (
         WorkSpaceTools.Bevel,
         Operators.Bevel,
     ),
-    tool_invoke_kmi(
-        "O",
-        WorkSpaceTools.Offset,
-        Operators.Offset
-    ),
+    tool_invoke_kmi("O", WorkSpaceTools.Offset, Operators.Offset),
     tool_invoke_kmi(
         "S",
         WorkSpaceTools.AddSketch,
@@ -326,6 +322,12 @@ tool_select = (
         {"type": "LEFTMOUSE", "value": "CLICK", "ctrl": True},
         {"properties": [("mode", "SUBTRACT")]},
     ),
+    # Alt+click: select the next entity in the overlapping stack (issue #50).
+    (
+        Operators.Select,
+        {"type": "LEFTMOUSE", "value": "CLICK", "alt": True},
+        {"properties": [("cycle", True)]},
+    ),
     (
         Operators.SelectInvert,
         {"type": "I", "value": "PRESS", "ctrl": True},
@@ -381,6 +383,16 @@ def register():
         kmi.properties.name = BLENDER_SELECT_TOOL
         addon_keymaps.append((km, kmi))
 
+        # Cycle the hovered element through overlapping entities under the cursor
+        # (issue #50). Alt+wheel, so it does not collide with zoom; a no-op unless
+        # more than one entity is stacked under the cursor.
+        for event_type, direction in (("WHEELUPMOUSE", 1), ("WHEELDOWNMOUSE", -1)):
+            kmi = km.keymap_items.new(
+                Operators.HoverCycle, event_type, "PRESS", alt=True
+            )
+            kmi.properties.direction = direction
+            addon_keymaps.append((km, kmi))
+
         # Add Sketch: switch to the Add Sketch tool (workplane gizmo), then
         # invoke the operator (a pre-selected workplane creates immediately).
         kmi = km.keymap_items.new(
@@ -420,7 +432,6 @@ def register():
         kmi.properties.tool_name = WorkSpaceTools.ArrayLinear.value
         kmi.properties.operator = Operators.NodeArrayLinear.value
         addon_keymaps.append((km, kmi))
-
 
 
 def unregister():

--- a/operators/base_stateful.py
+++ b/operators/base_stateful.py
@@ -29,21 +29,23 @@ class GenericEntityOp(StatefulOperator):
             and len(selection.hover_candidates) > 1
         ):
             direction = 1 if event.type == "WHEELUPMOUSE" else -1
-            if selection.cycle_hover(direction):
+            if selection.cycle_hover(direction, lock=True):
                 if context.area:
                     context.area.tag_redraw()
                 return {"RUNNING_MODAL"}
 
         # Alt+click: pick the next occluded candidate. Step hover, then fall
         # through so the normal LEFTMOUSE confirm commits the cycled entity
-        # (check_event treats LEFTMOUSE-press as confirm regardless of Alt).
+        # (check_event treats LEFTMOUSE-press as confirm regardless of Alt). If the
+        # hover was just positioned with Alt+wheel, commit it instead of advancing.
         if (
             event.type == "LEFTMOUSE"
             and event.value == "PRESS"
             and event.alt
             and len(selection.hover_candidates) > 1
         ):
-            selection.cycle_hover(1)
+            if not selection.take_hover_lock():
+                selection.cycle_hover(1)
 
         return super().modal(context, event)
 

--- a/operators/base_stateful.py
+++ b/operators/base_stateful.py
@@ -1,20 +1,51 @@
-from typing import Optional, Any
+from typing import Any, Optional
 
-import numpy as np
 import bpy
-from bpy.types import Context
+import numpy as np
 from bpy.props import FloatVectorProperty
+from bpy.types import Context
 
 from .. import global_data
 from ..drawing import selection
+from ..model.types import SlvsGenericEntity, SlvsNormal3D, SlvsPoint2D, SlvsPoint3D
+from ..serialize import scene_from_dict, scene_to_dict
 from ..stateful_operator.integration import StatefulOperator
-from ..model.types import SlvsGenericEntity, SlvsPoint3D, SlvsPoint2D, SlvsNormal3D
 from .utilities import get_hovered
-from ..serialize import scene_to_dict, scene_from_dict
 
 
 class GenericEntityOp(StatefulOperator):
     """Extend StatefulOperator with extension specific types"""
+
+    def modal(self, context, event):
+        # Alt+wheel cycles the hovered entity through the overlapping stack under
+        # the cursor while drawing/constraining (issue #50). The preselection
+        # gizmo keeps selection.hover_candidates current during the modal, so this
+        # just steps hover; the next pick/commit reads it. Everything else falls
+        # through to the normal stateful modal (plain wheel still navigates).
+        if (
+            event.value == "PRESS"
+            and event.alt
+            and event.type in {"WHEELUPMOUSE", "WHEELDOWNMOUSE"}
+            and len(selection.hover_candidates) > 1
+        ):
+            direction = 1 if event.type == "WHEELUPMOUSE" else -1
+            if selection.cycle_hover(direction):
+                if context.area:
+                    context.area.tag_redraw()
+                return {"RUNNING_MODAL"}
+
+        # Alt+click: pick the next occluded candidate. Step hover, then fall
+        # through so the normal LEFTMOUSE confirm commits the cycled entity
+        # (check_event treats LEFTMOUSE-press as confirm regardless of Alt).
+        if (
+            event.type == "LEFTMOUSE"
+            and event.value == "PRESS"
+            and event.alt
+            and len(selection.hover_candidates) > 1
+        ):
+            selection.cycle_hover(1)
+
+        return super().modal(context, event)
 
     def check_event(self, event):
         # Shift = "place it raw": bypass both geometry snapping and inferred
@@ -23,7 +54,10 @@ class GenericEntityOp(StatefulOperator):
         #  - Auto-constraints are applied at the confirm click, so capture Shift
         #    there (not sticky) — releasing Shift restores normal behaviour.
         global_data.snap_bypass = bool(event.shift)
-        if event.type in ("LEFTMOUSE", "RET", "NUMPAD_ENTER") and event.value == "PRESS":
+        if (
+            event.type in ("LEFTMOUSE", "RET", "NUMPAD_ENTER")
+            and event.value == "PRESS"
+        ):
             self.state_data["skip_auto_constraints"] = bool(event.shift)
         return super().check_event(event)
 
@@ -35,9 +69,8 @@ class GenericEntityOp(StatefulOperator):
         """
         if state_data is None:
             state_data = self.state_data
-        return (
-            context.scene.sketcher.auto_axis_constraints
-            and not state_data.get("skip_auto_constraints", False)
+        return context.scene.sketcher.auto_axis_constraints and not state_data.get(
+            "skip_auto_constraints", False
         )
 
     def pick_element(self, context, coords):
@@ -70,10 +103,16 @@ class GenericEntityOp(StatefulOperator):
         hovered_cid = state_data.get("hovered", "")
         if hovered_cid and hasattr(self, "sketch") and self.sketch:
             from ..model.curve_ref import CurveRef
-            point_cid = point.curve_id if isinstance(point, CurveRef) else state_data.get("curve_id", "")
+
+            point_cid = (
+                point.curve_id
+                if isinstance(point, CurveRef)
+                else state_data.get("curve_id", "")
+            )
 
             state_data["coincident"] = self.sketch.constraints.add_coincident(
-                curve_id_1=point_cid, curve_id_2=hovered_cid,
+                curve_id_1=point_cid,
+                curve_id_2=hovered_cid,
             )
 
     def has_coincident(self):
@@ -142,7 +181,14 @@ class GenericEntityOp(StatefulOperator):
             return ""
 
         from ..model.curve_ref import CurveRef
-        if any([issubclass(t, (SlvsGenericEntity, CurveRef)) for t in state.types if isinstance(t, type)]):
+
+        if any(
+            [
+                issubclass(t, (SlvsGenericEntity, CurveRef))
+                for t in state.types
+                if isinstance(t, type)
+            ]
+        ):
             return pointer_name + "_fallback"
         return ""
 
@@ -154,7 +200,6 @@ class GenericEntityOp(StatefulOperator):
         if index is None:
             index = self.state_index
 
-        state = self.get_states_definition()[index]
         data = self._state_data.get(index, {})
         if "type" not in data.keys():
             return None
@@ -164,6 +209,7 @@ class GenericEntityOp(StatefulOperator):
             return None
 
         from ..model.curve_ref import CurveRef
+
         if pointer_type is not None and issubclass(pointer_type, CurveRef):
             cid = data.get("curve_id", "")
             if implicit:
@@ -172,7 +218,12 @@ class GenericEntityOp(StatefulOperator):
                 return None
             from ..model.curve_ref import curve_ref
             from ..model.sketch_ref import get_active_sketch
-            sketch = self.sketch if hasattr(self, "sketch") else get_active_sketch(bpy.context)
+
+            sketch = (
+                self.sketch
+                if hasattr(self, "sketch")
+                else get_active_sketch(bpy.context)
+            )
             return curve_ref(sketch, cid)
 
         if issubclass(pointer_type, SlvsGenericEntity):
@@ -191,13 +242,13 @@ class GenericEntityOp(StatefulOperator):
         if index is None:
             index = self.state_index
 
-        state = self.get_states_definition()[index]
         data = self._state_data.get(index, {})
         pointer_type = data.get("type")
         if pointer_type is None:
             return None
 
         from ..model.curve_ref import CurveRef
+
         if issubclass(pointer_type, CurveRef):
             value = values[0] if values is not None else None
             if value is None:
@@ -227,9 +278,11 @@ class GenericEntityOp(StatefulOperator):
         selected = super().gather_selection(context)
 
         from ..model.sketch_ref import get_active_sketch
+
         sketch = get_active_sketch(context)
         if sketch and selection.selected:
             from ..model.curve_ref import curve_ref
+
             for cid in selection.selected:
                 ref = curve_ref(sketch, cid)
                 if ref.valid:
@@ -258,24 +311,25 @@ class GenericEntityOp(StatefulOperator):
         for attr in curve_data.attributes:
             if attr.name == "position":
                 continue
-            domain_len = n_points if attr.domain == 'POINT' else n_curves
-            if attr.data_type == 'FLOAT_VECTOR':
+            domain_len = n_points if attr.domain == "POINT" else n_curves
+            if attr.data_type == "FLOAT_VECTOR":
                 data = np.zeros(domain_len * 3, dtype=np.float32)
                 attr.data.foreach_get("vector", data)
-            elif attr.data_type == 'BOOLEAN':
+            elif attr.data_type == "BOOLEAN":
                 data = np.zeros(domain_len, dtype=np.bool_)
                 attr.data.foreach_get("value", data)
-            elif attr.data_type in ('INT', 'INT8'):
+            elif attr.data_type in ("INT", "INT8"):
                 data = np.zeros(domain_len, dtype=np.int32)
                 attr.data.foreach_get("value", data)
-            elif attr.data_type in ('INT32_2D', 'INT16_2D'):
+            elif attr.data_type in ("INT32_2D", "INT16_2D"):
                 data = np.zeros(domain_len * 2, dtype=np.int32)
                 attr.data.foreach_get("value", data)
-            elif attr.data_type == 'FLOAT':
+            elif attr.data_type == "FLOAT":
                 data = np.zeros(domain_len, dtype=np.float32)
                 attr.data.foreach_get("value", data)
-            elif attr.data_type == 'STRING':
+            elif attr.data_type == "STRING":
                 from ..utilities.curve_data import get_str_attr
+
                 data = [get_str_attr(attr, i) for i in range(domain_len)]
             else:
                 continue
@@ -306,10 +360,9 @@ class GenericEntityOp(StatefulOperator):
         # This runs every mouse-move, so the rebuild otherwise scales the whole
         # sketch's geometry per frame.
         counts = snapshot["point_counts"]
-        same_topology = (
-            len(curve_data.curves) == snapshot["n_curves"]
-            and len(curve_data.points) == int(counts.sum())
-        )
+        same_topology = len(curve_data.curves) == snapshot["n_curves"] and len(
+            curve_data.points
+        ) == int(counts.sum())
         if same_topology:
             cur_counts = np.zeros(len(curve_data.curves), dtype=np.int32)
             curve_data.curves.foreach_get("points_length", cur_counts)
@@ -329,9 +382,9 @@ class GenericEntityOp(StatefulOperator):
                 attr = curve_data.attributes.new(
                     name, type=attr_info["type"], domain=attr_info["domain"]
                 )
-            if attr_info["type"] == 'FLOAT_VECTOR':
+            if attr_info["type"] == "FLOAT_VECTOR":
                 attr.data.foreach_set("vector", attr_info["data"])
-            elif attr_info["type"] == 'STRING':
+            elif attr_info["type"] == "STRING":
                 for i, v in enumerate(attr_info["data"]):
                     attr.data[i].value = v.encode() if isinstance(v, str) else v
             else:
@@ -391,6 +444,7 @@ class GenericEntityOp(StatefulOperator):
     def _snapshot_all_curves(self, context):
         """Snapshot curve data + constraints for all sketches."""
         from ..model.sketch_ref import get_sketches
+
         curve_snapshots = {}
         for sketch in get_sketches(context):
             obj = sketch.target_object
@@ -408,8 +462,9 @@ class GenericEntityOp(StatefulOperator):
 
     def _restore_all_curves(self, context, curve_snapshots):
         """Restore curve data + constraints for all sketches."""
-        from ..utilities.curve_data import invalidate_curve_id_cache
         from ..model.sketch_ref import get_sketches
+        from ..utilities.curve_data import invalidate_curve_id_cache
+
         invalidate_curve_id_cache()
 
         if not curve_snapshots:

--- a/operators/select.py
+++ b/operators/select.py
@@ -1,13 +1,12 @@
-from bpy.types import Operator, Context
-from bpy.props import IntProperty, BoolProperty, StringProperty
+from bpy.props import BoolProperty, IntProperty, StringProperty
+from bpy.types import Context, Operator
 from bpy.utils import register_classes_factory
 
-from .utilities import select_extend, select_invert
-from ..utilities.select import select_all, deselect_all
-from ..drawing import selection
 from ..declarations import Operators
+from ..drawing import selection
 from ..utilities.highlighting import HighlightElement
-from ..utilities.select import mode_property
+from ..utilities.select import deselect_all, mode_property, select_all
+from .utilities import select_extend, select_invert
 
 
 class View3D_OT_slvs_select(Operator, HighlightElement):
@@ -26,12 +25,15 @@ class View3D_OT_slvs_select(Operator, HighlightElement):
     # currently hovered curve id is used.
     index: StringProperty(name="Curve ID", default="")
     mode: mode_property
+    # Alt+click: step to the next entity in the overlapping stack under the cursor
+    # before selecting, so repeated Alt+clicks reach occluded geometry (issue #50).
+    cycle: BoolProperty(name="Cycle Overlapping", default=False, options={"SKIP_SAVE"})
 
     def execute(self, context: Context):
+        if self.cycle:
+            selection.cycle_hover(1)
         index = (
-            self.index
-            if self.properties.is_property_set("index")
-            else selection.hover
+            self.index if self.properties.is_property_set("index") else selection.hover
         )
         hit = bool(index)
         mode = self.mode
@@ -114,6 +116,23 @@ class View3D_OT_slvs_select_extend_all(Operator):
         return {"FINISHED"}
 
 
+class View3D_OT_slvs_hover_cycle(Operator):
+    """Cycle the hovered element through entities overlapping under the cursor"""
+
+    bl_idname = Operators.HoverCycle
+    bl_label = "Cycle Hovered Element"
+    bl_options = {"INTERNAL"}
+
+    direction: IntProperty(default=1)
+
+    def execute(self, context: Context):
+        if not selection.cycle_hover(self.direction):
+            return {"CANCELLED"}
+        if context.area:
+            context.area.tag_redraw()
+        return {"FINISHED"}
+
+
 register, unregister = register_classes_factory(
     (
         View3D_OT_slvs_select,
@@ -121,5 +140,6 @@ register, unregister = register_classes_factory(
         View3D_OT_slvs_select_invert,
         View3D_OT_slvs_select_extend,
         View3D_OT_slvs_select_extend_all,
+        View3D_OT_slvs_hover_cycle,
     )
 )

--- a/operators/select.py
+++ b/operators/select.py
@@ -30,7 +30,9 @@ class View3D_OT_slvs_select(Operator, HighlightElement):
     cycle: BoolProperty(name="Cycle Overlapping", default=False, options={"SKIP_SAVE"})
 
     def execute(self, context: Context):
-        if self.cycle:
+        # Alt+click: advance to the next candidate, unless the hover was just
+        # positioned with Alt+wheel -- then commit that one instead of overshooting.
+        if self.cycle and not selection.take_hover_lock():
             selection.cycle_hover(1)
         index = (
             self.index if self.properties.is_property_set("index") else selection.hover
@@ -126,7 +128,9 @@ class View3D_OT_slvs_hover_cycle(Operator):
     direction: IntProperty(default=1)
 
     def execute(self, context: Context):
-        if not selection.cycle_hover(self.direction):
+        # lock=True: this is a preview cycle, so a following Alt+click commits the
+        # positioned hover rather than advancing past it.
+        if not selection.cycle_hover(self.direction, lock=True):
             return {"CANCELLED"}
         if context.area:
             context.area.tag_redraw()

--- a/testing/test_picking.py
+++ b/testing/test_picking.py
@@ -50,6 +50,7 @@ class TestPicking(Sketch2dTestCase):
         selection.ignore_list = []
         selection.hover = ""
         selection.hover_candidates = []
+        selection.hover_locked = False
         super().tearDown()
 
     def test_pick_ranked_returns_overlapping_stack(self):
@@ -85,6 +86,27 @@ class TestPicking(Sketch2dTestCase):
         selection.hover_candidates = ["only"]
         selection.hover = "only"
         self.assertFalse(selection.cycle_hover(1))  # fewer than two -> no-op
+
+    def test_wheel_lock_stops_alt_click_overshoot(self):
+        # Alt+wheel previews to "b" and locks; the following Alt+click must commit
+        # "b" (consume the lock), not advance to "c".
+        selection.hover_candidates = ["a", "b", "c"]
+        selection.hover = "a"
+        self.assertTrue(selection.cycle_hover(1, lock=True))
+        self.assertEqual(selection.hover, "b")
+        self.assertTrue(selection.hover_locked)
+
+        self.assertTrue(selection.take_hover_lock())  # Alt+click commits "b"
+        self.assertFalse(selection.hover_locked)
+        # A further Alt+click (no lock) digs on to the next candidate.
+        self.assertFalse(selection.take_hover_lock())
+
+    def test_moving_off_element_clears_lock(self):
+        # A wheel lock must not persist once the cursor leaves the stack.
+        selection.hover = self.b.curve_id
+        selection.hover_locked = True
+        picking.update_hover(self.ctx, (1000, 1000))  # over nothing
+        self.assertFalse(selection.hover_locked)
 
     def test_point_takes_priority_over_edge(self):
         # Cursor over point b's screen location (40, 0).

--- a/testing/test_picking.py
+++ b/testing/test_picking.py
@@ -27,7 +27,9 @@ class _FakeContext:
 def _ortho_projection(world, region, rv3d):
     """Top-down orthographic stub: screen = (x*10, y*10), everything visible."""
     world = np.asarray(world, dtype=float).reshape(-1, 3)
-    return np.column_stack([world[:, 0] * 10, world[:, 1] * 10]), np.ones(len(world), bool)
+    return np.column_stack([world[:, 0] * 10, world[:, 1] * 10]), np.ones(
+        len(world), bool
+    )
 
 
 class TestPicking(Sketch2dTestCase):
@@ -46,7 +48,43 @@ class TestPicking(Sketch2dTestCase):
     def tearDown(self):
         picking._project_points_to_region = self._orig
         selection.ignore_list = []
+        selection.hover = ""
+        selection.hover_candidates = []
         super().tearDown()
+
+    def test_pick_ranked_returns_overlapping_stack(self):
+        # At point b's location (40, 0) the point and the line's endpoint overlap:
+        # both are candidates, point first (grabbable vertex over edge).
+        ranked = picking.pick_ranked(self.ctx, (40, 0))
+        self.assertEqual(ranked[0], self.b.curve_id)
+        self.assertIn(self.line.curve_id, ranked)
+        self.assertGreaterEqual(len(ranked), 2)
+
+    def test_update_hover_keeps_cycled_choice(self):
+        # Hover the stack (nearest = point b), cycle to the line, then re-hover the
+        # same spot: the cycled choice must survive rather than snap back to nearest.
+        selection.hover = ""
+        picking.update_hover(self.ctx, (40, 0))
+        self.assertEqual(selection.hover_candidates[0], self.b.curve_id)
+        self.assertTrue(selection.cycle_hover(1))
+        self.assertEqual(selection.hover, self.line.curve_id)
+        self.assertEqual(picking.update_hover(self.ctx, (40, 0)), self.line.curve_id)
+
+    def test_cycle_hover_wraps_and_noops(self):
+        selection.hover_candidates = ["a", "b", "c"]
+        selection.hover = "a"
+        self.assertTrue(selection.cycle_hover(1))
+        self.assertEqual(selection.hover, "b")
+        self.assertTrue(selection.cycle_hover(1))
+        self.assertEqual(selection.hover, "c")
+        self.assertTrue(selection.cycle_hover(1))  # wrap forward
+        self.assertEqual(selection.hover, "a")
+        self.assertTrue(selection.cycle_hover(-1))  # wrap backward
+        self.assertEqual(selection.hover, "c")
+
+        selection.hover_candidates = ["only"]
+        selection.hover = "only"
+        self.assertFalse(selection.cycle_hover(1))  # fewer than two -> no-op
 
     def test_point_takes_priority_over_edge(self):
         # Cursor over point b's screen location (40, 0).
@@ -87,7 +125,5 @@ class TestPicking(Sketch2dTestCase):
         line2 = self.add_line(self.b, c)
         self.solve()
         self.assertEqual(picking.pick(self.ctx, (40, 40)), c.curve_id)
-        self.assertIsNot(
-            picking._pick_cache[self.sketch.target_object.name][1], cached
-        )
+        self.assertIsNot(picking._pick_cache[self.sketch.target_object.name][1], cached)
         self.assertTrue(line2.valid)


### PR DESCRIPTION
Click-select and stateful picking could only ever reach the nearest entity under the cursor (box-select already handled overlaps). This adds a ranked candidate list so occluded geometry is reachable:

- Alt+click acts on the next entity in the stack, so repeated Alt+clicks dig through overlapping geometry, both when selecting and when picking during a draw/constraint tool.
- Alt+wheel cycles the highlight without committing (preview) for anyone with a wheel.

Both drive one shared cycle helper, so selection and stateful picking behave identically. Plain click and box-select are unchanged.

Relates to #50.