### PR TITLE
Improve origin workplane selection

### DIFF
--- a/declarations.py
+++ b/declarations.py
@@ -47,6 +47,7 @@ class Operators(str, Enum):
     AddSymmetry = "view3d.slvs_add_symmetry"
     AddRectangle = "view3d.slvs_add_rectangle"
     AddSketch = "view3d.slvs_add_sketch"
+    AddSketchOnPlane = "view3d.slvs_add_sketch_on_plane"
     AddTangent = "view3d.slvs_add_tangent"
     AddVertical = "view3d.slvs_add_vertical"
     MakeWorkplaneFree = "view3d.slvs_make_workplane_free"

--- a/draw_handler.py
+++ b/draw_handler.py
@@ -1,25 +1,34 @@
 import logging
 
+import blf
 import bpy
 import gpu
 from bpy.types import Context, Operator
 from bpy.utils import register_class, unregister_class
+from bpy_extras.view3d_utils import location_3d_to_region_2d
 from gpu_extras.batch import batch_for_shader
-from mathutils import Vector
+from mathutils import Matrix, Vector
 
 from . import global_data
+from .declarations import Operators
+from .shaders import Shaders
 from .utilities import preferences
 from .utilities.preferences import get_prefs
-from .shaders import Shaders
-from .declarations import Operators
 
 logger = logging.getLogger(__name__)
 
+# Blender's built-in default font.
+_FONT_ID = 0
+# Label height as a fraction of the origin plane's drawn side length.
+_LABEL_HEIGHT_FACTOR = 0.22
+# Inset of the label from the plane's outer corner, as a fraction of its side.
+_LABEL_CORNER_MARGIN = 0.08
 
 
 def _draw_curves_overlay(context: Context):
     """Draw native curve geometry as an overlay (cached, batched drawing system)."""
     from .drawing import overlay
+
     overlay.draw(context)
 
 
@@ -30,9 +39,18 @@ def draw_cb():
 
 # Bounding-box edges (Blender's 8-corner order).
 _BBOX_EDGES = (
-    (0, 1), (1, 2), (2, 3), (3, 0),
-    (4, 5), (5, 6), (6, 7), (7, 4),
-    (0, 4), (1, 5), (2, 6), (3, 7),
+    (0, 1),
+    (1, 2),
+    (2, 3),
+    (3, 0),
+    (4, 5),
+    (5, 6),
+    (6, 7),
+    (7, 4),
+    (0, 4),
+    (1, 5),
+    (2, 6),
+    (3, 7),
 )
 
 
@@ -159,12 +177,112 @@ def draw_hover_element():
         _draw_vertex_hover(context, ob, index, col, scale)
 
 
