### PR TITLE
Live-project mesh vertex, edge-midpoint and edge snaps instead of static points

### DIFF
--- a/model/group_sketcher.py
+++ b/model/group_sketcher.py
@@ -64,6 +64,17 @@ class SketcherProps(PropertyGroup):
         options={"SKIP_SAVE"},
         update=update_cb,
     )
+    use_snap_project: BoolProperty(
+        name="Live Project Snaps",
+        description=(
+            "When snapping a point onto external mesh geometry, project the "
+            "snapped element into the sketch as a live reference and link the "
+            "point to it, instead of placing a dead static point"
+        ),
+        default=True,
+        options={"SKIP_SAVE"},
+        update=update_cb,
+    )
     version: IntVectorProperty(
         name="Extension Version",
         description="CAD Sketcher extension version this scene was saved with",
@@ -96,9 +107,8 @@ class SketcherProps(PropertyGroup):
         scene = self.id_data
         key = f"{_EP_PREFIX}{uid}"
         if key not in scene:
-            if (
-                hasattr(constraint, "value_store")
-                and constraint.is_property_set("value_store")
+            if hasattr(constraint, "value_store") and constraint.is_property_set(
+                "value_store"
             ):
                 init_value = float(constraint.value_store)
             elif hasattr(constraint, "value") and constraint.is_property_set("value"):
@@ -110,7 +120,9 @@ class SketcherProps(PropertyGroup):
             try:
                 rna_prop = type(constraint).bl_rna.properties.get("value_store")
                 subtype = rna_prop.subtype if rna_prop else "NONE"
-                scene.id_properties_ui(key).update(subtype=subtype, min=0.0, soft_min=0.0)
+                scene.id_properties_ui(key).update(
+                    subtype=subtype, min=0.0, soft_min=0.0
+                )
             except Exception:
                 pass
         return key

--- a/operators/add_line_2d.py
+++ b/operators/add_line_2d.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 class View3D_OT_slvs_add_line2d(Operator, Operator2d):
     """Add a line to the active sketch"""
-    
+
     bl_idname = Operators.AddLine2D
     bl_label = "Add Solvespace 2D Line"
     bl_options = {"REGISTER", "UNDO"}
@@ -56,8 +56,13 @@ class View3D_OT_slvs_add_line2d(Operator, Operator2d):
         # auto vertical/horizontal constraint. Skip it when both endpoints are
         # anchored (e.g. both snapped to external geometry): the alignment can't
         # move either point, so adding it would just make the sketch inconsistent.
+        # An endpoint counts as anchored if it is fixed, or if it was live-projected
+        # onto a fixed vertex/midpoint (coincident to a fixed point -> immovable,
+        # even though the endpoint itself is not flagged fixed).
         self.has_alignment = False
-        both_fixed = self.target.p1.fixed and self.target.p2.fixed
+        p1_anchored = self.target.p1.fixed or self.point_is_anchored(0)
+        p2_anchored = self.target.p2.fixed or self.point_is_anchored(1)
+        both_fixed = p1_anchored and p2_anchored
         vec_dir = self.target.direction_vec()
         if vec_dir.length and self.use_auto_constraints(context) and not both_fixed:
             angle = vec_dir.angle(Vector((1, 0)))

--- a/operators/add_point_2d.py
+++ b/operators/add_point_2d.py
@@ -34,23 +34,29 @@ class View3D_OT_slvs_add_point2d(Operator, Operator2d):
     )
 
     def main(self, context: Context):
+        from ..model.curve_ref import curve_ref
+
         sketch = self.sketch
         construction = context.scene.sketcher.use_construction
         state_data = self.state_data
 
-        # Snapped onto external mesh geometry: live-project it and coincide so the
-        # point tracks the source (same path the pointer tools take in
-        # create_element). This is a plain coordinate state, so it never runs
-        # create_element -- do the link here or Add Point would only ever snap
-        # statically.
-        self._maybe_link_projected_snap(context, state_data)
-
-        # Fall back to an existing sketch entity under the cursor when the snap
-        # did not live-project onto external geometry.
-        if not state_data.get("hovered"):
-            hovered = selection.hover
-            if hovered and self._check_constrain(context, hovered):
-                state_data["hovered"] = hovered
+        # Entity picking wins over geometry snapping. Add Point is a coordinate
+        # state with no pick_element, so re-derive the hovered sketch entity each
+        # call: a pickable entity under the cursor (a point, an already-projected
+        # reference, or a constrainable curve) is preferred to projecting the mesh
+        # behind it. Only when nothing is pickable do we live-project the snap.
+        picked = selection.hover
+        ref = curve_ref(sketch, picked) if picked else None
+        if ref is not None and ref.valid:
+            state_data["hovered"] = picked
+            state_data["snap_link_kind"] = "COINCIDENT"
+            # A projected reference forces its link (bypasses Auto Constraints); a
+            # plain pick respects the toggle. Anchored only if the target is fixed.
+            state_data["snap_projected"] = self._is_projected_reference(picked)
+            state_data["snap_anchored"] = bool(getattr(ref, "fixed", False))
+        else:
+            state_data["hovered"] = ""
+            self._maybe_link_projected_snap(context, state_data)
 
         # A point snapped to external geometry is fixed to hold it there; one
         # pinned by a coincident constraint (sketch entity or projected ref) is

--- a/operators/add_point_2d.py
+++ b/operators/add_point_2d.py
@@ -1,14 +1,14 @@
 import logging
 
-from bpy.types import Operator, Context
 from bpy.props import FloatVectorProperty
+from bpy.types import Context, Operator
 
-from ..drawing import selection
-from ..declarations import Operators
-from ..stateful_operator.utilities.register import register_stateops_factory
-from ..stateful_operator.state import state_from_args
 from ..curve_solver import solve_system
+from ..declarations import Operators
+from ..drawing import selection
 from ..model.curve_ref import PointRef
+from ..stateful_operator.state import state_from_args
+from ..stateful_operator.utilities.register import register_stateops_factory
 from .base_2d import Operator2d
 
 logger = logging.getLogger(__name__)
@@ -36,15 +36,32 @@ class View3D_OT_slvs_add_point2d(Operator, Operator2d):
     def main(self, context: Context):
         sketch = self.sketch
         construction = context.scene.sketcher.use_construction
+        state_data = self.state_data
 
-        self.target = PointRef.create(sketch, self.coordinates, construction=construction)
+        # Snapped onto external mesh geometry: live-project it and coincide so the
+        # point tracks the source (same path the pointer tools take in
+        # create_element). This is a plain coordinate state, so it never runs
+        # create_element -- do the link here or Add Point would only ever snap
+        # statically.
+        self._maybe_link_projected_snap(context, state_data)
 
-        # Store hovered curve_id for auto-coincident
-        hovered = selection.hover
-        if hovered and self._check_constrain(context, hovered):
-            self.state_data["hovered"] = hovered
+        # Fall back to an existing sketch entity under the cursor when the snap
+        # did not live-project onto external geometry.
+        if not state_data.get("hovered"):
+            hovered = selection.hover
+            if hovered and self._check_constrain(context, hovered):
+                state_data["hovered"] = hovered
 
-        self.add_coincident(context, self.target, self.state, self.state_data)
+        # A point snapped to external geometry is fixed to hold it there; one
+        # pinned by a coincident constraint (sketch entity or projected ref) is
+        # not, so the constraint drives it.
+        fixed = state_data.get("snapped", False) and not state_data.get("hovered")
+
+        self.target = PointRef.create(
+            sketch, self.coordinates, construction=construction, fixed=fixed
+        )
+
+        self.add_coincident(context, self.target, self.state, state_data)
         return True
 
     def fini(self, context: Context, succeede: bool):

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -167,11 +167,11 @@ class Operator2d(GenericEntityOp):
         Other snap types, and cases where the snapped feature can't be traced to an
         original one, fall back to the static point.
         """
-        if not context.scene.sketcher.use_snap_project:
-            state_data["snap_anchored"] = False
-            state_data["snap_link_kind"] = "COINCIDENT"
-            return
-        if not self.use_auto_constraints(context, state_data):
+        # Live-snap has its own toggle and does NOT depend on "Auto Constraints";
+        # only the per-placement Shift bypass still opts out (place it raw).
+        if not context.scene.sketcher.use_snap_project or state_data.get(
+            "skip_auto_constraints"
+        ):
             state_data["snap_anchored"] = False
             state_data["snap_link_kind"] = "COINCIDENT"
             return

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -233,6 +233,23 @@ class Operator2d(GenericEntityOp):
 
         if projected is not None and projected.valid:
             state_data["hovered"] = projected.curve_id
+            # A vertex/midpoint projection pins the endpoint to a FIXED point, so
+            # it can't move; an auto axis-alignment on such an endpoint would fight
+            # the fixed position (inconsistent when the features aren't exactly
+            # aligned). Flag it so the line tool skips alignment, same as it does
+            # for two statically-fixed endpoints. An edge projection is point-on-
+            # line (the endpoint can still slide), so it is not flagged.
+            if snap_type in ("VERTEX", "EDGE_MIDPOINT"):
+                state_data["snap_anchored"] = True
+
+    def point_is_anchored(self, index: int) -> bool:
+        """Whether the point placed for state ``index`` is pinned in place.
+
+        True when the endpoint is a live-projected vertex/midpoint (coincident to a
+        FIXED projected point) -- an auto axis-alignment on it would fight the fixed
+        position. Used by tools that add alignment constraints to skip it.
+        """
+        return bool(self._state_data.get(index, {}).get("snap_anchored", False))
 
     # create element depending on mode
     def create_element(self, context: Context, values: List[Any], state, state_data):

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -228,8 +228,15 @@ class Operator2d(GenericEntityOp):
             construction=True,
             world_co=snap.get("world_point"),
         )
+        _dbg(
+            "SNAPPROJ project_mesh_vertex -> %r valid=%r curve_id=%r",
+            projected,
+            getattr(projected, "valid", None),
+            getattr(projected, "curve_id", None),
+        )
         if projected is not None and projected.valid:
             state_data["hovered"] = projected.curve_id
+            _dbg("SNAPPROJ set hovered=%r", state_data["hovered"])
 
     # create element depending on mode
     def create_element(self, context: Context, values: List[Any], state, state_data):
@@ -247,10 +254,23 @@ class Operator2d(GenericEntityOp):
         # below instead, so skip those.
         fixed = state_data.get("snapped", False) and not state_data.get("hovered")
 
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "SNAPPROJ create_element fixed=%r hovered=%r snapped=%r",
+            fixed,
+            state_data.get("hovered"),
+            state_data.get("snapped"),
+        )
+
         ref = PointRef.create(sketch, loc, fixed=fixed)
         cid = ref.curve_id
 
         self.add_coincident(context, ref, state, state_data)
+        logging.getLogger(__name__).warning(
+            "SNAPPROJ create_element post add_coincident coincident=%r",
+            state_data.get("coincident"),
+        )
 
         ignore_hover(cid)
         state_data["type"] = PointRef

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -158,7 +158,8 @@ class Operator2d(GenericEntityOp):
         (or reuse) a live projected reference for that vertex and set it as the
         coincidence target, so the placed point tracks the source instead of
         being a dead static point. Scoped to mesh vertices; edges/curves and the
-        topology-changing-modifier case fall back to the static point.
+        case where the snapped vertex can't be traced to an original one fall
+        back to the static point.
         """
         if not context.scene.sketcher.use_snap_project:
             return
@@ -178,18 +179,29 @@ class Operator2d(GenericEntityOp):
         if source is None or source.type != "MESH":
             return
 
-        # Snapping reads the evaluated mesh; a topology-changing modifier makes
-        # its vertex index not line up with the original vertex we would bind, so
-        # skip projection then rather than link the wrong vertex.
+        # Snapping reads the evaluated mesh; resolve that evaluated vertex back to
+        # the original one to bind (by persistent id when tagged, else an
+        # order-preserving index). Skip when the correspondence isn't trustworthy.
         from ..stateful_operator.utilities.geometry import get_evaluated_obj
+        from ..utilities.projection_anchor import (
+            project_mesh_vertex,
+            resolve_source_vertex_index,
+        )
 
-        eval_mesh = get_evaluated_obj(context, source).data
-        if len(eval_mesh.vertices) != len(source.data.vertices):
+        eval_source = get_evaluated_obj(context, source)
+        orig_index = resolve_source_vertex_index(source, eval_source, v_index)
+        if orig_index is None:
             return
 
-        from ..utilities.projection_anchor import project_mesh_vertex
-
-        projected = project_mesh_vertex(self.sketch, source, v_index, construction=True)
+        # Place the point where the user snapped (the evaluated hit), so a
+        # vertex-moving modifier doesn't leave it a frame behind the source.
+        projected = project_mesh_vertex(
+            self.sketch,
+            source,
+            orig_index,
+            construction=True,
+            world_co=snap.get("world_point"),
+        )
         if projected is not None and projected.valid:
             state_data["hovered"] = projected.curve_id
 

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -88,6 +88,7 @@ class Operator2d(GenericEntityOp):
 
     def init(self, context: Context, event: Event):
         from ..model.sketch_ref import get_active_sketch
+
         self._active_sketch = get_active_sketch(context)
         return True
 
@@ -97,6 +98,7 @@ class Operator2d(GenericEntityOp):
             import bpy
 
             from ..model.sketch_ref import get_active_sketch
+
             self._active_sketch = get_active_sketch(bpy.context)
         return self._active_sketch
 
@@ -119,6 +121,9 @@ class Operator2d(GenericEntityOp):
         # deferred creation can anchor it (fixed) — otherwise an inferred
         # constraint would drag the snapped point off target (see create_element).
         self.state_data["snapped"] = self._snap is not None
+        # Stash the snap target so create_element can live-project it (the marker
+        # reflects the current position; at click this is the committed one).
+        self.state_data["snap"] = self._snap
 
         # Handle implicit properties based on state.types
         if SlvsPoint2D in state.types:
@@ -146,14 +151,62 @@ class Operator2d(GenericEntityOp):
 
         return super().state_func(context, coords)
 
+    def _maybe_link_projected_snap(self, context: Context, state_data):
+        """Live-project the snapped mesh vertex and register it for coincidence.
+
+        Prototype: when a point is snapped onto an external mesh vertex, create
+        (or reuse) a live projected reference for that vertex and set it as the
+        coincidence target, so the placed point tracks the source instead of
+        being a dead static point. Scoped to mesh vertices; edges/curves and the
+        topology-changing-modifier case fall back to the static point.
+        """
+        if not context.scene.sketcher.use_snap_project:
+            return
+        if not self.use_auto_constraints(context, state_data):
+            return
+        if state_data.get("hovered"):
+            return  # already coinciding with an existing sketch entity
+
+        snap = state_data.get("snap")
+        if not snap or snap.get("type") != "VERTEX":
+            return
+        ob_name = snap.get("object")
+        v_index = snap.get("vertex_index")
+        if ob_name is None or v_index is None:
+            return
+        source = bpy.data.objects.get(ob_name)
+        if source is None or source.type != "MESH":
+            return
+
+        # Snapping reads the evaluated mesh; a topology-changing modifier makes
+        # its vertex index not line up with the original vertex we would bind, so
+        # skip projection then rather than link the wrong vertex.
+        from ..stateful_operator.utilities.geometry import get_evaluated_obj
+
+        eval_mesh = get_evaluated_obj(context, source).data
+        if len(eval_mesh.vertices) != len(source.data.vertices):
+            return
+
+        from ..utilities.projection_anchor import project_mesh_vertex
+
+        projected = project_mesh_vertex(self.sketch, source, v_index, construction=True)
+        if projected is not None and projected.valid:
+            state_data["hovered"] = projected.curve_id
+
     # create element depending on mode
     def create_element(self, context: Context, values: List[Any], state, state_data):
         sketch = self.sketch
         loc = values[0]
 
+        # Snapped onto external mesh geometry: live-project it and coincide, so
+        # the point tracks the source. Registers the projected point as the
+        # coincidence target below (behaves like snapping onto a sketch entity).
+        self._maybe_link_projected_snap(context, state_data)
+
         # A point snapped to external geometry is a deliberate placement: fix it
-        # so the solver keeps it there. Points snapped onto a sketch entity are
-        # pinned by the coincident constraint below instead, so skip those.
+        # so the solver keeps it there. Points snapped onto a sketch entity (or a
+        # live-projected reference above) are pinned by the coincident constraint
+        # below instead, so skip those.
         fixed = state_data.get("snapped", False) and not state_data.get("hovered")
 
         ref = PointRef.create(sketch, loc, fixed=fixed)
@@ -169,6 +222,7 @@ class Operator2d(GenericEntityOp):
     def _check_constrain(self, context: Context, curve_id: int):
         """Check if a hovered curve_id is a constrainable type (line/arc/circle)."""
         from ..model.curve_ref import ArcRef, CircleRef, LineRef
+
         sketch = self.sketch
         if not sketch:
             return False
@@ -195,5 +249,3 @@ class Operator2d(GenericEntityOp):
         if cid:
             return PointRef(sketch, cid)
         return getattr(self, state.pointer)
-
-

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -117,19 +117,6 @@ class Operator2d(GenericEntityOp):
         self._snap = get_blender_snap_info(context, coords)
         pos = get_pos_2d(context, wp, coords, respect_snapping=True)
 
-        # TEMP diagnostic: what does Blender's snapping actually hand us as the
-        # cursor moves? Only logs when a snap is present, so it stays quiet over
-        # empty space. Strip once the live-project-on-snap issue is diagnosed.
-        if self._snap is not None:
-            import logging
-
-            logging.getLogger(__name__).warning(
-                "SNAPPROJ state_func snap type=%r object=%r vertex_index=%r",
-                self._snap.get("type"),
-                self._snap.get("object"),
-                self._snap.get("vertex_index"),
-            )
-
         # Remember whether this point landed on an external-geometry snap, so its
         # deferred creation can anchor it (fixed) — otherwise an inferred
         # constraint would drag the snapped point off target (see create_element).
@@ -165,78 +152,77 @@ class Operator2d(GenericEntityOp):
         return super().state_func(context, coords)
 
     def _maybe_link_projected_snap(self, context: Context, state_data):
-        """Live-project the snapped mesh vertex and register it for coincidence.
+        """Live-project a snapped mesh feature and register it for coincidence.
 
-        Prototype: when a point is snapped onto an external mesh vertex, create
-        (or reuse) a live projected reference for that vertex and set it as the
-        coincidence target, so the placed point tracks the source instead of
-        being a dead static point. Scoped to mesh vertices; edges/curves and the
-        case where the snapped vertex can't be traced to an original one fall
-        back to the static point.
+        When a point is snapped onto external mesh geometry, create (or reuse) a
+        live projected reference and set it as the coincidence target, so the
+        placed point tracks the source instead of being a dead static point.
+        Handles vertex snaps (bind the vertex) and edge-midpoint snaps (bind the
+        edge's two endpoints, ride at their midpoint). Other snap types, and cases
+        where the snapped feature can't be traced to an original one, fall back to
+        the static point.
         """
-        import logging
-
-        _dbg = logging.getLogger(__name__).warning
-        _dbg("SNAPPROJ enter (state_data keys=%s)", sorted(state_data.keys()))
         if not context.scene.sketcher.use_snap_project:
-            _dbg("SNAPPROJ bail: use_snap_project off")
             return
         if not self.use_auto_constraints(context, state_data):
-            _dbg("SNAPPROJ bail: auto_constraints off / shift bypass")
             return
         if state_data.get("hovered"):
-            _dbg("SNAPPROJ bail: already hovered=%r", state_data.get("hovered"))
             return  # already coinciding with an existing sketch entity
 
         snap = state_data.get("snap")
-        _dbg("SNAPPROJ snap=%r", snap)
-        if not snap or snap.get("type") != "VERTEX":
-            _dbg("SNAPPROJ bail: snap missing or not VERTEX")
+        if not snap:
             return
-        ob_name = snap.get("object")
-        v_index = snap.get("vertex_index")
-        if ob_name is None or v_index is None:
-            _dbg("SNAPPROJ bail: no object/vertex_index in snap")
+        snap_type = snap.get("type")
+        if snap_type not in ("VERTEX", "EDGE_MIDPOINT"):
             return
-        source = bpy.data.objects.get(ob_name)
+        source = bpy.data.objects.get(snap.get("object") or "")
         if source is None or source.type != "MESH":
-            _dbg("SNAPPROJ bail: source missing/not mesh: %r", source)
             return
 
-        # Snapping reads the evaluated mesh; resolve that evaluated vertex back to
-        # the original one to bind (by persistent id when tagged, else an
+        # Snapping reads the evaluated mesh; resolve the evaluated vertices back to
+        # the original ones to bind (by persistent id when tagged, else an
         # order-preserving index). Skip when the correspondence isn't trustworthy.
         from ..stateful_operator.utilities.geometry import get_evaluated_obj
         from ..utilities.projection_anchor import (
+            project_mesh_edge_midpoint,
             project_mesh_vertex,
             resolve_source_vertex_index,
         )
 
         eval_source = get_evaluated_obj(context, source)
-        orig_index = resolve_source_vertex_index(source, eval_source, v_index)
-        if orig_index is None:
-            _dbg("SNAPPROJ bail: could not resolve orig index for eval %r", v_index)
-            return
-        _dbg("SNAPPROJ projecting source=%s orig_index=%s", ob_name, orig_index)
+        world_point = snap.get("world_point")
 
         # Place the point where the user snapped (the evaluated hit), so a
         # vertex-moving modifier doesn't leave it a frame behind the source.
-        projected = project_mesh_vertex(
-            self.sketch,
-            source,
-            orig_index,
-            construction=True,
-            world_co=snap.get("world_point"),
-        )
-        _dbg(
-            "SNAPPROJ project_mesh_vertex -> %r valid=%r curve_id=%r",
-            projected,
-            getattr(projected, "valid", None),
-            getattr(projected, "curve_id", None),
-        )
+        if snap_type == "VERTEX":
+            v_index = snap.get("vertex_index")
+            if v_index is None:
+                return
+            orig = resolve_source_vertex_index(source, eval_source, v_index)
+            if orig is None:
+                return
+            projected = project_mesh_vertex(
+                self.sketch, source, orig, construction=True, world_co=world_point
+            )
+        else:  # EDGE_MIDPOINT
+            edge = snap.get("edge_vertices")
+            if not edge:
+                return
+            orig_a = resolve_source_vertex_index(source, eval_source, edge[0])
+            orig_b = resolve_source_vertex_index(source, eval_source, edge[1])
+            if orig_a is None or orig_b is None:
+                return
+            projected = project_mesh_edge_midpoint(
+                self.sketch,
+                source,
+                orig_a,
+                orig_b,
+                construction=True,
+                world_co=world_point,
+            )
+
         if projected is not None and projected.valid:
             state_data["hovered"] = projected.curve_id
-            _dbg("SNAPPROJ set hovered=%r", state_data["hovered"])
 
     # create element depending on mode
     def create_element(self, context: Context, values: List[Any], state, state_data):
@@ -254,23 +240,10 @@ class Operator2d(GenericEntityOp):
         # below instead, so skip those.
         fixed = state_data.get("snapped", False) and not state_data.get("hovered")
 
-        import logging
-
-        logging.getLogger(__name__).warning(
-            "SNAPPROJ create_element fixed=%r hovered=%r snapped=%r",
-            fixed,
-            state_data.get("hovered"),
-            state_data.get("snapped"),
-        )
-
         ref = PointRef.create(sketch, loc, fixed=fixed)
         cid = ref.curve_id
 
         self.add_coincident(context, ref, state, state_data)
-        logging.getLogger(__name__).warning(
-            "SNAPPROJ create_element post add_coincident coincident=%r",
-            state_data.get("coincident"),
-        )
 
         ignore_hover(cid)
         state_data["type"] = PointRef

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -152,21 +152,28 @@ class Operator2d(GenericEntityOp):
         return super().state_func(context, coords)
 
     def _maybe_link_projected_snap(self, context: Context, state_data):
-        """Live-project a snapped mesh feature and register it for coincidence.
+        """Live-project a snapped mesh feature and register it for constraining.
 
         When a point is snapped onto external mesh geometry, create (or reuse) a
-        live projected reference and set it as the coincidence target, so the
-        placed point tracks the source instead of being a dead static point.
-        Handles vertex snaps (bind the vertex) and edge-midpoint snaps (bind the
-        edge's two endpoints, ride at their midpoint). Other snap types, and cases
-        where the snapped feature can't be traced to an original one, fall back to
-        the static point.
+        live projected reference and set it as the constraint target, so the placed
+        point tracks the source instead of being a dead static point:
+
+        - vertex: project the vertex as a point; coincide the placed point on it.
+        - along an edge: project the edge as a line; coincide the point on the line
+          (point-on-line) so it slides along the edge.
+        - edge midpoint: project the edge as a line; add a midpoint constraint so
+          the point stays centered as the edge's endpoints track the source.
+
+        Other snap types, and cases where the snapped feature can't be traced to an
+        original one, fall back to the static point.
         """
         if not context.scene.sketcher.use_snap_project:
             state_data["snap_anchored"] = False
+            state_data["snap_link_kind"] = "COINCIDENT"
             return
         if not self.use_auto_constraints(context, state_data):
             state_data["snap_anchored"] = False
+            state_data["snap_link_kind"] = "COINCIDENT"
             return
         hovered = state_data.get("hovered")
         if hovered:
@@ -184,10 +191,12 @@ class Operator2d(GenericEntityOp):
                 return
             state_data["hovered"] = ""
 
-        # Fresh (re)evaluation of this state: default to not-anchored, so a stale
-        # flag from a previous frame (e.g. the cursor moved off a vertex) is
-        # cleared. It is set True again below only on a fixed-point projection.
+        # Fresh (re)evaluation of this state: default to not-anchored and a plain
+        # coincidence, so stale flags from a previous frame (e.g. the cursor moved
+        # off a vertex/midpoint) are cleared. They are set again below only when the
+        # current snap warrants it.
         state_data["snap_anchored"] = False
+        state_data["snap_link_kind"] = "COINCIDENT"
 
         snap = state_data.get("snap")
         if not snap:
@@ -205,7 +214,6 @@ class Operator2d(GenericEntityOp):
         from ..stateful_operator.utilities.geometry import get_evaluated_obj
         from ..utilities.projection_anchor import (
             project_mesh_edge,
-            project_mesh_edge_midpoint,
             project_mesh_vertex,
             resolve_source_vertex_index,
         )
@@ -225,7 +233,7 @@ class Operator2d(GenericEntityOp):
             projected = project_mesh_vertex(
                 self.sketch, source, orig, construction=True, world_co=world_point
             )
-        else:  # EDGE_MIDPOINT or EDGE: both bind the edge's two endpoints
+        else:  # EDGE_MIDPOINT or EDGE: project the edge as a live line
             edge = snap.get("edge_vertices")
             if not edge:
                 return
@@ -233,34 +241,26 @@ class Operator2d(GenericEntityOp):
             orig_b = resolve_source_vertex_index(source, eval_source, edge[1])
             if orig_a is None or orig_b is None:
                 return
-            if snap_type == "EDGE_MIDPOINT":
-                projected = project_mesh_edge_midpoint(
-                    self.sketch,
-                    source,
-                    orig_a,
-                    orig_b,
-                    construction=True,
-                    world_co=world_point,
-                )
-            else:
-                # Project the edge as a live line; the placed point coincides onto
-                # it (point-on-line), so it slides along the edge rather than being
-                # pinned. SlvsCoincident accepts (POINT, LINE), so setting the line
-                # as the hovered target below yields the right constraint.
-                projected = project_mesh_edge(
-                    self.sketch, source, orig_a, orig_b, construction=True
-                )
+            projected = project_mesh_edge(
+                self.sketch, source, orig_a, orig_b, construction=True
+            )
 
         if projected is not None and projected.valid:
             state_data["hovered"] = projected.curve_id
-            # A vertex/midpoint projection pins the endpoint to a FIXED point, so
-            # it can't move; an auto axis-alignment on such an endpoint would fight
-            # the fixed position (inconsistent when the features aren't exactly
-            # aligned). Flag it so the line tool skips alignment, same as it does
-            # for two statically-fixed endpoints. An edge projection is point-on-
-            # line (the endpoint can still slide), so it is not flagged.
-            if snap_type in ("VERTEX", "EDGE_MIDPOINT"):
+            if snap_type == "EDGE_MIDPOINT":
+                # Constrain the point to the edge's midpoint (POINT, LINE). The
+                # projected line's endpoints track the source, and the midpoint
+                # constraint keeps the point centered as they move. It fully pins
+                # the point, so treat it as anchored for the alignment guard.
+                state_data["snap_link_kind"] = "MIDPOINT"
                 state_data["snap_anchored"] = True
+            elif snap_type == "VERTEX":
+                # Coincident to a FIXED point: an auto axis-alignment would fight
+                # the fixed position, so flag it anchored (the line tool skips
+                # alignment, as it does for two statically-fixed endpoints).
+                state_data["snap_anchored"] = True
+            # EDGE: point-on-line coincidence (default kind); the point can still
+            # slide along the line, so it is not flagged anchored.
 
     def point_is_anchored(self, index: int) -> bool:
         """Whether the point placed for state ``index`` is pinned in place.

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -168,10 +168,21 @@ class Operator2d(GenericEntityOp):
         if not self.use_auto_constraints(context, state_data):
             state_data["snap_anchored"] = False
             return
-        if state_data.get("hovered"):
-            # Already coincident with an existing sketch entity or a projection
-            # from an earlier frame; leave its anchored state untouched.
-            return
+        hovered = state_data.get("hovered")
+        if hovered:
+            # Coincident with something already. If it still resolves to a LIVE
+            # curve (a genuine pick, or this state's projection), leave it be. But
+            # a non-current state's projection gets wiped by the preview restore
+            # each frame while its stale hovered id lingers here -- honoring it
+            # would coincide the endpoint to a deleted curve (a dead static point,
+            # the "snaps but no live link" bug). Detect that and fall through to
+            # re-project so the reference is recreated.
+            from ..model.curve_ref import curve_ref
+
+            existing = curve_ref(self.sketch, hovered)
+            if existing is not None and existing.valid:
+                return
+            state_data["hovered"] = ""
 
         # Fresh (re)evaluation of this state: default to not-anchored, so a stale
         # flag from a previous frame (e.g. the cursor moved off a vertex) is

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -173,7 +173,7 @@ class Operator2d(GenericEntityOp):
         if not snap:
             return
         snap_type = snap.get("type")
-        if snap_type not in ("VERTEX", "EDGE_MIDPOINT"):
+        if snap_type not in ("VERTEX", "EDGE_MIDPOINT", "EDGE"):
             return
         source = bpy.data.objects.get(snap.get("object") or "")
         if source is None or source.type != "MESH":
@@ -184,6 +184,7 @@ class Operator2d(GenericEntityOp):
         # order-preserving index). Skip when the correspondence isn't trustworthy.
         from ..stateful_operator.utilities.geometry import get_evaluated_obj
         from ..utilities.projection_anchor import (
+            project_mesh_edge,
             project_mesh_edge_midpoint,
             project_mesh_vertex,
             resolve_source_vertex_index,
@@ -204,7 +205,7 @@ class Operator2d(GenericEntityOp):
             projected = project_mesh_vertex(
                 self.sketch, source, orig, construction=True, world_co=world_point
             )
-        else:  # EDGE_MIDPOINT
+        else:  # EDGE_MIDPOINT or EDGE: both bind the edge's two endpoints
             edge = snap.get("edge_vertices")
             if not edge:
                 return
@@ -212,14 +213,23 @@ class Operator2d(GenericEntityOp):
             orig_b = resolve_source_vertex_index(source, eval_source, edge[1])
             if orig_a is None or orig_b is None:
                 return
-            projected = project_mesh_edge_midpoint(
-                self.sketch,
-                source,
-                orig_a,
-                orig_b,
-                construction=True,
-                world_co=world_point,
-            )
+            if snap_type == "EDGE_MIDPOINT":
+                projected = project_mesh_edge_midpoint(
+                    self.sketch,
+                    source,
+                    orig_a,
+                    orig_b,
+                    construction=True,
+                    world_co=world_point,
+                )
+            else:
+                # Project the edge as a live line; the placed point coincides onto
+                # it (point-on-line), so it slides along the edge rather than being
+                # pinned. SlvsCoincident accepts (POINT, LINE), so setting the line
+                # as the hovered target below yields the right constraint.
+                projected = project_mesh_edge(
+                    self.sketch, source, orig_a, orig_b, construction=True
+                )
 
         if projected is not None and projected.valid:
             state_data["hovered"] = projected.curve_id

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -125,6 +125,14 @@ class Operator2d(GenericEntityOp):
         # reflects the current position; at click this is the committed one).
         self.state_data["snap"] = self._snap
 
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "SNAPPROJ state_func idx=%s snap=%s",
+            self.state_index,
+            None if self._snap is None else self._snap.get("type"),
+        )
+
         # Handle implicit properties based on state.types
         if SlvsPoint2D in state.types:
             return pos
@@ -259,7 +267,20 @@ class Operator2d(GenericEntityOp):
         # Snapped onto external mesh geometry: live-project it and coincide, so
         # the point tracks the source. Registers the projected point as the
         # coincidence target below (behaves like snapping onto a sketch entity).
+        import logging
+
+        _snap = state_data.get("snap")
+        logging.getLogger(__name__).warning(
+            "SNAPPROJ create_element snap=%s snapped=%s",
+            None if _snap is None else _snap.get("type"),
+            state_data.get("snapped"),
+        )
         self._maybe_link_projected_snap(context, state_data)
+        logging.getLogger(__name__).warning(
+            "SNAPPROJ create_element -> hovered=%r anchored=%s",
+            state_data.get("hovered"),
+            state_data.get("snap_anchored"),
+        )
 
         # A point snapped to external geometry is a deliberate placement: fix it
         # so the solver keeps it there. Points snapped onto a sketch entity (or a

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -125,14 +125,6 @@ class Operator2d(GenericEntityOp):
         # reflects the current position; at click this is the committed one).
         self.state_data["snap"] = self._snap
 
-        import logging
-
-        logging.getLogger(__name__).warning(
-            "SNAPPROJ state_func idx=%s snap=%s",
-            self.state_index,
-            None if self._snap is None else self._snap.get("type"),
-        )
-
         # Handle implicit properties based on state.types
         if SlvsPoint2D in state.types:
             return pos
@@ -171,11 +163,20 @@ class Operator2d(GenericEntityOp):
         the static point.
         """
         if not context.scene.sketcher.use_snap_project:
+            state_data["snap_anchored"] = False
             return
         if not self.use_auto_constraints(context, state_data):
+            state_data["snap_anchored"] = False
             return
         if state_data.get("hovered"):
-            return  # already coinciding with an existing sketch entity
+            # Already coincident with an existing sketch entity or a projection
+            # from an earlier frame; leave its anchored state untouched.
+            return
+
+        # Fresh (re)evaluation of this state: default to not-anchored, so a stale
+        # flag from a previous frame (e.g. the cursor moved off a vertex) is
+        # cleared. It is set True again below only on a fixed-point projection.
+        state_data["snap_anchored"] = False
 
         snap = state_data.get("snap")
         if not snap:
@@ -267,20 +268,7 @@ class Operator2d(GenericEntityOp):
         # Snapped onto external mesh geometry: live-project it and coincide, so
         # the point tracks the source. Registers the projected point as the
         # coincidence target below (behaves like snapping onto a sketch entity).
-        import logging
-
-        _snap = state_data.get("snap")
-        logging.getLogger(__name__).warning(
-            "SNAPPROJ create_element snap=%s snapped=%s",
-            None if _snap is None else _snap.get("type"),
-            state_data.get("snapped"),
-        )
         self._maybe_link_projected_snap(context, state_data)
-        logging.getLogger(__name__).warning(
-            "SNAPPROJ create_element -> hovered=%r anchored=%s",
-            state_data.get("hovered"),
-            state_data.get("snap_anchored"),
-        )
 
         # A point snapped to external geometry is a deliberate placement: fix it
         # so the solver keeps it there. Points snapped onto a sketch entity (or a

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -117,6 +117,19 @@ class Operator2d(GenericEntityOp):
         self._snap = get_blender_snap_info(context, coords)
         pos = get_pos_2d(context, wp, coords, respect_snapping=True)
 
+        # TEMP diagnostic: what does Blender's snapping actually hand us as the
+        # cursor moves? Only logs when a snap is present, so it stays quiet over
+        # empty space. Strip once the live-project-on-snap issue is diagnosed.
+        if self._snap is not None:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "SNAPPROJ state_func snap type=%r object=%r vertex_index=%r",
+                self._snap.get("type"),
+                self._snap.get("object"),
+                self._snap.get("vertex_index"),
+            )
+
         # Remember whether this point landed on an external-geometry snap, so its
         # deferred creation can anchor it (fixed) — otherwise an inferred
         # constraint would drag the snapped point off target (see create_element).
@@ -161,22 +174,33 @@ class Operator2d(GenericEntityOp):
         case where the snapped vertex can't be traced to an original one fall
         back to the static point.
         """
+        import logging
+
+        _dbg = logging.getLogger(__name__).warning
+        _dbg("SNAPPROJ enter (state_data keys=%s)", sorted(state_data.keys()))
         if not context.scene.sketcher.use_snap_project:
+            _dbg("SNAPPROJ bail: use_snap_project off")
             return
         if not self.use_auto_constraints(context, state_data):
+            _dbg("SNAPPROJ bail: auto_constraints off / shift bypass")
             return
         if state_data.get("hovered"):
+            _dbg("SNAPPROJ bail: already hovered=%r", state_data.get("hovered"))
             return  # already coinciding with an existing sketch entity
 
         snap = state_data.get("snap")
+        _dbg("SNAPPROJ snap=%r", snap)
         if not snap or snap.get("type") != "VERTEX":
+            _dbg("SNAPPROJ bail: snap missing or not VERTEX")
             return
         ob_name = snap.get("object")
         v_index = snap.get("vertex_index")
         if ob_name is None or v_index is None:
+            _dbg("SNAPPROJ bail: no object/vertex_index in snap")
             return
         source = bpy.data.objects.get(ob_name)
         if source is None or source.type != "MESH":
+            _dbg("SNAPPROJ bail: source missing/not mesh: %r", source)
             return
 
         # Snapping reads the evaluated mesh; resolve that evaluated vertex back to
@@ -191,7 +215,9 @@ class Operator2d(GenericEntityOp):
         eval_source = get_evaluated_obj(context, source)
         orig_index = resolve_source_vertex_index(source, eval_source, v_index)
         if orig_index is None:
+            _dbg("SNAPPROJ bail: could not resolve orig index for eval %r", v_index)
             return
+        _dbg("SNAPPROJ projecting source=%s orig_index=%s", ob_name, orig_index)
 
         # Place the point where the user snapped (the evaluated hit), so a
         # vertex-moving modifier doesn't leave it a frame behind the source.

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -174,29 +174,40 @@ class Operator2d(GenericEntityOp):
         ):
             state_data["snap_anchored"] = False
             state_data["snap_link_kind"] = "COINCIDENT"
+            state_data["snap_projected"] = False
             return
         hovered = state_data.get("hovered")
         if hovered:
-            # Coincident with something already. If it still resolves to a LIVE
-            # curve (a genuine pick, or this state's projection), leave it be. But
-            # a non-current state's projection gets wiped by the preview restore
-            # each frame while its stale hovered id lingers here -- honoring it
-            # would coincide the endpoint to a deleted curve (a dead static point,
-            # the "snaps but no live link" bug). Detect that and fall through to
-            # re-project so the reference is recreated.
             from ..model.curve_ref import curve_ref
 
             existing = curve_ref(self.sketch, hovered)
             if existing is not None and existing.valid:
+                if self._is_projected_reference(hovered):
+                    # A live projection from an earlier (non-current) state: its
+                    # flags were set when projected, keep them. (Re-projecting is
+                    # unnecessary while the curve is still valid.)
+                    state_data["snap_projected"] = True
+                    return
+                # A genuine pick of an existing sketch entity under the cursor
+                # (e.g. a pointer tool's constrain target): a plain coincidence
+                # that respects Auto Constraints, anchored only if it is fixed.
+                state_data["snap_projected"] = False
+                state_data["snap_link_kind"] = "COINCIDENT"
+                state_data["snap_anchored"] = bool(getattr(existing, "fixed", False))
                 return
+            # Stale: a projection wiped by the preview restore while its id lingers
+            # here. Honoring it would coincide the endpoint to a deleted curve (a
+            # dead static point, the "snaps but no live link" bug); clear it and
+            # re-project below so the reference is recreated.
             state_data["hovered"] = ""
 
-        # Fresh (re)evaluation of this state: default to not-anchored and a plain
-        # coincidence, so stale flags from a previous frame (e.g. the cursor moved
-        # off a vertex/midpoint) are cleared. They are set again below only when the
-        # current snap warrants it.
+        # Fresh (re)evaluation of this state: default to not-anchored, a plain
+        # coincidence, and not-projected, so stale flags from a previous frame
+        # (e.g. the cursor moved off a vertex/midpoint) are cleared. They are set
+        # again below only when the current snap warrants it.
         state_data["snap_anchored"] = False
         state_data["snap_link_kind"] = "COINCIDENT"
+        state_data["snap_projected"] = False
 
         snap = state_data.get("snap")
         if not snap:
@@ -247,6 +258,9 @@ class Operator2d(GenericEntityOp):
 
         if projected is not None and projected.valid:
             state_data["hovered"] = projected.curve_id
+            # This link IS a projection: its constraint is created regardless of
+            # the Auto Constraints toggle (see add_coincident).
+            state_data["snap_projected"] = True
             if snap_type == "EDGE_MIDPOINT":
                 # Constrain the point to the edge's midpoint (POINT, LINE). The
                 # projected line's endpoints track the source, and the midpoint
@@ -261,6 +275,27 @@ class Operator2d(GenericEntityOp):
                 state_data["snap_anchored"] = True
             # EDGE: point-on-line coincidence (default kind); the point can still
             # slide along the line, so it is not flagged anchored.
+
+    def _is_projected_reference(self, curve_id: str) -> bool:
+        """Whether ``curve_id`` is a live-projected reference, not a picked entity.
+
+        A projected reference is a bound point, or a line whose endpoints are both
+        bound. Distinguishes "our projection" (whose constraint bypasses the Auto
+        Constraints toggle) from a genuine pick of a pre-existing sketch entity.
+        """
+        from ..model.curve_ref import LineRef, curve_ref
+        from ..utilities.projection_anchor import iter_projected_point_bindings
+
+        bound = {cid for cid, *_ in iter_projected_point_bindings(self.sketch)}
+        if not bound:
+            return False
+        if curve_id in bound:
+            return True
+        ref = curve_ref(self.sketch, curve_id)
+        if isinstance(ref, LineRef):
+            p1, p2 = ref.p1, ref.p2
+            return bool(p1 and p2 and p1.curve_id in bound and p2.curve_id in bound)
+        return False
 
     def point_is_anchored(self, index: int) -> bool:
         """Whether the point placed for state ``index`` is pinned in place.

--- a/operators/base_stateful.py
+++ b/operators/base_stateful.py
@@ -102,16 +102,10 @@ class GenericEntityOp(StatefulOperator):
     def add_coincident(self, context: Context, point, state, state_data):
         # A live-projected snap creates its link independently of the "Auto
         # Constraints" toggle: it is the projection itself, not an inferred
-        # constraint. It is exactly the case where the current snap is projectable
-        # mesh geometry and Live Project Snaps is on. Every other target (a
-        # coincidence onto an existing sketch entity) still respects the toggle.
-        snap = state_data.get("snap")
-        is_projection = bool(
-            context.scene.sketcher.use_snap_project
-            and snap
-            and snap.get("object")
-            and snap.get("type") in ("VERTEX", "EDGE", "EDGE_MIDPOINT")
-        )
+        # constraint. ``snap_projected`` is set by _maybe_link_projected_snap only
+        # when it actually projected. Every other target (a coincidence onto an
+        # existing sketch entity) still respects the toggle.
+        is_projection = bool(state_data.get("snap_projected"))
         if not is_projection and not self.use_auto_constraints(context, state_data):
             return
         hovered_cid = state_data.get("hovered", "")

--- a/operators/base_stateful.py
+++ b/operators/base_stateful.py
@@ -100,7 +100,19 @@ class GenericEntityOp(StatefulOperator):
         return hovered.curve_id if hovered else None
 
     def add_coincident(self, context: Context, point, state, state_data):
-        if not self.use_auto_constraints(context, state_data):
+        # A live-projected snap creates its link independently of the "Auto
+        # Constraints" toggle: it is the projection itself, not an inferred
+        # constraint. It is exactly the case where the current snap is projectable
+        # mesh geometry and Live Project Snaps is on. Every other target (a
+        # coincidence onto an existing sketch entity) still respects the toggle.
+        snap = state_data.get("snap")
+        is_projection = bool(
+            context.scene.sketcher.use_snap_project
+            and snap
+            and snap.get("object")
+            and snap.get("type") in ("VERTEX", "EDGE", "EDGE_MIDPOINT")
+        )
+        if not is_projection and not self.use_auto_constraints(context, state_data):
             return
         hovered_cid = state_data.get("hovered", "")
         if hovered_cid and hasattr(self, "sketch") and self.sketch:

--- a/operators/base_stateful.py
+++ b/operators/base_stateful.py
@@ -112,7 +112,15 @@ class GenericEntityOp(StatefulOperator):
                 else state_data.get("curve_id", "")
             )
 
