### PR TITLE
Changelog and docs for recent 0.3.0 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,5 +17,9 @@ into Blender, better stability and performance.
 - Added auto-constraints toggle to add horizontal, vertical and coincident constraints while drawing; hold Shift to skip
 - Snap sketch points to existing 3D geometry (vertices, edges, midpoints, face center); this is a static snap at placement time and does not track the underlying geometry afterwards
 - Added Workspacetools for parametric Extrude and Linear Array
+- Added Project Geometry: bring an external object's edges into the active sketch as construction geometry that stays linked to the source and follows its edits
+- Added a pie menu (Ctrl+Shift+M) for quick access to drawing tools and constraints
+- Dimensional constraints (distance, angle, diameter) are placed in one step: pick the geometry, drag the label into position, and optionally type the value
+- Select overlapping entities under the cursor: Alt+click steps through the stack, Alt+wheel cycles the highlight without selecting
 - Added extension auto-update via the extension repository
 - New "What's New" dialog surfaces changes after each update

--- a/docs/content/constraints.md
+++ b/docs/content/constraints.md
@@ -38,6 +38,11 @@ will be colored red, additionally the failed sketch will be marked.
 ::: CAD_Sketcher.model.types.SlvsRatio
 
 ### Dimensional Constraints
+Adding a dimensional constraint places its label in the same step: pick the
+geometry, then move the mouse to position the label and, optionally, type a value
+before confirming. The label's position can be adjusted later by dragging its
+gizmo.
+
 ::: CAD_Sketcher.model.types.SlvsDistance
 
 ::: CAD_Sketcher.model.types.SlvsDiameter

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -84,6 +84,7 @@ Available in Object Mode regardless of the active tool.
 |A|Ctrl+Shift|Add sketch / leave the active sketch|
 |E|Ctrl+Shift|Extrude the active sketch|
 |D|Ctrl+Shift|Linear array of the active sketch|
+|M|Ctrl+Shift|Open the CAD Sketcher pie menu (drawing tools and constraints)|
 |Esc|Shift|Switch to Blender's Select tool|
 
 ### Basic Tool Keymap
@@ -122,6 +123,8 @@ The basic tool interaction is consistent between tools.
 |LMB (click)|-   |Toggle select|
 |LMB (click)|Shift|Extend selection|
 |LMB (click)|Ctrl|Subtract from selection|
+|LMB (click)|Alt|Select the next entity in the overlapping stack under the cursor|
+|Wheel|Alt|Cycle the hovered entity through overlapping ones without selecting|
 |LMB (drag)|-|Box select, or tweak the hovered entity|
 |LMB (drag)|Shift|Box select (extend)|
 |LMB (drag)|Ctrl|Box select (subtract)|
@@ -136,6 +139,11 @@ The basic tool interaction is consistent between tools.
 
 > **INFO:** Chain selection works with coincident constraints too
 
+> **INFO:** When entities overlap, a plain click grabs the nearest one. Alt+click
+steps to the next entity down (repeat to dig through the stack), and Alt+wheel
+cycles the hovered entity so you can preview before clicking. This also works
+while picking geometry inside a drawing or constraint tool.
+
 ::: CAD_Sketcher.operators.add_point_2d.View3D_OT_slvs_add_point2d
 
 ::: CAD_Sketcher.operators.add_line_2d.View3D_OT_slvs_add_line2d
@@ -147,6 +155,12 @@ The basic tool interaction is consistent between tools.
 ::: CAD_Sketcher.operators.add_rectangle.View3D_OT_slvs_add_rectangle
 
 ::: CAD_Sketcher.operators.trim.View3D_OT_slvs_trim
+
+::: CAD_Sketcher.operators.project_geometry.VIEW3D_OT_slvs_project_geometry
+
+Project Geometry brings a mesh object's edges into the active sketch as native
+construction points and lines. The projected points stay linked to their source
+vertices, so editing or transforming the source object updates the projection.
 
 ### Workplane tools
 A workplane is any Blender object whose transform defines the sketch plane (see


### PR DESCRIPTION
Document the user-facing features that merged after the 0.3.0 changelog section was first written (the changelog also feeds the in-app What's New):

- Project Geometry
- Pie menu (Ctrl+Shift+M)
- Dimension placement and value entry in one step
- Overlapping-entity selection (Alt+click / Alt+wheel)

Custom attributes is left out until #612 merges.