+def draw_origin_labels():
+    """POST_VIEW: name each origin workplane (XY/XZ/YZ), lying in its plane.
+
+    Drawn in the 3D pass so ``blf`` is transformed by the plane's matrix and the
+    text tilts with it in perspective. Visibility mirrors the workplane gizmo:
+    only while the Add Sketch tool is active, and ``iter_wp_empties`` already
+    respects ``show_origin``. The glyph raster is sized to the label's on-screen
+    height so it stays crisp instead of being magnified; the text sits in the
+    plane's outer corner, uses the themed constraint-text color, is mirrored
+    when seen from behind so it never reads backwards, and skips the depth test
+    so it stays legible over geometry.
+    """
+    from .declarations import GizmoGroups
+    from .drawing import selection
+    from .utilities.workplane import (
+        ORIGIN_AXIS_COLOR,
+        ORIGIN_LABEL,
+        iter_wp_empties,
+        wp_plane_bounds,
+    )
+
+    context = bpy.context
+    region, rv3d = context.region, context.region_data
+    if region is None or rv3d is None:
+        return
+
+    tool = context.workspace.tools.from_space_view3d_mode(context.mode)
+    if tool is None or tool.widget != GizmoGroups.Workplane.value:
+        return
+
+    # Direction the view looks along, in world space, to detect back-facing text.
+    view_forward = rv3d.view_rotation @ Vector((0.0, 0.0, -1.0))
+
+    gpu.state.blend_set("ALPHA")
+    gpu.state.depth_test_set("NONE")
+
+    for wp_obj, pick_id in iter_wp_empties(context):
+        label = ORIGIN_LABEL.get(pick_id)
+        if not label:
+            continue
+
+        min_x, min_y, max_x, max_y = wp_plane_bounds(context, pick_id)
+        side = max_x - min_x
+        target_h = side * _LABEL_HEIGHT_FACTOR
+
+        plane_mat = wp_obj.matrix_world
+        up_world = plane_mat.to_3x3().col[1].normalized()
+        corner = plane_mat @ Vector((max_x, max_y, 0.0))
+
+        # Raster the glyphs at their on-screen pixel height so they stay sharp:
+        # magnifying a small raster into world space is what made them blurry.
+        s0 = location_3d_to_region_2d(region, rv3d, corner)
+        s1 = location_3d_to_region_2d(region, rv3d, corner + up_world * target_h)
+        if s0 is None or s1 is None:  # behind the view plane
+            continue
+        blf.size(_FONT_ID, max(8, min(round((s1 - s0).length), 256)))
+
+        w, h = blf.dimensions(_FONT_ID, label)
+        if h <= 0.0:
+            continue
+        scale = target_h / h
+
+        # Anchor the text box's outer corner a margin in from the plane's outer
+        # corner, so it reads as a corner label rather than filling the plane.
+        margin = side * _LABEL_CORNER_MARGIN
+        box_cx = max_x - margin - (w * scale) / 2
+        box_cy = max_y - margin - (h * scale) / 2
+
+        normal = plane_mat.to_3x3().col[2].normalized()
+        # Flip in-plane X when looking at the plane's back so the glyphs read
+        # left-to-right from the viewer's side instead of mirrored.
+        sx = -1.0 if normal.dot(view_forward) > 0.0 else 1.0
+
+        # Right-to-left: center the glyph box, mirror if needed, scale to world,
+        # move to the corner anchor, then into the plane's frame.
+        mat = (
+            plane_mat
+            @ Matrix.Translation((box_cx, box_cy, 0.0))
+            @ Matrix.Scale(scale, 4)
+            @ Matrix.Diagonal((sx, 1.0, 1.0, 1.0))
+            @ Matrix.Translation((-w / 2, -h / 2, 0.0))
+        )
+
+        # Axis-tinted, lightened toward white so the text reads a bit softer
+        # than the plane fill, brighter still while hovered.
+        axis = ORIGIN_AXIS_COLOR[pick_id]
+        lift = 0.55 if selection.hover == pick_id else 0.35
+        color = tuple(c + (1.0 - c) * lift for c in axis) + (1.0,)
+        blf.color(_FONT_ID, *color)
+
+        with gpu.matrix.push_pop():
+            gpu.matrix.multiply_matrix(mat)
+            blf.position(_FONT_ID, 0.0, 0.0, 0.0)
+            blf.draw(_FONT_ID, label)
+
+    gpu.state.depth_test_set("LESS_EQUAL")
+    gpu.state.blend_set("NONE")
+
+
 class View3D_OT_slvs_register_draw_cb(Operator):
     bl_idname = Operators.RegisterDrawCB
     bl_label = "Register Draw Callback"
 
     def execute(self, context: Context):
         from .drawing import constraint_icons
+
         global_data.draw_handle = bpy.types.SpaceView3D.draw_handler_add(
             draw_cb, (), "WINDOW", "POST_VIEW"
         )
@@ -174,6 +292,10 @@ class View3D_OT_slvs_register_draw_cb(Operator):
         # Constraint icons draw in screen space, batched from one atlas.
         global_data.icon_draw_handle = bpy.types.SpaceView3D.draw_handler_add(
             constraint_icons.draw, (), "WINDOW", "POST_PIXEL"
+        )
+        # Origin-plane labels are drawn in the plane, so they need the 3D pass.
+        global_data.origin_label_draw_handle = bpy.types.SpaceView3D.draw_handler_add(
+            draw_origin_labels, (), "WINDOW", "POST_VIEW"
         )
 
         return {"FINISHED"}
@@ -195,6 +317,11 @@ class View3D_OT_slvs_unregister_draw_cb(Operator):
                 global_data.icon_draw_handle, "WINDOW"
             )
             global_data.icon_draw_handle = None
+        if getattr(global_data, "origin_label_draw_handle", None) is not None:
+            bpy.types.SpaceView3D.draw_handler_remove(
+                global_data.origin_label_draw_handle, "WINDOW"
+            )
+            global_data.origin_label_draw_handle = None
         return {"FINISHED"}
 
 