-            state_data["coincident"] = self.sketch.constraints.add_coincident(
+            # A snapped edge-midpoint projects the edge as a line and pins the point
+            # to its midpoint; everything else is a plain coincidence (point-point
+            # or point-on-line). Both constraints take (point, target) in order.
+            constraints = self.sketch.constraints
+            if state_data.get("snap_link_kind") == "MIDPOINT":
+                add = constraints.add_midpoint
+            else:
+                add = constraints.add_coincident
+            state_data["coincident"] = add(
                 curve_id_1=point_cid,
                 curve_id_2=hovered_cid,
             )

--- a/testing/test_operators.py
+++ b/testing/test_operators.py
@@ -280,6 +280,47 @@ class TestCreateOperators(Sketch2dTestCase):
         # A midpoint binding carries its second vertex (binding2 is not None).
         self.assertIsNotNone(bindings[0][5], "must be an edge-midpoint binding")
 
+    def test_point_snapped_along_edge_coincides_on_projected_line(self):
+        # Snapping along an edge (not at a vertex/midpoint) projects the edge as a
+        # live line and coincides the placed point ONTO it (point-on-line), so the
+        # point slides along the edge instead of being a dead static point.
+        from mathutils import Vector
+
+        from ..model.curve_ref import LineRef, curve_ref
+        from ..operators.add_point_2d import View3D_OT_slvs_add_point2d
+        from ..utilities.projection_anchor import iter_projected_point_bindings
+
+        mesh = self.data.meshes.new("EdgeSrc2")
+        mesh.from_pydata([(0.0, 0.0, 0.0), (2.0, 0.0, 0.0)], [(0, 1)], [])
+        mesh.update()
+        source = self.data.objects.new("EdgeSrc2", mesh)
+        self.scene.collection.objects.link(source)
+        self.context.view_layer.update()
+
+        self.context.scene.sketcher.auto_axis_constraints = True
+        self.context.scene.sketcher.use_snap_project = True
+
+        h = self._harness(View3D_OT_slvs_add_point2d)
+        h.set_value(Vector((0.7, 0.0)))  # arbitrary point along the edge
+        data = h.op.get_state_data(0)
+        data["snapped"] = True
+        data["snap"] = {
+            "type": "EDGE",
+            "object": "EdgeSrc2",
+            "edge_vertices": (0, 1),
+            "world_point": Vector((0.7, 0.0, 0.0)),
+        }
+        h.finish()
+
+        # Both endpoints are projected (two live bindings) and a coincidence links
+        # the placed point to the projected LINE.
+        bindings = list(iter_projected_point_bindings(self.sketch))
+        self.assertEqual(len(bindings), 2, "edge projection binds both endpoints")
+        coincident = list(self.sketch.constraints.coincident)
+        self.assertEqual(len(coincident), 1, "one point-on-line coincidence")
+        target = curve_ref(self.sketch, coincident[0].curve_id_2)
+        self.assertIsInstance(target, LineRef, "the coincidence target is a line")
+
     # -- mixed paradigm: pick an existing point, place the other ------------
     def test_line_reuses_picked_start_point(self):
         from ..operators.add_line_2d import View3D_OT_slvs_add_line2d

--- a/testing/test_operators.py
+++ b/testing/test_operators.py
@@ -9,10 +9,9 @@ for a property state, ``pick`` for an existing element -- and assert the geometr
 and the auto-constraints ``main``/``fini`` add.
 """
 
-import math
 
-from .utils import Sketch2dTestCase, OpHarness
-from ..model.curve_ref import LineRef, CircleRef, ArcRef, PointRef
+from ..model.curve_ref import ArcRef, CircleRef, LineRef, PointRef
+from .utils import OpHarness, Sketch2dTestCase
 
 
 class TestCreateOperators(Sketch2dTestCase):
@@ -41,8 +40,8 @@ class TestCreateOperators(Sketch2dTestCase):
         self.assertAlmostEqual(line.p2.co.y, 5.0)
 
     def test_axis_aligned_line_gets_horizontal_constraint(self):
-        from ..operators.add_line_2d import View3D_OT_slvs_add_line2d
         from ..model.horizontal import SlvsHorizontal
+        from ..operators.add_line_2d import View3D_OT_slvs_add_line2d
 
         self.context.scene.sketcher.auto_axis_constraints = True
         h = self._harness(View3D_OT_slvs_add_line2d)
@@ -52,15 +51,18 @@ class TestCreateOperators(Sketch2dTestCase):
         self.assertTrue(h.op.has_alignment)
         line_cid = h.op.target.curve_id
         horiz = [
-            c for c in self.sketch.constraints.all
+            c
+            for c in self.sketch.constraints.all
             if isinstance(c, SlvsHorizontal) and line_cid in c.curve_id_placements()
         ]
-        self.assertEqual(len(horiz), 1, "expected exactly one auto horizontal constraint")
+        self.assertEqual(
+            len(horiz), 1, "expected exactly one auto horizontal constraint"
+        )
 
     def test_auto_constraints_toggle_off_suppresses_alignment(self):
         """With Auto Constraints disabled, an axis-aligned line gets no constraint."""
-        from ..operators.add_line_2d import View3D_OT_slvs_add_line2d
         from ..model.horizontal import SlvsHorizontal
+        from ..operators.add_line_2d import View3D_OT_slvs_add_line2d
 
         self.context.scene.sketcher.auto_axis_constraints = False
         try:
@@ -68,21 +70,26 @@ class TestCreateOperators(Sketch2dTestCase):
             h.place_point((0.0, 0.0)).place_point((5.0, 0.0))  # horizontal
             h.finish()
 
-            self.assertFalse(h.op.has_alignment, "toggle off must suppress auto alignment")
+            self.assertFalse(
+                h.op.has_alignment, "toggle off must suppress auto alignment"
+            )
             line_cid = h.op.target.curve_id
             horiz = [
-                c for c in self.sketch.constraints.all
+                c
+                for c in self.sketch.constraints.all
                 if isinstance(c, SlvsHorizontal) and line_cid in c.curve_id_placements()
             ]
-            self.assertEqual(len(horiz), 0, "no auto constraint should be added when disabled")
+            self.assertEqual(
+                len(horiz), 0, "no auto constraint should be added when disabled"
+            )
         finally:
             self.context.scene.sketcher.auto_axis_constraints = True
 
     def test_shift_bypass_suppresses_alignment(self):
         """Shift on a segment (skip_auto_constraints) bypasses auto alignment
         even with the toggle enabled."""
-        from ..operators.add_line_2d import View3D_OT_slvs_add_line2d
         from ..model.horizontal import SlvsHorizontal
+        from ..operators.add_line_2d import View3D_OT_slvs_add_line2d
 
         self.context.scene.sketcher.auto_axis_constraints = True
         h = self._harness(View3D_OT_slvs_add_line2d)
@@ -91,13 +98,18 @@ class TestCreateOperators(Sketch2dTestCase):
         h.op.get_state_data(h.op.state_index)["skip_auto_constraints"] = True
         h.finish()
 
-        self.assertFalse(h.op.has_alignment, "Shift bypass must suppress auto alignment")
+        self.assertFalse(
+            h.op.has_alignment, "Shift bypass must suppress auto alignment"
+        )
         line_cid = h.op.target.curve_id
         horiz = [
-            c for c in self.sketch.constraints.all
+            c
+            for c in self.sketch.constraints.all
             if isinstance(c, SlvsHorizontal) and line_cid in c.curve_id_placements()
         ]
-        self.assertEqual(len(horiz), 0, "no auto constraint should be added under Shift bypass")
+        self.assertEqual(
+            len(horiz), 0, "no auto constraint should be added under Shift bypass"
+        )
 
     def test_shift_bypass_is_not_sticky(self):
         """A confirm with Shift sets the bypass; a later confirm without Shift
@@ -112,7 +124,9 @@ class TestCreateOperators(Sketch2dTestCase):
 
         op = self._harness(View3D_OT_slvs_add_line2d).op
         op.check_event(_Event(shift=True))
-        self.assertTrue(op.state_data.get("skip_auto_constraints"), "Shift confirm sets bypass")
+        self.assertTrue(
+            op.state_data.get("skip_auto_constraints"), "Shift confirm sets bypass"
+        )
         op.check_event(_Event(shift=False))
         self.assertFalse(
             op.state_data.get("skip_auto_constraints"),
@@ -126,7 +140,9 @@ class TestCreateOperators(Sketch2dTestCase):
         h.place_point((0.0, 0.0)).place_point((5.0, 5.0))  # 45 degrees
         h.finish()
 
-        self.assertFalse(h.op.has_alignment, "diagonal line must not be auto-constrained")
+        self.assertFalse(
+            h.op.has_alignment, "diagonal line must not be auto-constrained"
+        )
 
     def test_line_continue_draw_after_placed_endpoint(self):
         from ..operators.add_line_2d import View3D_OT_slvs_add_line2d
@@ -155,9 +171,9 @@ class TestCreateOperators(Sketch2dTestCase):
         from ..operators.add_arc import View3D_OT_slvs_add_arc2d
 
         h = self._harness(View3D_OT_slvs_add_arc2d)
-        h.place_point((0.0, 0.0))   # center
-        h.place_point((2.0, 0.0))   # start
-        h.place_point((0.0, 2.0))   # end
+        h.place_point((0.0, 0.0))  # center
+        h.place_point((2.0, 0.0))  # start
+        h.place_point((0.0, 2.0))  # end
         h.finish()
 
         arc = h.op.target
@@ -174,12 +190,15 @@ class TestCreateOperators(Sketch2dTestCase):
         h.place_point((0.0, 0.0)).place_point((4.0, 2.0))
         h.finish()
 
-        self.assertEqual(self._count_lines() - before, 4, "rectangle must add four lines")
+        self.assertEqual(
+            self._count_lines() - before, 4, "rectangle must add four lines"
+        )
 
     # -- point (single property state) ---------------------------------------
     def test_point_from_coordinates(self):
-        from ..operators.add_point_2d import View3D_OT_slvs_add_point2d
         from mathutils import Vector
+
+        from ..operators.add_point_2d import View3D_OT_slvs_add_point2d
 
         h = self._harness(View3D_OT_slvs_add_point2d)
         h.set_value(Vector((7.0, 8.0)))
@@ -189,6 +208,42 @@ class TestCreateOperators(Sketch2dTestCase):
         self.assertIsInstance(pt, PointRef)
         self.assertAlmostEqual(pt.co.x, 7.0)
         self.assertAlmostEqual(pt.co.y, 8.0)
+
+    def test_point_snapped_to_mesh_vertex_live_projects(self):
+        # Add Point is a coordinate state (no create_element), so its main() must
+        # run the snap-link itself -- otherwise snapping onto a mesh vertex would
+        # only ever place a dead static point.
+        from mathutils import Vector
+
+        from ..operators.add_point_2d import View3D_OT_slvs_add_point2d
+        from ..utilities.projection_anchor import iter_projected_point_bindings
+
+        mesh = self.data.meshes.new("SnapSrc")
+        mesh.from_pydata([(1.0, 1.0, 0.0)], [], [])
+        mesh.update()
+        source = self.data.objects.new("SnapSrc", mesh)
+        self.scene.collection.objects.link(source)
+        self.context.view_layer.update()
+
+        self.context.scene.sketcher.auto_axis_constraints = True
+        self.context.scene.sketcher.use_snap_project = True
+
+        h = self._harness(View3D_OT_slvs_add_point2d)
+        h.set_value(Vector((1.0, 1.0)))
+        # Emulate what state_func stashes when the cursor is on a mesh vertex.
+        data = h.op.get_state_data(0)
+        data["snapped"] = True
+        data["snap"] = {
+            "type": "VERTEX",
+            "object": "SnapSrc",
+            "vertex_index": 0,
+            "world_point": Vector((1.0, 1.0, 0.0)),
+        }
+        h.finish()
+
+        bindings = list(iter_projected_point_bindings(self.sketch))
+        self.assertEqual(len(bindings), 1, "the snap must create one live binding")
+        self.assertEqual(bindings[0][1], source)
 
     # -- mixed paradigm: pick an existing point, place the other ------------
     def test_line_reuses_picked_start_point(self):

--- a/testing/test_operators.py
+++ b/testing/test_operators.py
@@ -244,6 +244,87 @@ class TestCreateOperators(Sketch2dTestCase):
         self.assertEqual(len(bindings), 1, "the snap must create one live binding")
         self.assertEqual(bindings[0][1], source)
 
+    def test_live_snap_does_not_require_auto_constraints(self):
+        # Live Project Snaps is its own feature: it works with the "Auto
+        # Constraints" toggle OFF (only the Shift bypass opts out). A vertex snap
+        # must still project and coincide even though auto-alignment is disabled.
+        from mathutils import Vector
+
+        from ..operators.add_point_2d import View3D_OT_slvs_add_point2d
+        from ..utilities.projection_anchor import iter_projected_point_bindings
+
+        mesh = self.data.meshes.new("NoAutoSrc")
+        mesh.from_pydata([(1.0, 1.0, 0.0)], [], [])
+        mesh.update()
+        source = self.data.objects.new("NoAutoSrc", mesh)
+        self.scene.collection.objects.link(source)
+        self.context.view_layer.update()
+
+        self.context.scene.sketcher.auto_axis_constraints = False  # the point
+        self.context.scene.sketcher.use_snap_project = True
+
+        def snap_dict():
+            return {
+                "type": "VERTEX",
+                "object": "NoAutoSrc",
+                "vertex_index": 0,
+                "world_point": Vector((1.0, 1.0, 0.0)),
+            }
+
+        h = self._harness(View3D_OT_slvs_add_point2d)
+        h.set_value(Vector((1.0, 1.0)))
+        data = h.op.get_state_data(0)
+        data["snapped"] = True
+        data["snap"] = snap_dict()
+        h.finish()
+
+        self.assertEqual(
+            len(list(iter_projected_point_bindings(self.sketch))),
+            1,
+            "projection must work with Auto Constraints off",
+        )
+        self.assertEqual(
+            len(list(self.sketch.constraints.coincident)),
+            1,
+            "the projection coincidence must be created with Auto Constraints off",
+        )
+
+    def test_shift_bypass_still_suppresses_live_snap(self):
+        # The Shift bypass (skip_auto_constraints) remains the "place it raw"
+        # escape hatch: no projection, no coincidence, just a fixed point.
+        from mathutils import Vector
+
+        from ..operators.add_point_2d import View3D_OT_slvs_add_point2d
+        from ..utilities.projection_anchor import iter_projected_point_bindings
+
+        mesh = self.data.meshes.new("ShiftSrc")
+        mesh.from_pydata([(1.0, 1.0, 0.0)], [], [])
+        mesh.update()
+        source = self.data.objects.new("ShiftSrc", mesh)
+        self.scene.collection.objects.link(source)
+        self.context.view_layer.update()
+        self.context.scene.sketcher.use_snap_project = True
+
+        h = self._harness(View3D_OT_slvs_add_point2d)
+        h.set_value(Vector((1.0, 1.0)))
+        data = h.op.get_state_data(0)
+        data["snapped"] = True
+        data["skip_auto_constraints"] = True  # Shift held
+        data["snap"] = {
+            "type": "VERTEX",
+            "object": "ShiftSrc",
+            "vertex_index": 0,
+            "world_point": Vector((1.0, 1.0, 0.0)),
+        }
+        h.finish()
+
+        self.assertEqual(
+            len(list(iter_projected_point_bindings(self.sketch))),
+            0,
+            "Shift bypass must suppress the projection",
+        )
+        self.assertEqual(len(list(self.sketch.constraints.coincident)), 0)
+
     def test_point_snapped_to_edge_midpoint_projects_edge_and_midpoints(self):
         # An edge-midpoint snap projects the EDGE as a live line (both endpoints
         # bound) and pins the point with a MIDPOINT constraint, not a dead static

--- a/testing/test_operators.py
+++ b/testing/test_operators.py
@@ -244,6 +244,101 @@ class TestCreateOperators(Sketch2dTestCase):
         self.assertEqual(len(bindings), 1, "the snap must create one live binding")
         self.assertEqual(bindings[0][1], source)
 
+    def test_entity_pick_beats_geometry_snap(self):
+        # A sketch entity under the cursor wins over the mesh snap behind it: the
+        # point coincides with the entity instead of live-projecting the mesh.
+        from mathutils import Vector
+
+        from ..drawing import selection
+        from ..operators.add_point_2d import View3D_OT_slvs_add_point2d
+        from ..utilities.projection_anchor import iter_projected_point_bindings
+
+        existing = self.add_point((3.0, 4.0))
+
+        mesh = self.data.meshes.new("Compete")
+        mesh.from_pydata([(3.0, 4.0, 0.0)], [], [])
+        mesh.update()
+        source = self.data.objects.new("Compete", mesh)
+        self.scene.collection.objects.link(source)
+        self.context.view_layer.update()
+
+        self.context.scene.sketcher.use_snap_project = True
+        self.context.scene.sketcher.auto_axis_constraints = True
+
+        h = self._harness(View3D_OT_slvs_add_point2d)
+        h.set_value(Vector((3.0, 4.0)))
+        data = h.op.get_state_data(0)
+        data["snapped"] = True
+        data["snap"] = {
+            "type": "VERTEX",
+            "object": "Compete",
+            "vertex_index": 0,
+            "world_point": Vector((3.0, 4.0, 0.0)),
+        }
+        selection.hover = existing.curve_id
+        try:
+            h.finish()
+        finally:
+            selection.hover = ""
+
+        self.assertEqual(
+            len(list(iter_projected_point_bindings(self.sketch))),
+            0,
+            "hovering a sketch entity must beat the mesh snap (no projection)",
+        )
+        coincident = list(self.sketch.constraints.coincident)
+        self.assertEqual(len(coincident), 1)
+        self.assertIn(
+            existing.curve_id, (coincident[0].curve_id_1, coincident[0].curve_id_2)
+        )
+
+    def test_hovering_projected_reference_reuses_it(self):
+        # Hovering an already-projected reference reuses it (no second projection),
+        # and its link is created even with Auto Constraints off (it is a live
+        # projection, not an inferred constraint).
+        from mathutils import Vector
+
+        from ..drawing import selection
+        from ..operators.add_point_2d import View3D_OT_slvs_add_point2d
+        from ..utilities.projection_anchor import (
+            iter_projected_point_bindings,
+            project_mesh_vertex,
+        )
+
+        mesh = self.data.meshes.new("ProjSrc")
+        mesh.from_pydata([(2.0, 2.0, 0.0)], [], [])
+        mesh.update()
+        source = self.data.objects.new("ProjSrc", mesh)
+        self.scene.collection.objects.link(source)
+        self.context.view_layer.update()
+
+        proj = project_mesh_vertex(self.sketch, source, 0, construction=True)
+        self.assertEqual(len(list(iter_projected_point_bindings(self.sketch))), 1)
+
+        self.context.scene.sketcher.use_snap_project = True
+        self.context.scene.sketcher.auto_axis_constraints = False
+
+        h = self._harness(View3D_OT_slvs_add_point2d)
+        h.set_value(Vector((2.0, 2.0)))
+        selection.hover = proj.curve_id
+        try:
+            h.finish()
+        finally:
+            selection.hover = ""
+
+        self.assertEqual(
+            len(list(iter_projected_point_bindings(self.sketch))),
+            1,
+            "hovering a projected reference must reuse it, not add another",
+        )
+        coincident = list(self.sketch.constraints.coincident)
+        self.assertEqual(
+            len(coincident), 1, "a projected-reference pick forces the coincidence"
+        )
+        self.assertIn(
+            proj.curve_id, (coincident[0].curve_id_1, coincident[0].curve_id_2)
+        )
+
     def test_live_snap_does_not_require_auto_constraints(self):
         # Live Project Snaps is its own feature: it works with the "Auto
         # Constraints" toggle OFF (only the Shift bypass opts out). A vertex snap

--- a/testing/test_operators.py
+++ b/testing/test_operators.py
@@ -321,6 +321,83 @@ class TestCreateOperators(Sketch2dTestCase):
         target = curve_ref(self.sketch, coincident[0].curve_id_2)
         self.assertIsInstance(target, LineRef, "the coincidence target is a line")
 
+    def test_snapped_endpoints_skip_conflicting_auto_alignment(self):
+        # Two endpoints live-projected onto near-but-not-exactly-aligned vertices
+        # must NOT get an auto horizontal/vertical: the fixed projected positions
+        # disagree with the alignment, so the solver would yank an endpoint off its
+        # vertex (the "endpoint jumps to origin" report). Alignment is skipped and
+        # both endpoints keep their projected positions.
+        from mathutils import Vector
+
+        from ..operators.add_line_2d import View3D_OT_slvs_add_line2d
+
+        mesh = self.data.meshes.new("AlignSrc")
+        # ~2.3deg off horizontal: within the auto-align threshold, so alignment
+        # would fire if not suppressed, but the y values (0 vs 0.2) conflict.
+        mesh.from_pydata([(0.0, 0.0, 0.0), (5.0, 0.2, 0.0)], [(0, 1)], [])
+        mesh.update()
+        source = self.data.objects.new("AlignSrc", mesh)
+        self.scene.collection.objects.link(source)
+        self.context.view_layer.update()
+
+        self.context.scene.sketcher.auto_axis_constraints = True
+        self.context.scene.sketcher.use_snap_project = True
+
+        h = self._harness(View3D_OT_slvs_add_line2d)
+        h.place_point((0.0, 0.0)).place_point((5.0, 0.2))
+        for i, (vi, co) in enumerate(((0, (0.0, 0.0, 0.0)), (1, (5.0, 0.2, 0.0)))):
+            d = h.op.get_state_data(i)
+            d["snapped"] = True
+            d["snap"] = {
+                "type": "VERTEX",
+                "object": "AlignSrc",
+                "vertex_index": vi,
+                "world_point": Vector(co),
+            }
+        h.finish()
+
+        self.assertFalse(
+            h.op.has_alignment, "must not auto-align two anchored snapped endpoints"
+        )
+        self.assertLess((h.op.target.p1.co - Vector((0.0, 0.0))).length, 1e-4)
+        self.assertLess(
+            (h.op.target.p2.co - Vector((5.0, 0.2))).length,
+            1e-4,
+            f"endpoint pulled off its vertex: {tuple(h.op.target.p2.co)}",
+        )
+
+    def test_single_snapped_endpoint_still_auto_aligns(self):
+        # With only one endpoint anchored, the free end can absorb the alignment,
+        # so an axis-aligned line still gets its auto constraint (no regression).
+        from mathutils import Vector
+
+        from ..operators.add_line_2d import View3D_OT_slvs_add_line2d
+
+        mesh = self.data.meshes.new("AlignSrc2")
+        mesh.from_pydata([(5.0, 0.0, 0.0)], [], [])
+        mesh.update()
+        source = self.data.objects.new("AlignSrc2", mesh)
+        self.scene.collection.objects.link(source)
+        self.context.view_layer.update()
+
+        self.context.scene.sketcher.auto_axis_constraints = True
+        self.context.scene.sketcher.use_snap_project = True
+
+        h = self._harness(View3D_OT_slvs_add_line2d)
+        h.place_point((0.0, 0.05)).place_point((5.0, 0.0))  # near-horizontal
+        d = h.op.get_state_data(1)
+        d["snapped"] = True
+        d["snap"] = {
+            "type": "VERTEX",
+            "object": "AlignSrc2",
+            "vertex_index": 0,
+            "world_point": Vector((5.0, 0.0, 0.0)),
+        }
+        h.finish()
+
+        self.assertTrue(h.op.has_alignment, "one free end should still auto-align")
+        self.assertLess((h.op.target.p2.co - Vector((5.0, 0.0))).length, 1e-4)
+
     # -- mixed paradigm: pick an existing point, place the other ------------
     def test_line_reuses_picked_start_point(self):
         from ..operators.add_line_2d import View3D_OT_slvs_add_line2d

--- a/testing/test_operators.py
+++ b/testing/test_operators.py
@@ -244,12 +244,13 @@ class TestCreateOperators(Sketch2dTestCase):
         self.assertEqual(len(bindings), 1, "the snap must create one live binding")
         self.assertEqual(bindings[0][1], source)
 
-    def test_point_snapped_to_edge_midpoint_live_projects(self):
-        # An edge-midpoint snap binds a live point to BOTH endpoints (midpoint),
-        # not a dead static point. Drives the EDGE_MIDPOINT branch of
-        # _maybe_link_projected_snap through the coordinate-state main().
+    def test_point_snapped_to_edge_midpoint_projects_edge_and_midpoints(self):
+        # An edge-midpoint snap projects the EDGE as a live line (both endpoints
+        # bound) and pins the point with a MIDPOINT constraint, not a dead static
+        # point. Drives the EDGE_MIDPOINT branch through the coordinate-state main().
         from mathutils import Vector
 
+        from ..model.curve_ref import LineRef, curve_ref
         from ..operators.add_point_2d import View3D_OT_slvs_add_point2d
         from ..utilities.projection_anchor import iter_projected_point_bindings
 
@@ -275,10 +276,14 @@ class TestCreateOperators(Sketch2dTestCase):
         }
         h.finish()
 
+        # Both edge endpoints are projected (two live bindings) ...
         bindings = list(iter_projected_point_bindings(self.sketch))
-        self.assertEqual(len(bindings), 1, "the snap must create one live binding")
-        # A midpoint binding carries its second vertex (binding2 is not None).
-        self.assertIsNotNone(bindings[0][5], "must be an edge-midpoint binding")
+        self.assertEqual(len(bindings), 2, "edge projection binds both endpoints")
+        # ... and the placed point is pinned by a midpoint constraint on the line.
+        midpoints = list(self.sketch.constraints.midpoint)
+        self.assertEqual(len(midpoints), 1, "one midpoint constraint")
+        target = curve_ref(self.sketch, midpoints[0].curve_id_2)
+        self.assertIsInstance(target, LineRef, "the midpoint target is a line")
 
     def test_point_snapped_along_edge_coincides_on_projected_line(self):
         # Snapping along an edge (not at a vertex/midpoint) projects the edge as a

--- a/testing/test_operators.py
+++ b/testing/test_operators.py
@@ -9,7 +9,6 @@ for a property state, ``pick`` for an existing element -- and assert the geometr
 and the auto-constraints ``main``/``fini`` add.
 """
 
-
 from ..model.curve_ref import ArcRef, CircleRef, LineRef, PointRef
 from .utils import OpHarness, Sketch2dTestCase
 
@@ -244,6 +243,42 @@ class TestCreateOperators(Sketch2dTestCase):
         bindings = list(iter_projected_point_bindings(self.sketch))
         self.assertEqual(len(bindings), 1, "the snap must create one live binding")
         self.assertEqual(bindings[0][1], source)
+
+    def test_point_snapped_to_edge_midpoint_live_projects(self):
+        # An edge-midpoint snap binds a live point to BOTH endpoints (midpoint),
+        # not a dead static point. Drives the EDGE_MIDPOINT branch of
+        # _maybe_link_projected_snap through the coordinate-state main().
+        from mathutils import Vector
+
+        from ..operators.add_point_2d import View3D_OT_slvs_add_point2d
+        from ..utilities.projection_anchor import iter_projected_point_bindings
+
+        mesh = self.data.meshes.new("EdgeSrc")
+        mesh.from_pydata([(0.0, 0.0, 0.0), (2.0, 0.0, 0.0)], [(0, 1)], [])
+        mesh.update()
+        source = self.data.objects.new("EdgeSrc", mesh)
+        self.scene.collection.objects.link(source)
+        self.context.view_layer.update()
+
+        self.context.scene.sketcher.auto_axis_constraints = True
+        self.context.scene.sketcher.use_snap_project = True
+
+        h = self._harness(View3D_OT_slvs_add_point2d)
+        h.set_value(Vector((1.0, 0.0)))
+        data = h.op.get_state_data(0)
+        data["snapped"] = True
+        data["snap"] = {
+            "type": "EDGE_MIDPOINT",
+            "object": "EdgeSrc",
+            "edge_vertices": (0, 1),
+            "world_point": Vector((1.0, 0.0, 0.0)),
+        }
+        h.finish()
+
+        bindings = list(iter_projected_point_bindings(self.sketch))
+        self.assertEqual(len(bindings), 1, "the snap must create one live binding")
+        # A midpoint binding carries its second vertex (binding2 is not None).
+        self.assertIsNotNone(bindings[0][5], "must be an edge-midpoint binding")
 
     # -- mixed paradigm: pick an existing point, place the other ------------
     def test_line_reuses_picked_start_point(self):

--- a/testing/test_operators.py
+++ b/testing/test_operators.py
@@ -321,6 +321,70 @@ class TestCreateOperators(Sketch2dTestCase):
         target = curve_ref(self.sketch, coincident[0].curve_id_2)
         self.assertIsInstance(target, LineRef, "the coincidence target is a line")
 
+    def test_first_point_projection_survives_preview_churn(self):
+        # Modal flow regression: the first point is snapped/projected, then the
+        # SECOND state previews across several restore+redo frames. The preview
+        # restore wipes the first point's projected reference each frame; its stale
+        # `hovered` must not make the endpoint coincide to a deleted curve (the
+        # "snaps but no live link" bug). The reference must be re-created so both
+        # endpoints stay coincident to LIVE projected points.
+        from mathutils import Vector
+
+        from ..model.curve_ref import curve_ref
+        from ..operators.add_line_2d import View3D_OT_slvs_add_line2d
+        from ..utilities.projection_anchor import iter_projected_point_bindings
+
+        mesh = self.data.meshes.new("ChurnSrc")
+        mesh.from_pydata([(0.0, 0.0, 0.0), (5.0, 3.0, 0.0)], [(0, 1)], [])
+        mesh.update()
+        source = self.data.objects.new("ChurnSrc", mesh)
+        self.scene.collection.objects.link(source)
+        self.context.view_layer.update()
+        self.context.scene.sketcher.use_snap_project = True
+
+        def vsnap(vi, co):
+            return {
+                "type": "VERTEX",
+                "object": "ChurnSrc",
+                "vertex_index": vi,
+                "world_point": Vector(co),
+            }
+
+        def set_point(op, index, co, snap):
+            for p in op.get_property(index=index) or []:
+                setattr(op, p, Vector(co))
+            d = op.get_state_data(index)
+            d["is_existing_entity"] = False
+            d["snapped"] = True
+            d["snap"] = snap
+
+        op = self._harness(View3D_OT_slvs_add_line2d).op
+        snap0 = op.create_snapshot(self.context)  # invoke-time baseline (empty)
+
+        op.state_index = 0
+        set_point(op, 0, (0.0, 0.0), vsnap(0, (0.0, 0.0, 0.0)))
+        op.redo_states(self.context)
+
+        # Second state previews: restore (wipes the first point's projection) then
+        # rebuild, several frames -- exactly what the modal does on mouse-move.
+        op.state_index = 1
+        for _ in range(4):
+            op.restore_snapshot(self.context, snap0)
+            set_point(op, 1, (5.0, 3.0), vsnap(1, (5.0, 3.0, 0.0)))
+            op.redo_states(self.context)
+        op.main(self.context)
+
+        bindings = list(iter_projected_point_bindings(self.sketch))
+        self.assertEqual(len(bindings), 2, "both endpoints must stay projected")
+        for c in self.sketch.constraints.coincident:
+            target = curve_ref(self.sketch, c.curve_id_2)
+            self.assertTrue(
+                target is not None and target.valid,
+                f"coincidence targets a wiped curve: {c.curve_id_2}",
+            )
+        self.assertFalse(op.target.p1.fixed, "first endpoint became a static point")
+        self.assertFalse(op.target.p2.fixed, "second endpoint became a static point")
+
     def test_snapped_endpoints_skip_conflicting_auto_alignment(self):
         # Two endpoints live-projected onto near-but-not-exactly-aligned vertices
         # must NOT get an auto horizontal/vertical: the fixed projected positions

--- a/testing/test_projection_anchor.py
+++ b/testing/test_projection_anchor.py
@@ -9,6 +9,7 @@ from ..utilities.projection_anchor import (
     VERTEX_ID_ATTR,
     find_projected_point,
     project_curves_object,
+    project_mesh_edge,
     project_mesh_edge_midpoint,
     project_mesh_element,
     project_mesh_object,
@@ -360,6 +361,49 @@ class TestProjectionAnchor(Sketch2dTestCase):
         depsgraph = self.context.evaluated_depsgraph_get()
         refresh_projection_for_sketch(self.sketch, depsgraph, changed={source})
         self.assertLess((point.co - Vector((11.0, 0.0))).length, 1e-5)
+
+    def test_project_mesh_edge_returns_live_line(self):
+        # Snapping along an edge projects it as a live LINE (bound endpoints), so a
+        # placed point can coincide onto it and slide along the edge.
+        from ..model.curve_ref import LineRef
+
+        source = self._mesh_object()  # edge 0: v0 (0,0,1) -- v1 (2,0,1)
+        line = project_mesh_edge(self.sketch, source, 0, 1, construction=True)
+        self.assertIsInstance(line, LineRef)
+        self.assertTrue(line.construction)
+        # Both endpoints are live-bound to their source vertices.
+        self.assertIsNotNone(find_projected_point(self.sketch, source, 0))
+        self.assertIsNotNone(find_projected_point(self.sketch, source, 1))
+
+        # Re-snapping the same edge reuses the same line (no duplicate).
+        again = project_mesh_edge(self.sketch, source, 1, 0, construction=True)
+        self.assertEqual(again.curve_id, line.curve_id)
+
+        # Degenerate / out-of-range inputs are no-ops.
+        self.assertIsNone(project_mesh_edge(self.sketch, source, 1, 1))
+        self.assertIsNone(project_mesh_edge(self.sketch, source, 0, 99))
+
+    def test_project_mesh_edge_skips_plane_perpendicular_edge(self):
+        # An edge going straight through the sketch plane collapses to a point;
+        # there is no usable line, so the projection bails (static fallback).
+        mesh = self.data.meshes.new("PerpEdge")
+        mesh.from_pydata([(1.0, 1.0, 0.0), (1.0, 1.0, 2.0)], [(0, 1)], [])
+        mesh.update()
+        source = self.data.objects.new("PerpEdge", mesh)
+        self.scene.collection.objects.link(source)
+        self.assertIsNone(project_mesh_edge(self.sketch, source, 0, 1))
+
+    def test_projected_edge_line_tracks_object_translation(self):
+        # The projected edge's endpoints (and thus the line) follow the object.
+        source = self._mesh_object()
+        line = project_mesh_edge(self.sketch, source, 0, 1, construction=True)
+        p1_before = Vector(line.p1.co)
+
+        source.location = (5.0, 0.0, 0.0)
+        self.context.view_layer.update()
+        depsgraph = self.context.evaluated_depsgraph_get()
+        refresh_projection_for_sketch(self.sketch, depsgraph, changed={source})
+        self.assertLess((line.p1.co - (p1_before + Vector((5.0, 0.0)))).length, 1e-5)
 
     def test_project_mesh_vertex_places_at_snapped_world_co(self):
         # A snap hands the evaluated world position; the point lands there rather

--- a/testing/test_projection_anchor.py
+++ b/testing/test_projection_anchor.py
@@ -13,6 +13,7 @@ from ..utilities.projection_anchor import (
     project_mesh_object,
     project_mesh_vertex,
     refresh_projection_for_sketch,
+    resolve_source_vertex_index,
 )
 from .utils import Sketch2dTestCase
 
@@ -290,3 +291,24 @@ class TestProjectionAnchor(Sketch2dTestCase):
         depsgraph = self.context.evaluated_depsgraph_get()
         refresh_projection_for_sketch(self.sketch, depsgraph, force=True)
         self.assertLess((point.co - Vector((4.0, 1.0))).length, 1e-5)
+
+    def test_project_mesh_vertex_places_at_snapped_world_co(self):
+        # A snap hands the evaluated world position; the point lands there rather
+        # than at the (possibly modifier-shifted) original vertex coordinate.
+        source = self._mesh_object()
+        point = project_mesh_vertex(
+            self.sketch, source, 1, construction=True, world_co=(5.0, 6.0, 1.0)
+        )
+        self.assertIsNotNone(point)
+        self.assertLess((point.co - Vector((5.0, 6.0))).length, 1e-6)
+
+    def test_resolve_source_vertex_index(self):
+        source = self._mesh_object()
+        self.context.view_layer.update()
+        depsgraph = self.context.evaluated_depsgraph_get()
+        eval_source = source.evaluated_get(depsgraph)
+
+        # No modifier: the evaluated index maps straight through (count matches).
+        self.assertEqual(resolve_source_vertex_index(source, eval_source, 1), 1)
+        # An out-of-range evaluated index resolves to nothing rather than crash.
+        self.assertIsNone(resolve_source_vertex_index(source, eval_source, 99))

--- a/testing/test_projection_anchor.py
+++ b/testing/test_projection_anchor.py
@@ -10,7 +10,6 @@ from ..utilities.projection_anchor import (
     find_projected_point,
     project_curves_object,
     project_mesh_edge,
-    project_mesh_edge_midpoint,
     project_mesh_element,
     project_mesh_object,
     project_mesh_vertex,
@@ -314,53 +313,6 @@ class TestProjectionAnchor(Sketch2dTestCase):
 
         # The bound point follows the object's new world position (2 + 3 = 5 on X).
         self.assertLess((point.co - Vector((5.0, 0.0))).length, 1e-5)
-
-    def test_project_edge_midpoint_binds_both_endpoints(self):
-        # An edge-midpoint snap binds BOTH endpoints and rides at their midpoint.
-        source = self._mesh_object()  # edge 0 links v0 (0,0,1) and v1 (2,0,1)
-
-        point = project_mesh_edge_midpoint(self.sketch, source, 0, 1, construction=True)
-        self.assertIsNotNone(point)
-        self.assertTrue(point.fixed)
-        self.assertTrue(point.construction)
-        self.assertLess((point.co - Vector((1.0, 0.0))).length, 1e-6)
-
-        # Re-snapping the same edge midpoint (either vertex order) reuses the point.
-        again = project_mesh_edge_midpoint(self.sketch, source, 1, 0, construction=True)
-        self.assertEqual(again.curve_id, point.curve_id)
-
-        # It is distinct from a single-vertex projection of one endpoint.
-        vtx = project_mesh_vertex(self.sketch, source, 0, construction=True)
-        self.assertNotEqual(vtx.curve_id, point.curve_id)
-
-        # Degenerate / out-of-range inputs are no-ops, not crashes.
-        self.assertIsNone(project_mesh_edge_midpoint(self.sketch, source, 0, 0))
-        self.assertIsNone(project_mesh_edge_midpoint(self.sketch, source, 0, 99))
-
-    def test_edge_midpoint_tracks_a_moving_endpoint(self):
-        # Moving one endpoint drags the midpoint by half the delta.
-        source = self._mesh_object()
-        point = project_mesh_edge_midpoint(self.sketch, source, 0, 1, construction=True)
-        self.assertLess((point.co - Vector((1.0, 0.0))).length, 1e-6)
-
-        source.data.vertices[1].co = (4.0, 0.0, 1.0)  # was (2,0,1)
-        source.data.update()
-        self.context.view_layer.update()
-        depsgraph = self.context.evaluated_depsgraph_get()
-        refresh_projection_for_sketch(self.sketch, depsgraph, force=True)
-        # Midpoint of (0,0) and (4,0) is (2,0).
-        self.assertLess((point.co - Vector((2.0, 0.0))).length, 1e-5)
-
-    def test_edge_midpoint_tracks_object_translation(self):
-        # Translating the whole object moves the bound midpoint with it.
-        source = self._mesh_object()
-        point = project_mesh_edge_midpoint(self.sketch, source, 0, 1, construction=True)
-
-        source.location = (10.0, 0.0, 0.0)
-        self.context.view_layer.update()
-        depsgraph = self.context.evaluated_depsgraph_get()
-        refresh_projection_for_sketch(self.sketch, depsgraph, changed={source})
-        self.assertLess((point.co - Vector((11.0, 0.0))).length, 1e-5)
 
     def test_project_mesh_edge_returns_live_line(self):
         # Snapping along an edge projects it as a live LINE (bound endpoints), so a

--- a/testing/test_projection_anchor.py
+++ b/testing/test_projection_anchor.py
@@ -9,6 +9,7 @@ from ..utilities.projection_anchor import (
     VERTEX_ID_ATTR,
     find_projected_point,
     project_curves_object,
+    project_mesh_edge_midpoint,
     project_mesh_element,
     project_mesh_object,
     project_mesh_vertex,
@@ -291,6 +292,74 @@ class TestProjectionAnchor(Sketch2dTestCase):
         depsgraph = self.context.evaluated_depsgraph_get()
         refresh_projection_for_sketch(self.sketch, depsgraph, force=True)
         self.assertLess((point.co - Vector((4.0, 1.0))).length, 1e-5)
+
+    def test_translating_source_object_reprojects_bound_point(self):
+        # The snap workflow's real payoff: moving the whole source OBJECT (its
+        # matrix_world changes, its mesh data does not) must drag the bound point
+        # along. This is a different depsgraph path than editing a vertex .co, and
+        # it must fire without force -- only via the object being in ``changed``.
+        source = self._mesh_object()
+        point = project_mesh_vertex(self.sketch, source, 1, construction=True)
+        self.assertLess((point.co - Vector((2.0, 0.0))).length, 1e-6)
+
+        # Translate the object by +3 on X (no mesh edit at all).
+        source.location = (3.0, 0.0, 0.0)
+        self.context.view_layer.update()
+        depsgraph = self.context.evaluated_depsgraph_get()
+
+        # Mimic the depsgraph handler: object translation puts the object (not its
+        # mesh) in the changed set. No force -- change-detection must catch it.
+        refresh_projection_for_sketch(self.sketch, depsgraph, changed={source})
+
+        # The bound point follows the object's new world position (2 + 3 = 5 on X).
+        self.assertLess((point.co - Vector((5.0, 0.0))).length, 1e-5)
+
+    def test_project_edge_midpoint_binds_both_endpoints(self):
+        # An edge-midpoint snap binds BOTH endpoints and rides at their midpoint.
+        source = self._mesh_object()  # edge 0 links v0 (0,0,1) and v1 (2,0,1)
+
+        point = project_mesh_edge_midpoint(self.sketch, source, 0, 1, construction=True)
+        self.assertIsNotNone(point)
+        self.assertTrue(point.fixed)
+        self.assertTrue(point.construction)
+        self.assertLess((point.co - Vector((1.0, 0.0))).length, 1e-6)
+
+        # Re-snapping the same edge midpoint (either vertex order) reuses the point.
+        again = project_mesh_edge_midpoint(self.sketch, source, 1, 0, construction=True)
+        self.assertEqual(again.curve_id, point.curve_id)
+
+        # It is distinct from a single-vertex projection of one endpoint.
+        vtx = project_mesh_vertex(self.sketch, source, 0, construction=True)
+        self.assertNotEqual(vtx.curve_id, point.curve_id)
+
+        # Degenerate / out-of-range inputs are no-ops, not crashes.
+        self.assertIsNone(project_mesh_edge_midpoint(self.sketch, source, 0, 0))
+        self.assertIsNone(project_mesh_edge_midpoint(self.sketch, source, 0, 99))
+
+    def test_edge_midpoint_tracks_a_moving_endpoint(self):
+        # Moving one endpoint drags the midpoint by half the delta.
+        source = self._mesh_object()
+        point = project_mesh_edge_midpoint(self.sketch, source, 0, 1, construction=True)
+        self.assertLess((point.co - Vector((1.0, 0.0))).length, 1e-6)
+
+        source.data.vertices[1].co = (4.0, 0.0, 1.0)  # was (2,0,1)
+        source.data.update()
+        self.context.view_layer.update()
+        depsgraph = self.context.evaluated_depsgraph_get()
+        refresh_projection_for_sketch(self.sketch, depsgraph, force=True)
+        # Midpoint of (0,0) and (4,0) is (2,0).
+        self.assertLess((point.co - Vector((2.0, 0.0))).length, 1e-5)
+
+    def test_edge_midpoint_tracks_object_translation(self):
+        # Translating the whole object moves the bound midpoint with it.
+        source = self._mesh_object()
+        point = project_mesh_edge_midpoint(self.sketch, source, 0, 1, construction=True)
+
+        source.location = (10.0, 0.0, 0.0)
+        self.context.view_layer.update()
+        depsgraph = self.context.evaluated_depsgraph_get()
+        refresh_projection_for_sketch(self.sketch, depsgraph, changed={source})
+        self.assertLess((point.co - Vector((11.0, 0.0))).length, 1e-5)
 
     def test_project_mesh_vertex_places_at_snapped_world_co(self):
         # A snap hands the evaluated world position; the point lands there rather

--- a/testing/test_projection_anchor.py
+++ b/testing/test_projection_anchor.py
@@ -11,6 +11,7 @@ from ..utilities.projection_anchor import (
     project_curves_object,
     project_mesh_element,
     project_mesh_object,
+    project_mesh_vertex,
     refresh_projection_for_sketch,
 )
 from .utils import Sketch2dTestCase
@@ -259,3 +260,33 @@ class TestProjectionAnchor(Sketch2dTestCase):
         # The standalone point landed at its position.
         self.assertTrue(any((p.co - Vector((3.0, 4.0))).length < 1e-6 for p in points))
         self.assertEqual(skipped, 1, "the arc must be counted as skipped")
+
+    def test_project_single_vertex_dedup_and_live(self):
+        # The granular snap path: one vertex -> one live point, reused on repeat.
+        source = self._mesh_object()
+
+        point = project_mesh_vertex(self.sketch, source, 1, construction=True)
+        self.assertIsNotNone(point)
+        self.assertTrue(point.fixed)
+        self.assertTrue(point.construction)
+        self.assertLess((point.co - Vector((2.0, 0.0))).length, 1e-6)
+
+        # Snapping the same vertex again must reuse the existing point, not stack
+        # a second projected reference on top of it.
+        again = project_mesh_vertex(self.sketch, source, 1, construction=True)
+        self.assertEqual(again.curve_id, point.curve_id)
+
+        # A different vertex gets its own point.
+        other = project_mesh_vertex(self.sketch, source, 0, construction=True)
+        self.assertNotEqual(other.curve_id, point.curve_id)
+
+        # Out-of-range index is a no-op rather than a crash.
+        self.assertIsNone(project_mesh_vertex(self.sketch, source, 99))
+
+        # The live link tracks source edits, same as a full projection.
+        source.data.vertices[1].co = (4.0, 1.0, 1.0)
+        source.data.update()
+        self.context.view_layer.update()
+        depsgraph = self.context.evaluated_depsgraph_get()
+        refresh_projection_for_sketch(self.sketch, depsgraph, force=True)
+        self.assertLess((point.co - Vector((4.0, 1.0))).length, 1e-5)

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -32,11 +32,6 @@ PROJECT_SRC_SLOT_ATTR = "slvs_project_src_slot"
 PROJECT_VERTEX_ID_ATTR = "slvs_project_vertex_id"
 PROJECT_VERTEX_INDEX_ATTR = "slvs_project_vertex_index"
 PROJECT_LAST_CO_ATTR = "slvs_project_last_co"
-# A second bound vertex, used only for edge-midpoint bindings: the point rides at
-# the midpoint of vertex_id and vertex_id_2. Zero here marks a single-vertex
-# binding (the common case), so existing bindings read as before.
-PROJECT_VERTEX_ID_2_ATTR = "slvs_project_vertex_id_2"
-PROJECT_VERTEX_INDEX_2_ATTR = "slvs_project_vertex_index_2"
 
 _updating = False
 
@@ -69,8 +64,6 @@ def _ensure_projection_attributes(curve_data):
     ensure_attribute(attributes, PROJECT_VERTEX_ID_ATTR, "INT", "CURVE")
     ensure_attribute(attributes, PROJECT_VERTEX_INDEX_ATTR, "INT", "CURVE")
     ensure_attribute(attributes, PROJECT_LAST_CO_ATTR, "FLOAT_VECTOR", "CURVE")
-    ensure_attribute(attributes, PROJECT_VERTEX_ID_2_ATTR, "INT", "CURVE")
-    ensure_attribute(attributes, PROJECT_VERTEX_INDEX_2_ATTR, "INT", "CURVE")
 
 
 def _get_or_add_source_slot(owner, source):
@@ -99,16 +92,12 @@ def _source_point_index(source, vertex_index):
     return Vector(source.data.points[vertex_index].position)
 
 
-def bind_projected_point(sketch, point, source, vertex_index, vertex_index_2=None):
+def bind_projected_point(sketch, point, source, vertex_index):
     """Bind a native sketch point to a source element.
 
     The source is a mesh (bind to a vertex) or another sketch/curve (bind to a
     control point). Both mint the persistent id on the source's POINT-domain
     ``VERTEX_ID_ATTR`` so the reproject can find the element after edits.
-
-    Pass ``vertex_index_2`` to bind an edge *midpoint*: the point then rides at the
-    midpoint of the two source vertices and tracks either one moving. Leaving it
-    ``None`` is the ordinary single-vertex binding.
     """
     if source is None or source.type not in (_MESH_SOURCE | _CURVE_SOURCE):
         raise TypeError("Projected geometry source must be a mesh or sketch/curve")
@@ -122,34 +111,17 @@ def bind_projected_point(sketch, point, source, vertex_index, vertex_index_2=Non
     source_slot = _get_or_add_source_slot(sketch.target_object, source)
     attributes = curve_data.attributes
 
-    if vertex_index_2 is None:
-        vertex_id_2 = 0
-        last_co = _source_point_index(source, vertex_index)
-    else:
-        vertex_id_2 = ensure_vertex_id(source.data, vertex_index_2)
-        last_co = (
-            _source_point_index(source, vertex_index)
-            + _source_point_index(source, vertex_index_2)
-        ) / 2
-
     attributes[PROJECT_SRC_SLOT_ATTR].data[curve_index].value = source_slot
     attributes[PROJECT_VERTEX_ID_ATTR].data[curve_index].value = vertex_id
     attributes[PROJECT_VERTEX_INDEX_ATTR].data[curve_index].value = int(vertex_index)
-    attributes[PROJECT_VERTEX_ID_2_ATTR].data[curve_index].value = vertex_id_2
-    attributes[PROJECT_VERTEX_INDEX_2_ATTR].data[curve_index].value = (
-        int(vertex_index_2) if vertex_index_2 is not None else 0
+    attributes[PROJECT_LAST_CO_ATTR].data[curve_index].vector = _source_point_index(
+        source, vertex_index
     )
-    attributes[PROJECT_LAST_CO_ATTR].data[curve_index].vector = last_co
     return vertex_id
 
 
 def iter_projected_point_bindings(sketch):
-    """Yield ``(curve_id, source, vertex_id, fallback_index, last_co, binding2)``.
-
-    ``binding2`` is ``None`` for a single-vertex binding, or ``(vertex_id_2,
-    fallback_index_2)`` for an edge-midpoint binding (the point rides at the
-    midpoint of the two vertices).
-    """
+    """Yield ``(curve_id, source, vertex_id, fallback_index, last_co)``."""
     owner = sketch.target_object
     curve_data = sketch.data
     if owner is None or curve_data is None:
@@ -162,11 +134,6 @@ def iter_projected_point_bindings(sketch):
     last_co_attr = attributes.get(PROJECT_LAST_CO_ATTR)
     if not all((slot_attr, vertex_id_attr, fallback_attr, last_co_attr)):
         return
-
-    # Second-vertex attrs are absent on sketches whose bindings predate midpoint
-    # support; treat a missing attr as "all single-vertex".
-    vertex_id_2_attr = attributes.get(PROJECT_VERTEX_ID_2_ATTR)
-    fallback_2_attr = attributes.get(PROJECT_VERTEX_INDEX_2_ATTR)
 
     curve_ids = read_curve_id_list(curve_data)
     slots = owner.slvs_project_sources
@@ -181,19 +148,7 @@ def iter_projected_point_bindings(sketch):
         source = slots[slot_index].source if 0 <= slot_index < len(slots) else None
         fallback = int(fallback_attr.data[index].value)
         last_co = tuple(last_co_attr.data[index].vector)
-
-        binding2 = None
-        if vertex_id_2_attr is not None:
-            vertex_id_2 = int(vertex_id_2_attr.data[index].value)
-            if vertex_id_2 > 0:
-                fallback_2 = (
-                    int(fallback_2_attr.data[index].value)
-                    if fallback_2_attr is not None
-                    else 0
-                )
-                binding2 = (vertex_id_2, fallback_2)
-
-        yield curve_id, source, vertex_id, fallback, last_co, binding2
+        yield curve_id, source, vertex_id, fallback, last_co
 
 
 def _resolve_evaluated_vertex(eval_ob, vertex_id, fallback_index, last_co):
@@ -272,7 +227,7 @@ def refresh_projection_for_sketch(sketch, depsgraph, changed=None, force=False):
     updates = {}
     source_cache = {}
 
-    for curve_id, source, vertex_id, fallback_index, last_co, binding2 in list(
+    for curve_id, source, vertex_id, fallback_index, last_co in list(
         iter_projected_point_bindings(sketch)
     ):
         point = PointRef(sketch, curve_id)
@@ -298,29 +253,12 @@ def refresh_projection_for_sketch(sketch, depsgraph, changed=None, force=False):
             if eval_ob is None:
                 eval_ob = source.evaluated_get(depsgraph)
                 source_cache[source] = eval_ob
-            # last_co disambiguates duplicate ids by proximity, but for a midpoint
-            # binding it stores the midpoint (not either vertex), so skip that
-            # tie-break here and resolve each endpoint by id/index alone.
             vertex = _resolve_evaluated_vertex(
-                eval_ob,
-                vertex_id,
-                fallback_index,
-                None if binding2 is not None else last_co,
+                eval_ob, vertex_id, fallback_index, last_co
             )
             if vertex is None:
                 continue
             source_co = Vector(vertex.co)
-            # Edge-midpoint binding: average the two endpoint vertices so the point
-            # tracks either one moving. A missing second vertex detaches this frame
-            # (skip) rather than snapping to the lone endpoint.
-            if binding2 is not None:
-                vertex_id_2, fallback_2 = binding2
-                vertex_b = _resolve_evaluated_vertex(
-                    eval_ob, vertex_id_2, fallback_2, None
-                )
-                if vertex_b is None:
-                    continue
-                source_co = (source_co + Vector(vertex_b.co)) / 2
             world = eval_ob.matrix_world @ source_co
         else:
             source_co = _resolve_curve_point(
@@ -395,36 +333,8 @@ def find_projected_vertex_point(sketch, source, vertex_id):
         bound_vid,
         _fallback,
         _last_co,
-        binding2,
     ) in iter_projected_point_bindings(sketch):
-        # A midpoint binding is a distinct target -- don't hand it back as a
-        # single-vertex reuse.
-        if binding2 is None and bound_source == source and bound_vid == vertex_id:
-            existing = PointRef(sketch, curve_id)
-            if existing.valid:
-                return existing
-    return None
-
-
-def find_projected_midpoint(sketch, source, vertex_id, vertex_id_2):
-    """Return an existing point bound to ``source``'s edge midpoint, or None.
-
-    Matches the unordered pair of persistent source vertex ids, so re-snapping the
-    same edge midpoint reuses the one live point (and repeated snaps coincide on
-    it) regardless of which endpoint was resolved first.
-    """
-    wanted = {vertex_id, vertex_id_2}
-    for (
-        curve_id,
-        bound_source,
-        bound_vid,
-        _fallback,
-        _last_co,
-        binding2,
-    ) in iter_projected_point_bindings(sketch):
-        if binding2 is None or bound_source != source:
-            continue
-        if {bound_vid, binding2[0]} == wanted:
+        if bound_source == source and bound_vid == vertex_id:
             existing = PointRef(sketch, curve_id)
             if existing.valid:
                 return existing
@@ -622,57 +532,6 @@ def project_mesh_vertex(sketch, source, vertex_index, construction=True, world_c
             name="Projected Point",
         )
         bind_projected_point(sketch, point, source, vertex_index)
-    return point
-
-
-def project_mesh_edge_midpoint(
-    sketch, source, vertex_index, vertex_index_2, construction=True, world_co=None
-):
-    """Project a source edge's midpoint onto ``sketch`` as a live point.
-
-    The snap counterpart to :func:`project_mesh_vertex` for edge-midpoint snaps:
-    the point is bound to *both* endpoint vertices and rides at their midpoint, so
-    it tracks either endpoint (or the whole object) moving. Repeated snaps to the
-    same edge midpoint are deduplicated on the unordered vertex-id pair. Returns
-    the ``PointRef`` (fixed, driven by the edge), or None if an index is out of
-    range or the two indices coincide.
-
-    ``world_co`` places the point at the snapped hit (the evaluated midpoint),
-    avoiding a one-frame jump under a vertex-moving modifier; it defaults to the
-    midpoint of the original vertices.
-    """
-    if source is None or source.type != "MESH":
-        raise TypeError("Source must be a mesh object")
-    mesh = source.data
-    n = len(mesh.vertices)
-    if not (0 <= vertex_index < n and 0 <= vertex_index_2 < n):
-        return None
-    if vertex_index == vertex_index_2:
-        return None
-
-    vertex_id = ensure_vertex_id(mesh, vertex_index)
-    vertex_id_2 = ensure_vertex_id(mesh, vertex_index_2)
-    existing = find_projected_midpoint(sketch, source, vertex_id, vertex_id_2)
-    if existing is not None:
-        return existing
-
-    owner = sketch.target_object
-    if world_co is not None:
-        world = Vector(world_co)
-    else:
-        world = source.matrix_world @ (
-            (mesh.vertices[vertex_index].co + mesh.vertices[vertex_index_2].co) / 2
-        )
-    local = owner.matrix_world.inverted() @ world
-    with batch_update(sketch):
-        point = PointRef.create(
-            sketch,
-            (local.x, local.y),
-            construction=construction,
-            fixed=True,
-            name="Projected Point",
-        )
-        bind_projected_point(sketch, point, source, vertex_index, vertex_index_2)
     return point
 
 

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -32,6 +32,11 @@ PROJECT_SRC_SLOT_ATTR = "slvs_project_src_slot"
 PROJECT_VERTEX_ID_ATTR = "slvs_project_vertex_id"
 PROJECT_VERTEX_INDEX_ATTR = "slvs_project_vertex_index"
 PROJECT_LAST_CO_ATTR = "slvs_project_last_co"
+# A second bound vertex, used only for edge-midpoint bindings: the point rides at
+# the midpoint of vertex_id and vertex_id_2. Zero here marks a single-vertex
+# binding (the common case), so existing bindings read as before.
+PROJECT_VERTEX_ID_2_ATTR = "slvs_project_vertex_id_2"
+PROJECT_VERTEX_INDEX_2_ATTR = "slvs_project_vertex_index_2"
 
 _updating = False
 
@@ -64,6 +69,8 @@ def _ensure_projection_attributes(curve_data):
     ensure_attribute(attributes, PROJECT_VERTEX_ID_ATTR, "INT", "CURVE")
     ensure_attribute(attributes, PROJECT_VERTEX_INDEX_ATTR, "INT", "CURVE")
     ensure_attribute(attributes, PROJECT_LAST_CO_ATTR, "FLOAT_VECTOR", "CURVE")
+    ensure_attribute(attributes, PROJECT_VERTEX_ID_2_ATTR, "INT", "CURVE")
+    ensure_attribute(attributes, PROJECT_VERTEX_INDEX_2_ATTR, "INT", "CURVE")
 
 
 def _get_or_add_source_slot(owner, source):
@@ -92,12 +99,16 @@ def _source_point_index(source, vertex_index):
     return Vector(source.data.points[vertex_index].position)
 
 
-def bind_projected_point(sketch, point, source, vertex_index):
+def bind_projected_point(sketch, point, source, vertex_index, vertex_index_2=None):
     """Bind a native sketch point to a source element.
 
     The source is a mesh (bind to a vertex) or another sketch/curve (bind to a
     control point). Both mint the persistent id on the source's POINT-domain
     ``VERTEX_ID_ATTR`` so the reproject can find the element after edits.
+
+    Pass ``vertex_index_2`` to bind an edge *midpoint*: the point then rides at the
+    midpoint of the two source vertices and tracks either one moving. Leaving it
+    ``None`` is the ordinary single-vertex binding.
     """
     if source is None or source.type not in (_MESH_SOURCE | _CURVE_SOURCE):
         raise TypeError("Projected geometry source must be a mesh or sketch/curve")
@@ -111,17 +122,34 @@ def bind_projected_point(sketch, point, source, vertex_index):
     source_slot = _get_or_add_source_slot(sketch.target_object, source)
     attributes = curve_data.attributes
 
+    if vertex_index_2 is None:
+        vertex_id_2 = 0
+        last_co = _source_point_index(source, vertex_index)
+    else:
+        vertex_id_2 = ensure_vertex_id(source.data, vertex_index_2)
+        last_co = (
+            _source_point_index(source, vertex_index)
+            + _source_point_index(source, vertex_index_2)
+        ) / 2
+
     attributes[PROJECT_SRC_SLOT_ATTR].data[curve_index].value = source_slot
     attributes[PROJECT_VERTEX_ID_ATTR].data[curve_index].value = vertex_id
     attributes[PROJECT_VERTEX_INDEX_ATTR].data[curve_index].value = int(vertex_index)
-    attributes[PROJECT_LAST_CO_ATTR].data[curve_index].vector = _source_point_index(
-        source, vertex_index
+    attributes[PROJECT_VERTEX_ID_2_ATTR].data[curve_index].value = vertex_id_2
+    attributes[PROJECT_VERTEX_INDEX_2_ATTR].data[curve_index].value = (
+        int(vertex_index_2) if vertex_index_2 is not None else 0
     )
+    attributes[PROJECT_LAST_CO_ATTR].data[curve_index].vector = last_co
     return vertex_id
 
 
 def iter_projected_point_bindings(sketch):
-    """Yield ``(curve_id, source, vertex_id, fallback_index, last_co)``."""
+    """Yield ``(curve_id, source, vertex_id, fallback_index, last_co, binding2)``.
+
+    ``binding2`` is ``None`` for a single-vertex binding, or ``(vertex_id_2,
+    fallback_index_2)`` for an edge-midpoint binding (the point rides at the
+    midpoint of the two vertices).
+    """
     owner = sketch.target_object
     curve_data = sketch.data
     if owner is None or curve_data is None:
@@ -134,6 +162,11 @@ def iter_projected_point_bindings(sketch):
     last_co_attr = attributes.get(PROJECT_LAST_CO_ATTR)
     if not all((slot_attr, vertex_id_attr, fallback_attr, last_co_attr)):
         return
+
+    # Second-vertex attrs are absent on sketches whose bindings predate midpoint
+    # support; treat a missing attr as "all single-vertex".
+    vertex_id_2_attr = attributes.get(PROJECT_VERTEX_ID_2_ATTR)
+    fallback_2_attr = attributes.get(PROJECT_VERTEX_INDEX_2_ATTR)
 
     curve_ids = read_curve_id_list(curve_data)
     slots = owner.slvs_project_sources
@@ -148,7 +181,19 @@ def iter_projected_point_bindings(sketch):
         source = slots[slot_index].source if 0 <= slot_index < len(slots) else None
         fallback = int(fallback_attr.data[index].value)
         last_co = tuple(last_co_attr.data[index].vector)
-        yield curve_id, source, vertex_id, fallback, last_co
+
+        binding2 = None
+        if vertex_id_2_attr is not None:
+            vertex_id_2 = int(vertex_id_2_attr.data[index].value)
+            if vertex_id_2 > 0:
+                fallback_2 = (
+                    int(fallback_2_attr.data[index].value)
+                    if fallback_2_attr is not None
+                    else 0
+                )
+                binding2 = (vertex_id_2, fallback_2)
+
+        yield curve_id, source, vertex_id, fallback, last_co, binding2
 
 
 def _resolve_evaluated_vertex(eval_ob, vertex_id, fallback_index, last_co):
@@ -227,7 +272,7 @@ def refresh_projection_for_sketch(sketch, depsgraph, changed=None, force=False):
     updates = {}
     source_cache = {}
 
-    for curve_id, source, vertex_id, fallback_index, last_co in list(
+    for curve_id, source, vertex_id, fallback_index, last_co, binding2 in list(
         iter_projected_point_bindings(sketch)
     ):
         point = PointRef(sketch, curve_id)
@@ -253,12 +298,29 @@ def refresh_projection_for_sketch(sketch, depsgraph, changed=None, force=False):
             if eval_ob is None:
                 eval_ob = source.evaluated_get(depsgraph)
                 source_cache[source] = eval_ob
+            # last_co disambiguates duplicate ids by proximity, but for a midpoint
+            # binding it stores the midpoint (not either vertex), so skip that
+            # tie-break here and resolve each endpoint by id/index alone.
             vertex = _resolve_evaluated_vertex(
-                eval_ob, vertex_id, fallback_index, last_co
+                eval_ob,
+                vertex_id,
+                fallback_index,
+                None if binding2 is not None else last_co,
             )
             if vertex is None:
                 continue
             source_co = Vector(vertex.co)
+            # Edge-midpoint binding: average the two endpoint vertices so the point
+            # tracks either one moving. A missing second vertex detaches this frame
+            # (skip) rather than snapping to the lone endpoint.
+            if binding2 is not None:
+                vertex_id_2, fallback_2 = binding2
+                vertex_b = _resolve_evaluated_vertex(
+                    eval_ob, vertex_id_2, fallback_2, None
+                )
+                if vertex_b is None:
+                    continue
+                source_co = (source_co + Vector(vertex_b.co)) / 2
             world = eval_ob.matrix_world @ source_co
         else:
             source_co = _resolve_curve_point(
@@ -297,36 +359,21 @@ def update_projected_geometry(context, depsgraph):
         if original is not None:
             changed.add(original)
 
-    import logging
-
     from .. import global_data
     from ..model.sketch_ref import get_sketches
 
-    _dbg = logging.getLogger(__name__).warning
-
     if global_data.stateful_op_running:
-        _dbg("SNAPPROJ handler skip: stateful_op_running")
         return
 
     _updating = True
     try:
         moved = 0
         for sketch in get_sketches(context.scene):
-            n = 0
-            bindings = list(iter_projected_point_bindings(sketch))
-            n = refresh_projection_for_sketch(
+            moved += refresh_projection_for_sketch(
                 sketch,
                 depsgraph,
                 changed=changed,
             )
-            if bindings:
-                _dbg(
-                    "SNAPPROJ handler sketch=%s bindings=%d moved=%d",
-                    getattr(sketch.target_object, "name", "?"),
-                    len(bindings),
-                    n,
-                )
-            moved += n
     finally:
         _updating = False
 
@@ -348,8 +395,36 @@ def find_projected_vertex_point(sketch, source, vertex_id):
         bound_vid,
         _fallback,
         _last_co,
+        binding2,
     ) in iter_projected_point_bindings(sketch):
-        if bound_source == source and bound_vid == vertex_id:
+        # A midpoint binding is a distinct target -- don't hand it back as a
+        # single-vertex reuse.
+        if binding2 is None and bound_source == source and bound_vid == vertex_id:
+            existing = PointRef(sketch, curve_id)
+            if existing.valid:
+                return existing
+    return None
+
+
+def find_projected_midpoint(sketch, source, vertex_id, vertex_id_2):
+    """Return an existing point bound to ``source``'s edge midpoint, or None.
+
+    Matches the unordered pair of persistent source vertex ids, so re-snapping the
+    same edge midpoint reuses the one live point (and repeated snaps coincide on
+    it) regardless of which endpoint was resolved first.
+    """
+    wanted = {vertex_id, vertex_id_2}
+    for (
+        curve_id,
+        bound_source,
+        bound_vid,
+        _fallback,
+        _last_co,
+        binding2,
+    ) in iter_projected_point_bindings(sketch):
+        if binding2 is None or bound_source != source:
+            continue
+        if {bound_vid, binding2[0]} == wanted:
             existing = PointRef(sketch, curve_id)
             if existing.valid:
                 return existing
@@ -541,6 +616,57 @@ def project_mesh_vertex(sketch, source, vertex_index, construction=True, world_c
             name="Projected Point",
         )
         bind_projected_point(sketch, point, source, vertex_index)
+    return point
+
+
+def project_mesh_edge_midpoint(
+    sketch, source, vertex_index, vertex_index_2, construction=True, world_co=None
+):
+    """Project a source edge's midpoint onto ``sketch`` as a live point.
+
+    The snap counterpart to :func:`project_mesh_vertex` for edge-midpoint snaps:
+    the point is bound to *both* endpoint vertices and rides at their midpoint, so
+    it tracks either endpoint (or the whole object) moving. Repeated snaps to the
+    same edge midpoint are deduplicated on the unordered vertex-id pair. Returns
+    the ``PointRef`` (fixed, driven by the edge), or None if an index is out of
+    range or the two indices coincide.
+
+    ``world_co`` places the point at the snapped hit (the evaluated midpoint),
+    avoiding a one-frame jump under a vertex-moving modifier; it defaults to the
+    midpoint of the original vertices.
+    """
+    if source is None or source.type != "MESH":
+        raise TypeError("Source must be a mesh object")
+    mesh = source.data
+    n = len(mesh.vertices)
+    if not (0 <= vertex_index < n and 0 <= vertex_index_2 < n):
+        return None
+    if vertex_index == vertex_index_2:
+        return None
+
+    vertex_id = ensure_vertex_id(mesh, vertex_index)
+    vertex_id_2 = ensure_vertex_id(mesh, vertex_index_2)
+    existing = find_projected_midpoint(sketch, source, vertex_id, vertex_id_2)
+    if existing is not None:
+        return existing
+
+    owner = sketch.target_object
+    if world_co is not None:
+        world = Vector(world_co)
+    else:
+        world = source.matrix_world @ (
+            (mesh.vertices[vertex_index].co + mesh.vertices[vertex_index_2].co) / 2
+        )
+    local = owner.matrix_world.inverted() @ world
+    with batch_update(sketch):
+        point = PointRef.create(
+            sketch,
+            (local.x, local.y),
+            construction=construction,
+            fixed=True,
+            name="Projected Point",
+        )
+        bind_projected_point(sketch, point, source, vertex_index, vertex_index_2)
     return point
 
 

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -297,21 +297,36 @@ def update_projected_geometry(context, depsgraph):
         if original is not None:
             changed.add(original)
 
+    import logging
+
     from .. import global_data
     from ..model.sketch_ref import get_sketches
 
+    _dbg = logging.getLogger(__name__).warning
+
     if global_data.stateful_op_running:
+        _dbg("SNAPPROJ handler skip: stateful_op_running")
         return
 
     _updating = True
     try:
         moved = 0
         for sketch in get_sketches(context.scene):
-            moved += refresh_projection_for_sketch(
+            n = 0
+            bindings = list(iter_projected_point_bindings(sketch))
+            n = refresh_projection_for_sketch(
                 sketch,
                 depsgraph,
                 changed=changed,
             )
+            if bindings:
+                _dbg(
+                    "SNAPPROJ handler sketch=%s bindings=%d moved=%d",
+                    getattr(sketch.target_object, "name", "?"),
+                    len(bindings),
+                    n,
+                )
+            moved += n
     finally:
         _updating = False
 

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -442,25 +442,31 @@ def find_projected_point(sketch, source, vertex_index):
     return find_projected_vertex_point(sketch, source, vertex_id)
 
 
+def _line_curve_id_between(sketch, p1, p2):
+    """curve_id of a native line connecting ``p1`` and ``p2`` (either order), or None."""
+    curve_data = sketch.data
+    type_attr = curve_data.attributes.get("sketch_type")
+    if not type_attr:
+        return None
+    starts = read_uuid_list(curve_data, "start_point_id")
+    ends = read_uuid_list(curve_data, "end_point_id")
+    curve_ids = read_curve_id_list(curve_data)
+    wanted = {p1.curve_id, p2.curve_id}
+    for index in range(len(curve_data.curves)):
+        if type_attr.data[index].value != SketchCurveType.LINE:
+            continue
+        if {starts[index], ends[index]} == wanted:
+            return curve_ids[index]
+    return None
+
+
 def _line_exists_between(sketch, p1, p2):
     """Whether a native line already connects ``p1`` and ``p2`` (either order).
 
     Re-projecting the same edge or face reuses its already-projected points, so
     without this the connecting lines would stack a fresh duplicate every time.
     """
-    curve_data = sketch.data
-    type_attr = curve_data.attributes.get("sketch_type")
-    if not type_attr:
-        return False
-    starts = read_uuid_list(curve_data, "start_point_id")
-    ends = read_uuid_list(curve_data, "end_point_id")
-    wanted = {p1.curve_id, p2.curve_id}
-    for index in range(len(curve_data.curves)):
-        if type_attr.data[index].value != SketchCurveType.LINE:
-            continue
-        if {starts[index], ends[index]} == wanted:
-            return True
-    return False
+    return _line_curve_id_between(sketch, p1, p2) is not None
 
 
 def project_mesh_element(sketch, source, elem_type, elem_index, construction=True):
@@ -668,6 +674,60 @@ def project_mesh_edge_midpoint(
         )
         bind_projected_point(sketch, point, source, vertex_index, vertex_index_2)
     return point
+
+
+def project_mesh_edge(sketch, source, vertex_index, vertex_index_2, construction=True):
+    """Project a source edge onto ``sketch`` as a live line, returning its ``LineRef``.
+
+    The snap counterpart for snapping *along* an edge (not at a vertex or the
+    midpoint): the edge is projected as a live construction line bound to both
+    endpoints, and the caller coincides the placed point onto that line so it
+    slides along the edge instead of being pinned. Endpoints and the line are
+    deduplicated, so re-snapping the same edge reuses them. Returns None if an
+    index is out of range, the indices coincide, or the edge collapses to a point
+    on the sketch plane (a zero-length line the solver cannot use).
+    """
+    if source is None or source.type != "MESH":
+        raise TypeError("Source must be a mesh object")
+    mesh = source.data
+    n = len(mesh.vertices)
+    if not (0 <= vertex_index < n and 0 <= vertex_index_2 < n):
+        return None
+    if vertex_index == vertex_index_2:
+        return None
+
+    owner = sketch.target_object
+    inv = owner.matrix_world.inverted()
+
+    def _endpoint(index):
+        existing = find_projected_point(sketch, source, index)
+        if existing is not None:
+            return existing
+        local = inv @ (source.matrix_world @ mesh.vertices[index].co)
+        point = PointRef.create(
+            sketch,
+            (local.x, local.y),
+            construction=construction,
+            fixed=True,
+            name="Projected Point",
+        )
+        bind_projected_point(sketch, point, source, index)
+        return point
+
+    with batch_update(sketch):
+        p0 = _endpoint(vertex_index)
+        p1 = _endpoint(vertex_index_2)
+        # An edge perpendicular to the sketch plane collapses to a point; a
+        # zero-length line is useless to the solver and to a point-on-line
+        # coincidence, so bail to the static fallback.
+        if (p0.co - p1.co).length < 1e-6:
+            return None
+        existing_line = _line_curve_id_between(sketch, p0, p1)
+        if existing_line:
+            return LineRef(sketch, existing_line)
+        return LineRef.create(
+            sketch, p0, p1, construction=construction, name="Projected Line"
+        )
 
 
 def project_mesh_object(sketch, source, construction=True):

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -320,29 +320,12 @@ def update_projected_geometry(context, depsgraph):
         global_data.needs_redraw = True
 
 
-def find_projected_point(sketch, source, vertex_index):
-    """Return an existing valid ``PointRef`` bound to ``(source, vertex_index)``.
-
-    Lets repeated element picks reuse a shared corner instead of stacking
-    duplicate points, so an edge and an adjacent face project as one connected
-    outline. Matched on the fallback vertex index (stable at creation time).
-    """
-    for curve_id, bound_source, _vid, fallback, _last in iter_projected_point_bindings(
-        sketch
-    ):
-        if bound_source == source and fallback == int(vertex_index):
-            point = PointRef(sketch, curve_id)
-            if point.valid:
-                return point
-    return None
-
-
 def find_projected_vertex_point(sketch, source, vertex_id):
     """Return an existing live point bound to ``source``'s ``vertex_id``, or None.
 
-    Like :func:`find_projected_point` but matched on the persistent source vertex
-    id (survives topology edits) rather than the creation-time index. Used by the
-    snap path, which mints/knows the id before placing.
+    The single dedup used by both the projection tool and the snap path: matches
+    on the persistent source vertex id, which survives topology edits that
+    reshuffle indices, rather than the creation-time index.
     """
     for (
         curve_id,
@@ -356,6 +339,17 @@ def find_projected_vertex_point(sketch, source, vertex_id):
             if existing.valid:
                 return existing
     return None
+
+
+def find_projected_point(sketch, source, vertex_index):
+    """Return an existing valid ``PointRef`` bound to ``(source, vertex_index)``.
+
+    Resolves the vertex to its persistent source id and matches on that (via
+    :func:`find_projected_vertex_point`), so repeated element picks reuse a
+    shared corner even after topology edits shuffle the raw indices.
+    """
+    vertex_id = ensure_vertex_id(source.data, int(vertex_index))
+    return find_projected_vertex_point(sketch, source, vertex_id)
 
 
 def _line_exists_between(sketch, p1, p2):
@@ -458,7 +452,39 @@ def project_mesh_element(sketch, source, elem_type, elem_index, construction=Tru
     return counters["points"], counters["lines"]
 
 
-def project_mesh_vertex(sketch, source, vertex_index, construction=True):
+def resolve_source_vertex_index(source, eval_source, eval_vertex_index):
+    """Map an evaluated-mesh vertex index back to the original mesh vertex.
+
+    Snapping picks a vertex on the *evaluated* mesh, but a live projection must
+    bind the *original* vertex. When the evaluated mesh carries the persistent
+    vertex id (already-tagged / previously projected vertices), match on that so
+    the binding is index-independent and survives index-shuffling modifiers.
+    Otherwise the index only corresponds when the modifier stack preserves vertex
+    order, which we approximate by an equal vertex count. Returns the original
+    index, or None when the correspondence can't be trusted.
+    """
+    orig_mesh = source.data
+    eval_mesh = eval_source.data
+    if not (0 <= eval_vertex_index < len(eval_mesh.vertices)):
+        return None
+
+    eval_attr = eval_mesh.attributes.get(VERTEX_ID_ATTR)
+    if eval_attr is not None and eval_attr.domain == "POINT":
+        vid = int(eval_attr.data[eval_vertex_index].value)
+        if vid:
+            orig_attr = orig_mesh.attributes.get(VERTEX_ID_ATTR)
+            if orig_attr is not None and orig_attr.domain == "POINT":
+                for index, item in enumerate(orig_attr.data):
+                    if int(item.value) == vid and index < len(orig_mesh.vertices):
+                        return index
+
+    # No id to match on: trust the index only when topology is preserved.
+    if len(eval_mesh.vertices) == len(orig_mesh.vertices):
+        return eval_vertex_index
+    return None
+
+
+def project_mesh_vertex(sketch, source, vertex_index, construction=True, world_co=None):
     """Project a single source mesh vertex onto ``sketch`` as a live point.
 
     Unlike :func:`project_mesh_object` (which projects a whole mesh), this is the
@@ -467,6 +493,11 @@ def project_mesh_vertex(sketch, source, vertex_index, construction=True):
     they share a single projected point (and thus become coincident). Returns the
     ``PointRef`` (fixed, driven by the source vertex), or None if the index is out
     of range.
+
+    ``world_co`` is the world-space position to place the point at, typically the
+    snap's evaluated hit. Passing it avoids a one-frame jump when the source has a
+    vertex-moving modifier (the original vertex position differs from the snapped,
+    evaluated one). It defaults to the original vertex position.
     """
     if source is None or source.type != "MESH":
         raise TypeError("Source must be a mesh object")
@@ -480,9 +511,12 @@ def project_mesh_vertex(sketch, source, vertex_index, construction=True):
         return existing
 
     owner = sketch.target_object
-    local = owner.matrix_world.inverted() @ (
-        source.matrix_world @ mesh.vertices[vertex_index].co
-    )
+    if world_co is not None:
+        local = owner.matrix_world.inverted() @ Vector(world_co)
+    else:
+        local = owner.matrix_world.inverted() @ (
+            source.matrix_world @ mesh.vertices[vertex_index].co
+        )
     with batch_update(sketch):
         point = PointRef.create(
             sketch,

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -337,6 +337,27 @@ def find_projected_point(sketch, source, vertex_index):
     return None
 
 
+def find_projected_vertex_point(sketch, source, vertex_id):
+    """Return an existing live point bound to ``source``'s ``vertex_id``, or None.
+
+    Like :func:`find_projected_point` but matched on the persistent source vertex
+    id (survives topology edits) rather than the creation-time index. Used by the
+    snap path, which mints/knows the id before placing.
+    """
+    for (
+        curve_id,
+        bound_source,
+        bound_vid,
+        _fallback,
+        _last_co,
+    ) in iter_projected_point_bindings(sketch):
+        if bound_source == source and bound_vid == vertex_id:
+            existing = PointRef(sketch, curve_id)
+            if existing.valid:
+                return existing
+    return None
+
+
 def _line_exists_between(sketch, p1, p2):
     """Whether a native line already connects ``p1`` and ``p2`` (either order).
 
@@ -435,6 +456,43 @@ def project_mesh_element(sketch, source, elem_type, elem_index, construction=Tru
             raise ValueError(f"Unsupported element type: {elem_type!r}")
 
     return counters["points"], counters["lines"]
+
+
+def project_mesh_vertex(sketch, source, vertex_index, construction=True):
+    """Project a single source mesh vertex onto ``sketch`` as a live point.
+
+    Unlike :func:`project_mesh_object` (which projects a whole mesh), this is the
+    granular path used by snapping: a point snapped to one vertex gets one live
+    projected reference. Repeated snaps to the same vertex are deduplicated so
+    they share a single projected point (and thus become coincident). Returns the
+    ``PointRef`` (fixed, driven by the source vertex), or None if the index is out
+    of range.
+    """
+    if source is None or source.type != "MESH":
+        raise TypeError("Source must be a mesh object")
+    mesh = source.data
+    if not (0 <= vertex_index < len(mesh.vertices)):
+        return None
+
+    vertex_id = ensure_vertex_id(mesh, vertex_index)
+    existing = find_projected_vertex_point(sketch, source, vertex_id)
+    if existing is not None:
+        return existing
+
+    owner = sketch.target_object
+    local = owner.matrix_world.inverted() @ (
+        source.matrix_world @ mesh.vertices[vertex_index].co
+    )
+    with batch_update(sketch):
+        point = PointRef.create(
+            sketch,
+            (local.x, local.y),
+            construction=construction,
+            fixed=True,
+            name="Projected Point",
+        )
+        bind_projected_point(sketch, point, source, vertex_index)
+    return point
 
 
 def project_mesh_object(sketch, source, construction=True):

--- a/utilities/view.py
+++ b/utilities/view.py
@@ -149,7 +149,9 @@ def _screen_snap_candidates(
 
     if "VERTEX" in elements:
         vertex_indices = (
-            face_vertex_indices if face_vertex_indices is not None else range(len(me.vertices))
+            face_vertex_indices
+            if face_vertex_indices is not None
+            else range(len(me.vertices))
         )
         for vertex_index in vertex_indices:
             vertex = me.vertices[vertex_index]
@@ -159,12 +161,18 @@ def _screen_snap_candidates(
                 {
                     "type": "VERTEX",
                     "world_point": matrix @ vertex.co,
+                    # Provenance so a placed point can be live-projected onto this
+                    # source vertex (see projection_anchor.project_mesh_vertex).
+                    "object": obj_eval.original.name,
+                    "vertex_index": vertex.index,
                 },
             )
 
     if "EDGE" in elements or "EDGE_MIDPOINT" in elements:
         if face_edge_keys is not None:
-            face_edge_map = {edge_key: me.edges[i] for i, edge_key in enumerate(me.edge_keys)}
+            face_edge_map = {
+                edge_key: me.edges[i] for i, edge_key in enumerate(me.edge_keys)
+            }
             edges = [face_edge_map[edge_key] for edge_key in face_edge_keys]
         else:
             edges = me.edges
@@ -192,7 +200,9 @@ def _screen_snap_candidates(
                 )
 
             if "EDGE" in elements:
-                world_closest = _closest_segment_point_world(coords, world_start, world_end, region, rv3d)
+                world_closest = _closest_segment_point_world(
+                    coords, world_start, world_end, region, rv3d
+                )
                 if world_closest is None:
                     continue
                 region_point = location_3d_to_region_2d(region, rv3d, world_closest)
@@ -251,7 +261,9 @@ def _project_points_to_region(world, region, rv3d):
     return screen, valid
 
 
-def _curve_snap_candidates(context: Context, obj, coords: Vector, elements, threshold=None):
+def _curve_snap_candidates(
+    context: Context, obj, coords: Vector, elements, threshold=None
+):
     """Snap candidates from a curve object's control points and segments.
 
     Curve objects (CAD Sketcher sketches) don't expose a readable evaluated
@@ -292,10 +304,14 @@ def _curve_snap_candidates(context: Context, obj, coords: Vector, elements, thre
     if "VERTEX" in elements:
         d = np.hypot(screen[:, 0] - cur[0], screen[:, 1] - cur[1])
         for i in np.nonzero(valid & (d <= threshold))[0]:
-            candidates.append((
-                0, float(d[i]), Vector((screen[i, 0], screen[i, 1])),
-                {"type": "VERTEX", "world_point": Vector(world[i])},
-            ))
+            candidates.append(
+                (
+                    0,
+                    float(d[i]),
+                    Vector((screen[i, 0], screen[i, 1])),
+                    {"type": "VERTEX", "world_point": Vector(world[i])},
+                )
+            )
 
     if "FACE_MIDPOINT" in elements:
         # A face only exists for a closed region. Cheaply: the centroid of each
@@ -316,10 +332,14 @@ def _curve_snap_candidates(context: Context, obj, coords: Vector, elements, thre
                 continue
             dc = (cur[0] - cs[0, 0]) ** 2 + (cur[1] - cs[0, 1]) ** 2
             if dc <= thr2:
-                candidates.append((
-                    3, float(dc ** 0.5), Vector((cs[0, 0], cs[0, 1])),
-                    {"type": "FACE_MIDPOINT", "world_point": Vector(center_world)},
-                ))
+                candidates.append(
+                    (
+                        3,
+                        float(dc**0.5),
+                        Vector((cs[0, 0], cs[0, 1])),
+                        {"type": "FACE_MIDPOINT", "world_point": Vector(center_world)},
+                    )
+                )
 
     if "EDGE" in elements or "EDGE_MIDPOINT" in elements:
         thr2 = threshold * threshold
@@ -335,14 +355,18 @@ def _curve_snap_candidates(context: Context, obj, coords: Vector, elements, thre
                     mid = (sa + sb) * 0.5
                     dm = (cur[0] - mid[0]) ** 2 + (cur[1] - mid[1]) ** 2
                     if dm <= thr2:
-                        candidates.append((
-                            1, float(dm ** 0.5), Vector((mid[0], mid[1])),
-                            {
-                                "type": "EDGE_MIDPOINT",
-                                "world_point": Vector((world[a] + world[b]) * 0.5),
-                                "world_edge": (Vector(world[a]), Vector(world[b])),
-                            },
-                        ))
+                        candidates.append(
+                            (
+                                1,
+                                float(dm**0.5),
+                                Vector((mid[0], mid[1])),
+                                {
+                                    "type": "EDGE_MIDPOINT",
+                                    "world_point": Vector((world[a] + world[b]) * 0.5),
+                                    "world_edge": (Vector(world[a]), Vector(world[b])),
+                                },
+                            )
+                        )
 
                 if "EDGE" in elements:
                     # Closest point on the screen-space segment to the cursor.
@@ -350,21 +374,27 @@ def _curve_snap_candidates(context: Context, obj, coords: Vector, elements, thre
                     seg_len2 = seg[0] * seg[0] + seg[1] * seg[1]
                     if seg_len2 < 1e-9:
                         continue
-                    t = ((cur[0] - sa[0]) * seg[0] + (cur[1] - sa[1]) * seg[1]) / seg_len2
+                    t = (
+                        (cur[0] - sa[0]) * seg[0] + (cur[1] - sa[1]) * seg[1]
+                    ) / seg_len2
                     t = min(1.0, max(0.0, t))
                     cx = sa[0] + t * seg[0]
                     cy = sa[1] + t * seg[1]
                     de = (cur[0] - cx) ** 2 + (cur[1] - cy) ** 2
                     if de <= thr2:
                         world_closest = Vector(world[a]).lerp(Vector(world[b]), t)
-                        candidates.append((
-                            2, float(de ** 0.5), Vector((cx, cy)),
-                            {
-                                "type": "EDGE",
-                                "world_point": world_closest,
-                                "world_edge": (Vector(world[a]), Vector(world[b])),
-                            },
-                        ))
+                        candidates.append(
+                            (
+                                2,
+                                float(de**0.5),
+                                Vector((cx, cy)),
+                                {
+                                    "type": "EDGE",
+                                    "world_point": world_closest,
+                                    "world_edge": (Vector(world[a]), Vector(world[b])),
+                                },
+                            )
+                        )
 
     return candidates
 
@@ -402,8 +432,12 @@ def curve_segment_under_cursor(context: Context, coords, threshold_px):
         if ob.type not in {"CURVE", "CURVES"}:
             continue
         cd = getattr(ob.original, "data", None)
-        if cd is None or not hasattr(cd, "points") or len(cd.points) == 0 \
-                or not hasattr(cd, "curves"):
+        if (
+            cd is None
+            or not hasattr(cd, "points")
+            or len(cd.points) == 0
+            or not hasattr(cd, "curves")
+        ):
             continue
         n = len(cd.points)
         local = np.empty(n * 3, dtype=np.float64)
@@ -448,6 +482,7 @@ def get_blender_snap_info(context: Context, coords: Vector) -> Optional[dict]:
     # otherwise capture the cursor (issue #591). Skip past it and keep looking for
     # real reference geometry behind it.
     from ..model.sketch_ref import get_active_sketch
+
     active = get_active_sketch(context)
     active_obj = active.target_object if active else None
 
@@ -483,7 +518,11 @@ def get_blender_snap_info(context: Context, coords: Vector) -> Optional[dict]:
     if ob.type == "MESH":
         # Restrict to the hit face's vertices/edges for a cheap, local search.
         candidates = _screen_snap_candidates(
-            context, coords, ob.evaluated_get(depsgraph), elements, face_index=face_index
+            context,
+            coords,
+            ob.evaluated_get(depsgraph),
+            elements,
+            face_index=face_index,
         )
     elif ob.type == "CURVES":
         # CAD Sketcher sketches (and other curve objects) are Curves objects; the
@@ -515,7 +554,7 @@ def get_pos_2d(
     origin, end_point = get_picking_origin_end(context, coords)
 
     # Support both entity workplanes and empty objects
-    if hasattr(wp, 'p1'):
+    if hasattr(wp, "p1"):
         # Entity workplane
         wp_origin = wp.p1.location
         wp_normal = wp.normal

--- a/utilities/view.py
+++ b/utilities/view.py
@@ -197,8 +197,9 @@ def _screen_snap_candidates(
                         "world_point": (world_start + world_end) / 2,
                         "world_edge": (world_start, world_end),
                         # Provenance so a placed point can be live-projected onto
-                        # this edge's midpoint (bound to both endpoint vertices, see
-                        # projection_anchor.project_mesh_edge_midpoint).
+                        # this edge's midpoint: the edge is projected as a line and a
+                        # midpoint constraint pins the point (see
+                        # projection_anchor.project_mesh_edge).
                         "object": obj_eval.original.name,
                         "edge_vertices": (int(v1), int(v2)),
                     },

--- a/utilities/view.py
+++ b/utilities/view.py
@@ -221,6 +221,12 @@ def _screen_snap_candidates(
                         "type": "EDGE",
                         "world_point": world_closest,
                         "world_edge": (world_start, world_end),
+                        # Provenance so a point snapped along this edge can be
+                        # live-projected onto it: the edge is projected and the
+                        # point slides on it via a point-on-line coincidence (see
+                        # projection_anchor.project_mesh_edge).
+                        "object": obj_eval.original.name,
+                        "edge_vertices": (int(v1), int(v2)),
                     },
                 )
 

--- a/utilities/view.py
+++ b/utilities/view.py
@@ -196,6 +196,11 @@ def _screen_snap_candidates(
                         "type": "EDGE_MIDPOINT",
                         "world_point": (world_start + world_end) / 2,
                         "world_edge": (world_start, world_end),
+                        # Provenance so a placed point can be live-projected onto
+                        # this edge's midpoint (bound to both endpoint vertices, see
+                        # projection_anchor.project_mesh_edge_midpoint).
+                        "object": obj_eval.original.name,
+                        "edge_vertices": (int(v1), int(v2)),
                     },
                 )
 

--- a/workspacetools/add_arc2d.py
+++ b/workspacetools/add_arc2d.py
@@ -20,4 +20,9 @@ class VIEW3D_T_slvs_add_arc2d(GenericStateTool, WorkSpaceTool):
     )
 
     def draw_settings(context, layout, tool):
-        layout.prop(context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints")
+        layout.prop(
+            context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints"
+        )
+        layout.prop(
+            context.scene.sketcher, "use_snap_project", text="Live Project Snaps"
+        )

--- a/workspacetools/add_circle2d.py
+++ b/workspacetools/add_circle2d.py
@@ -20,4 +20,9 @@ class VIEW3D_T_slvs_add_circle2d(GenericStateTool, WorkSpaceTool):
     )
 
     def draw_settings(context, layout, tool):
-        layout.prop(context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints")
+        layout.prop(
+            context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints"
+        )
+        layout.prop(
+            context.scene.sketcher, "use_snap_project", text="Live Project Snaps"
+        )

--- a/workspacetools/add_line2d.py
+++ b/workspacetools/add_line2d.py
@@ -22,4 +22,9 @@ class VIEW3D_T_slvs_add_line2d(GenericStateTool, WorkSpaceTool):
     def draw_settings(context, layout, tool):
         props = tool.operator_properties(Operators.AddLine2D)
         layout.prop(props, "continuous_draw")
-        layout.prop(context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints")
+        layout.prop(
+            context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints"
+        )
+        layout.prop(
+            context.scene.sketcher, "use_snap_project", text="Live Project Snaps"
+        )

--- a/workspacetools/add_point2d.py
+++ b/workspacetools/add_point2d.py
@@ -21,4 +21,9 @@ class VIEW3D_T_slvs_add_point2d(GenericStateTool, WorkSpaceTool):
     )
 
     def draw_settings(context, layout, tool):
-        layout.prop(context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints")
+        layout.prop(
+            context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints"
+        )
+        layout.prop(
+            context.scene.sketcher, "use_snap_project", text="Live Project Snaps"
+        )

--- a/workspacetools/add_rectangle.py
+++ b/workspacetools/add_rectangle.py
@@ -20,4 +20,9 @@ class VIEW3D_T_slvs_add_rectangle(GenericStateTool, WorkSpaceTool):
     )
 
     def draw_settings(context, layout, tool):
-        layout.prop(context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints")
+        layout.prop(
+            context.scene.sketcher, "auto_axis_constraints", text="Auto Constraints"
+        )
+        layout.prop(
+            context.scene.sketcher, "use_snap_project", text="Live Project Snaps"
+        )


### PR DESCRIPTION
Snapping a point onto external mesh geometry now projects that geometry into the sketch as a live construction reference and ties the placed point to it, instead of dropping a dead static point. Edit or move the source mesh and the sketch point follows, the same as a manual Project Geometry, but as a single snap gesture.

Static geometry snapping predates the projection feature; this makes a snap implicitly project-include the snapped element, so "reference external geometry" becomes a live parametric link rather than a fixed point the user has to notice is dead. Feature-flagged, on by default.

## Snap behaviors

Each snap kind binds to the source and coincides through the normal auto-coincident path, exactly as if you had snapped onto an existing sketch entity:

| Snap | Result |
| --- | --- |
| Vertex | live point bound to the vertex; point-point coincidence |
| Edge midpoint | live point bound to both endpoints (rides at their midpoint); point-point coincidence |
| Along an edge | live line bound to both endpoints; point-on-line coincidence, so the point slides along the edge |

`SlvsCoincident` already accepts `(POINT, LINE)`, so the along-edge case reuses the existing coincident constraint with no new constraint code.

## How it works

`state_func` stashes the snap; the deferred `create_element` (and Add Point's `main`) live-project the snapped feature and register the projected point or line as the coincidence target, then the existing auto-coincident path links the placed point to it. Reuses the projection machinery end to end.

- utilities/view.py: vertex, edge-midpoint and edge snap data now carry the source object and the relevant vertex indices (provenance)
- utilities/projection_anchor.py: project_mesh_vertex (single vertex), project_mesh_edge_midpoint (both endpoints, rides at midpoint) and project_mesh_edge (returns the projected line); dedup helpers find_projected_vertex_point / find_projected_midpoint; a second bound vertex is stored as two CURVE attrs (zero means single-vertex, so old bindings are unaffected) and the reproject handler averages the pair for midpoints
- operators/base_2d.py: _maybe_link_projected_snap handles VERTEX, EDGE_MIDPOINT and EDGE
- model/group_sketcher.py: use_snap_project toggle (default on), exposed as "Live Project Snaps" next to Auto Constraints on the draw tools

## Scope

- Mesh sources only. Face-midpoint snaps, and edges that collapse to a point on the sketch plane (plane-perpendicular), fall back to a static point.
- Topology-changing modifiers fall back to static (the evaluated vertex index would not line up with the original to bind).
- Deduplicated by source feature: snapping the same corner or edge twice shares one projected point or line, so coincident placements chain automatically.
- Gated behind the toggle and Auto Constraints; the Shift snap-bypass still works.
- The reproject handler is gated during a draw tool's continuous-draw; exit the tool before moving the source to see tracking.

## Tests

Covers vertex, edge-midpoint and edge projection: dedup, live reprojection on both source-vertex edit and whole-object translation, point-on-line coincidence on an along-edge snap, and the degenerate no-ops. Operator-level tests drive the snap through the real state machine. Full suite green.
