### PR TITLE
Fix sketch reporting fully defined after dragging

### DIFF
--- a/curve_solver.py
+++ b/curve_solver.py
@@ -540,7 +540,13 @@ class CurveSolver:
             self.result = bpyEnum(solver_state_items, index=result_code)
 
         self.sketch.solver_state = self.result.identifier
-        self.sketch.dof = retval.get("dof", 0)
+        # A tweak solve augments the system with a temporary dragged/coincident
+        # pin (see _init_geometry), so its reported dof is ~2 lower than the
+        # sketch's real dof. Dragging doesn't change the true dof, so don't
+        # publish the tweak value (it would read as "fully defined" after a
+        # drag); the tweak operator does a clean re-solve on release.
+        if self._tweak_curve_id is None:
+            self.sketch.dof = retval.get("dof", 0)
 
         if self.ok:
             self._write_results()

--- a/operators/tweak.py
+++ b/operators/tweak.py
@@ -3,7 +3,7 @@ from bpy.types import Context, Event, Operator
 from bpy.utils import register_classes_factory
 
 from .. import global_data
-from ..curve_solver import CurveSolver
+from ..curve_solver import CurveSolver, solve_system
 from ..declarations import Operators
 from ..drawing import selection
 from ..drawing.snap import draw_snap_marker
@@ -107,6 +107,10 @@ class View3D_OT_slvs_tweak(Operator):
                 and get_curve_type(self.sketch, self.curve_id) == SketchCurveType.POINT
             ):
                 PointRef(self.sketch, self.curve_id).fixed = True
+            # Clean re-solve without the drag pin so the published dof/state
+            # reflect the real system again (per-frame tweak solves don't publish
+            # dof, and a drag-onto-snap above just changed the true dof).
+            solve_system(context, sketch=self.sketch)
             # Topology rebuild to trigger GN modifier refresh
             refresh_curve_geometry(self.sketch)
             self._remove_snap_marker()

--- a/testing/test_tweak_stability.py
+++ b/testing/test_tweak_stability.py
@@ -179,3 +179,27 @@ class TestTweakStability(Sketch2dTestCase, TweakStabilityMixin):
         solver.solve()
         print(f"[tweak-stability] fully_defined_drag: state={self.sketch.solver_state}")
         self.assertNotEqual(self.sketch.solver_state, "INCONSISTENT")
+
+    def test_drag_does_not_over_report_dof(self):
+        """A drag must not make an under-constrained sketch read 'fully defined'.
+
+        The per-frame tweak solve pins the dragged point with a temporary
+        dragged/coincident constraint, so that system's dof is ~2 below the real
+        one. Publishing it left ``sketch.dof`` at 0 after dragging a free point,
+        showing "Fully defined sketch" for a clearly under-defined sketch. The
+        true dof must survive a drag unchanged.
+        """
+        p0 = self.add_point((0.0, 0.0), fixed=True)
+        p1 = self.add_point((3.0, 0.0))  # free: 2 dof
+        self.add_line(p0, p1)
+        self.solve()
+        self.assertEqual(self.sketch.dof, 2)
+
+        solver = CurveSolver(self.context, self.sketch)
+        solver.tweak(p1.curve_id, Vector((4.0, 1.0, 0.0)))
+        solver.solve()
+        self.assertEqual(
+            self.sketch.dof,
+            2,
+            "dragging pins nothing permanently; reported dof must not drop",
+        )


### PR DESCRIPTION
Dragging a point in an under-constrained sketch made the Sketcher panel report "Fully defined sketch", even though the geometry was clearly free.

## Cause

Each drag frame builds a CurveSolver, calls tweak(), and solve(). The tweak augments the system with a temporary dragged + coincident pin (in _init_geometry) to pull the point to the cursor, which removes about 2 DOF. solve() published that augmented system's dof straight to sketch.dof, so the value was ~2 too low, and there was no clean re-solve on release to correct it. That is why it only misbehaved after dragging: creation, refresh and update all solve the real system.

## Fix

1. A tweak solve no longer publishes dof (a drag does not change the true DOF), so solve() only writes sketch.dof when not tweaking. This also removes the flicker during the drag.
2. On mouse release the tweak operator does a clean solve_system() without the drag pin, which republishes the true dof/state. This also covers the drag-onto-snap case where release flips a point to fixed and the real DOF genuinely changes.

## Tests

New regression test test_drag_does_not_over_report_dof drives the exact per-frame solver path the operator uses: a free point + fixed point + line (dof 2); after a tweak solve it asserts dof is still 2. Confirmed it fails on the unfixed code (0 != 2) and passes with the fix. Full suite: 229 passed, expected failures 2.