--- a/gizmos/workplane.py
+++ b/gizmos/workplane.py
@@ -12,25 +12,12 @@ from ..utilities import preferences
 from ..utilities.geometry import face_bounds_in_plane, face_workplane_matrix
 from ..utilities.preferences import get_prefs
 from ..utilities.workplane import (
-    WP_ID_XY,
-    WP_ID_XZ,
-    WP_ID_YZ,
+    ORIGIN_AXIS_COLOR,
     iter_wp_empties,
     resolve_sketch_base,
     wp_plane_bounds,
 )
 from .utilities import context_mode_check
-
-# Blender-style axis colors used to tint the origin planes by their normal
-# (XY -> Z/blue, XZ -> Y/green, YZ -> X/red).
-_AXIS_X = (0.80, 0.24, 0.24)
-_AXIS_Y = (0.34, 0.67, 0.20)
-_AXIS_Z = (0.22, 0.40, 0.80)
-_ORIGIN_AXIS_COLOR = {
-    WP_ID_XY: _AXIS_Z,
-    WP_ID_XZ: _AXIS_Y,
-    WP_ID_YZ: _AXIS_X,
-}
 
 
 class VIEW3D_GGT_slvs_workplane(GizmoGroup):
@@ -88,7 +75,7 @@ class VIEW3D_GT_slvs_workplane(Gizmo):
         Origin planes are tinted by their normal axis; other planes keep the
         themed default/highlight look.
         """
-        axis = _ORIGIN_AXIS_COLOR.get(pick_id)
+        axis = ORIGIN_AXIS_COLOR.get(pick_id)
         if axis is None:
             return tuple(ts.highlight) if is_hovered else (*ts.default[:3], 0.3)
         if is_hovered:
@@ -154,7 +141,9 @@ class VIEW3D_GT_slvs_workplane(Gizmo):
             is_hovered = selection.hover == pick_id
             col = self._plane_color(pick_id, is_hovered, ts)
             bounds = wp_plane_bounds(context, pick_id)
-            self._draw_rect(context, wp_obj.matrix_world, bounds, scale, col, is_hovered)
+            self._draw_rect(
+                context, wp_obj.matrix_world, bounds, scale, col, is_hovered
+            )
 
         # Preview the workplane a hovered mesh face would create, sized to the
         # face's bounding box plus a margin.
@@ -169,9 +158,15 @@ class VIEW3D_GT_slvs_workplane(Gizmo):
                     bounds = None
                 if bounds is not None:
                     min_x, min_y, max_x, max_y = bounds
-                    margin = max(max_x - min_x, max_y - min_y) * self.FACE_PREVIEW_MARGIN
-                    bounds = (min_x - margin, min_y - margin,
-                              max_x + margin, max_y + margin)
+                    margin = (
+                        max(max_x - min_x, max_y - min_y) * self.FACE_PREVIEW_MARGIN
+                    )
+                    bounds = (
+                        min_x - margin,
+                        min_y - margin,
+                        max_x + margin,
+                        max_y + margin,
+                    )
                     self._draw_rect(context, mat, bounds, scale, ts.highlight, True)
 
     def test_select(self, context, location):

--- a/global_data.py
+++ b/global_data.py
@@ -37,6 +37,7 @@ Z_AXIS = Vector((0, 0, 1))
 draw_handle = None
 hover_draw_handle = None
 icon_draw_handle = None
+origin_label_draw_handle = None
 
 COPY_BUFFER = {}
 
@@ -59,8 +60,8 @@ solver_state_items = [
         "INCONSISTENT",
         "Inconsistent",
         (
-            f"Cannot solve sketch because of inconsistent constraints, check through the failed constraints "
-            f"and remove the ones that contradict each other."
+            "Cannot solve sketch because of inconsistent constraints, check through the failed constraints "
+            "and remove the ones that contradict each other."
         ),
         "ERROR",
         1,  # SLVS_RESULT_INCONSISTENT
@@ -83,8 +84,8 @@ solver_state_items = [
         "REDUNDANT_OK",
         "Redundant Constraints",
         (
-            f"Some constraints seem to be redundant, this might cause an error once the constraints are no longer consistent. "
-            f"Check through the marked constraints and only keep what's necessary."
+            "Some constraints seem to be redundant, this might cause an error once the constraints are no longer consistent. "
+            "Check through the marked constraints and only keep what's necessary."
         ),
         "INFO",
         4,  # SLVS_RESULT_REDUNDANT_OK

--- a/operators/add_sketch.py
+++ b/operators/add_sketch.py
@@ -15,6 +15,43 @@ from .utilities import activate_sketch
 logger = logging.getLogger(__name__)
 
 
+def create_sketch_on_workplane(context: Context, wp_empty, operator: Operator):
+    """Create and activate a Curves sketch parented to ``wp_empty``.
+
+    Shared by the interactive Add Sketch operator and the direct
+    keyboard-driven origin-plane operator so both build the sketch identically.
+    Returns the wrapped :class:`Sketch`.
+    """
+    from ..model.sketch_ref import Sketch, stamp_sketch_props
+    from ..utilities.curve_data import _ensure_convert_modifier
+
+    # Create sketch as a Curves object (parent provides the transform)
+    curve = bpy.data.hair_curves.new("Sketch")
+    sketch_obj = bpy.data.objects.new("Sketch", curve)
+
+    scene = context.scene
+    if sketch_obj.name not in scene.collection.objects:
+        scene.collection.objects.link(sketch_obj)
+
+    stamp_sketch_props(sketch_obj)
+    _ensure_convert_modifier(sketch_obj)
+
+    # Parent to workplane empty (before activate so align_view works)
+    wp_orig = wp_empty.original if hasattr(wp_empty, "original") else wp_empty
+    sketch_obj.parent = wp_orig
+    sketch_obj.lock_location = (True, True, True)
+    sketch_obj.lock_rotation = (True, True, True)
+    sketch_obj.lock_scale = (True, True, True)
+
+    sketch = Sketch(sketch_obj)
+
+    origin = PointRef.create(sketch, (0.0, 0.0), fixed=True)
+    assert origin is not None, "Failed to create origin point"
+
+    activate_sketch(context, sketch_obj, operator)
+    return sketch
+
+
 # TODO:
 # - Draw sketches
 class View3D_OT_slvs_add_sketch(Operator, Operator3d):
@@ -24,7 +61,10 @@ class View3D_OT_slvs_add_sketch(Operator, Operator3d):
     bl_label = "Add Sketch"
     bl_options = {"UNDO"}
 
-    sketch_state1_doc = ["Workplane", "Pick a workplane or mesh face as base for the sketch."]
+    sketch_state1_doc = [
+        "Workplane",
+        "Pick a workplane or mesh face as base for the sketch.",
+    ]
 
     states = (
         state_from_args(
@@ -38,7 +78,7 @@ class View3D_OT_slvs_add_sketch(Operator, Operator3d):
     )
 
     def gather_selection(self, context):
-        return [o for o in context.selected_objects if o.type == 'EMPTY']
+        return [o for o in context.selected_objects if o.type == "EMPTY"]
 
     def _use_workplane(self, empty):
         self.state_data["is_existing_entity"] = True
@@ -72,7 +112,7 @@ class View3D_OT_slvs_add_sketch(Operator, Operator3d):
         from ..utilities.face_anchor import stamp_face_anchor
 
         empty = bpy.data.objects.new("Workplane", None)
-        empty.empty_display_type = 'PLAIN_AXES'
+        empty.empty_display_type = "PLAIN_AXES"
         empty.empty_display_size = 0.5
         context.scene.collection.objects.link(empty)
 
@@ -117,45 +157,12 @@ class View3D_OT_slvs_add_sketch(Operator, Operator3d):
         return True
 
     def main(self, context: Context):
-        from ..model.sketch_ref import Sketch
-
         wp_empty = self.wp
-        if not wp_empty or wp_empty.type != 'EMPTY':
-            self.report({'WARNING'}, "Please select an Empty as workplane")
+        if not wp_empty or wp_empty.type != "EMPTY":
+            self.report({"WARNING"}, "Please select an Empty as workplane")
             return False
 
-        # Create sketch as a Curves object (parent provides the transform)
-        curve = bpy.data.hair_curves.new("Sketch")
-        sketch_obj = bpy.data.objects.new("Sketch", curve)
-
-        scene = context.scene
-        if sketch_obj.name not in scene.collection.objects:
-            scene.collection.objects.link(sketch_obj)
-
-        # Stamp sketch custom properties
-        from ..model.sketch_ref import stamp_sketch_props
-        stamp_sketch_props(sketch_obj)
-
-        # Add GN modifier
-        from ..utilities.curve_data import _ensure_convert_modifier
-        _ensure_convert_modifier(sketch_obj)
-
-        # Parent to workplane empty (before activate so align_view works)
-        wp_orig = wp_empty.original if hasattr(wp_empty, 'original') else wp_empty
-        sketch_obj.parent = wp_orig
-        sketch_obj.lock_location = (True, True, True)
-        sketch_obj.lock_rotation = (True, True, True)
-        sketch_obj.lock_scale = (True, True, True)
-
-        # Wrap as Sketch accessor
-        sketch = Sketch(sketch_obj)
-
-        # Add origin point
-        origin = PointRef.create(sketch, (0.0, 0.0), fixed=True)
-        assert origin is not None, "Failed to create origin point"
-
-        activate_sketch(context, sketch_obj, self)
-        self.target = sketch
+        self.target = create_sketch_on_workplane(context, wp_empty, self)
         return True
 
     def fini(self, context: Context, succeed: bool):
@@ -166,4 +173,55 @@ class View3D_OT_slvs_add_sketch(Operator, Operator3d):
             logger.debug("Add: {}".format(self.target))
 
 
-register, unregister = register_stateops_factory((View3D_OT_slvs_add_sketch,))
+class View3D_OT_slvs_add_sketch_on_plane(Operator):
+    """Create a sketch on an origin workplane by its normal axis.
+
+    Bound to X/Y/Z on the Add Sketch tool so a plane can be chosen directly,
+    without aiming at its (possibly edge-on) rectangle.
+    """
+
+    bl_idname = Operators.AddSketchOnPlane
+    bl_label = "Add Sketch on Origin Plane"
+    bl_options = {"REGISTER", "UNDO"}
+
+    # Value is the origin plane; the key is the axis normal to it (what the user
+    # presses): Z -> XY, Y -> XZ, X -> YZ.
+    plane: bpy.props.EnumProperty(
+        name="Plane",
+        items=(
+            ("XY", "XY", "Ground plane (normal Z)"),
+            ("XZ", "XZ", "Front plane (normal Y)"),
+            ("YZ", "YZ", "Side plane (normal X)"),
+        ),
+        default="XY",
+    )
+
+    def execute(self, context: Context):
+        ensure_origin_workplane_empties(context)
+        sketcher = context.scene.sketcher
+        empty = {
+            "XY": sketcher.wp_xy,
+            "XZ": sketcher.wp_xz,
+            "YZ": sketcher.wp_yz,
+        }[self.plane]
+        if empty is None:
+            self.report({"WARNING"}, "Origin workplane not available")
+            return {"CANCELLED"}
+
+        create_sketch_on_workplane(context, empty, self)
+        return {"FINISHED"}
+
+
+_register_stateops, _unregister_stateops = register_stateops_factory(
+    (View3D_OT_slvs_add_sketch,)
+)
+
+
+def register():
+    bpy.utils.register_class(View3D_OT_slvs_add_sketch_on_plane)
+    _register_stateops()
+
+
+def unregister():
+    _unregister_stateops()
+    bpy.utils.unregister_class(View3D_OT_slvs_add_sketch_on_plane)

--- a/utilities/workplane.py
+++ b/utilities/workplane.py
@@ -13,6 +13,22 @@ WP_ID_XY = 0xF00001
 WP_ID_XZ = 0xF00002
 WP_ID_YZ = 0xF00003
 
+# Blender-style axis colors used to tint each origin plane by its normal
+# (XY -> Z/blue, XZ -> Y/green, YZ -> X/red) and the short label drawn on it.
+_AXIS_X = (0.80, 0.24, 0.24)
+_AXIS_Y = (0.34, 0.67, 0.20)
+_AXIS_Z = (0.22, 0.40, 0.80)
+ORIGIN_AXIS_COLOR = {
+    WP_ID_XY: _AXIS_Z,
+    WP_ID_XZ: _AXIS_Y,
+    WP_ID_YZ: _AXIS_X,
+}
+ORIGIN_LABEL = {
+    WP_ID_XY: "XY",
+    WP_ID_XZ: "XZ",
+    WP_ID_YZ: "YZ",
+}
+
 # Sequential pick IDs for non-origin empties start here
 _EMPTY_PICK_START = 0xE00001
 
@@ -39,6 +55,7 @@ def get_workplane_empty_by_id(wp_id):
 # ---------------------------------------------------------------------------
 # Drawable workplane enumeration, sizing and picking
 # ---------------------------------------------------------------------------
+
 
 def iter_wp_empties(context):
     """Yield (empty_obj, pick_id) for all drawable workplane empties.
@@ -68,7 +85,7 @@ def iter_wp_empties(context):
         # visible_get() covers the eye-icon hide and collection visibility too,
         # not just hide_viewport (the monitor icon) -- an empty hidden with the
         # eye was still getting its workplane overlay drawn.
-        if obj.type != 'EMPTY' or obj.name in origin_names or not obj.visible_get():
+        if obj.type != "EMPTY" or obj.name in origin_names or not obj.visible_get():
             continue
         yield obj, pick_id
         pick_id += 1
@@ -191,6 +208,7 @@ def resolve_sketch_base(context, coords):
 # Workplane empty creation
 # ---------------------------------------------------------------------------
 
+
 def ensure_workplane_empty(sketch):
     """Ensure the sketch has a workplane empty object.
 
@@ -202,12 +220,12 @@ def ensure_workplane_empty(sketch):
     if sketch.workplane_object:
         return sketch.workplane_object
 
-    if not hasattr(sketch, 'wp') or not sketch.wp:
+    if not hasattr(sketch, "wp") or not sketch.wp:
         return None
 
     name = f"WP_{sketch.name}"
     empty = bpy.data.objects.new(name, None)
-    empty.empty_display_type = 'SINGLE_ARROW'
+    empty.empty_display_type = "SINGLE_ARROW"
     empty.hide_viewport = True
     empty.lock_location = (True, True, True)
     empty.lock_rotation = (True, True, True)
@@ -236,6 +254,7 @@ def _matrix_differs(a, b, eps=1e-6):
 
 def _target_matrix(euler_tuple):
     from mathutils import Euler
+
     return Euler(euler_tuple).to_matrix().to_4x4()
 
 
@@ -278,7 +297,7 @@ def ensure_origin_workplane_empties(context):
             continue
 
         empty = bpy.data.objects.new(name, None)
-        empty.empty_display_type = 'SINGLE_ARROW'
+        empty.empty_display_type = "SINGLE_ARROW"
         empty.matrix_world = _target_matrix(euler_tuple)
         empty.hide_viewport = True
         empty.lock_location = (True, True, True)

--- a/workspacetools/add_sketch.py
+++ b/workspacetools/add_sketch.py
@@ -15,11 +15,26 @@ class VIEW3D_T_slvs_add_sketch(GenericStateTool, WorkSpaceTool):
     bl_icon = "ops.mesh.primitive_grid_add_gizmo"
     bl_widget = GizmoGroups.Workplane
     bl_keymap = (
+        # Direct origin-plane pick by the axis normal to the plane: Z -> XY,
+        # Y -> XZ, X -> YZ (tool-scoped, so it only shadows those keys here).
+        (
+            Operators.AddSketchOnPlane,
+            {"type": "Z", "value": "PRESS"},
+            {"properties": [("plane", "XY")]},
+        ),
+        (
+            Operators.AddSketchOnPlane,
+            {"type": "Y", "value": "PRESS"},
+            {"properties": [("plane", "XZ")]},
+        ),
+        (
+            Operators.AddSketchOnPlane,
+            {"type": "X", "value": "PRESS"},
+            {"properties": [("plane", "YZ")]},
+        ),
         *tool_node,
         *operator_access(Operators.AddSketch),
     )
 
     def draw_settings(context, layout, tool):
-        layout.prop(
-            context.scene.sketcher, "show_origin", text="Origin Workplanes"
-        )
+        layout.prop(context.scene.sketcher, "show_origin", text="Origin Workplanes")


### PR DESCRIPTION
Two improvements to the Add Sketch origin-workplane step:

- Label each origin plane with XY/XZ/YZ, drawn in the plane so it tilts with the view. The glyph raster is sized to its on-screen height so it stays sharp, sits in the plane's outer corner, uses the axis color lightened toward white, and is mirrored when seen from behind so it never reads backwards.
- Add X/Y/Z hotkeys (tool-scoped) to create a sketch directly on an origin plane by the axis normal to it: Z for XY, Y for XZ, X for YZ. This avoids having to aim at a plane rectangle that may be edge-on. Both the hotkey and the interactive pick share one sketch-creation helper.

Labels only show while the Add Sketch tool is active and the Origin Workplanes toggle is on.