### PR TITLE
Return to select tool after one-off node tools

### DIFF
--- a/operators/add_sketch.py
+++ b/operators/add_sketch.py
@@ -3,7 +3,7 @@ import logging
 import bpy
 from bpy.types import Context, Event, Operator
 
-from ..declarations import Operators
+from ..declarations import Operators, WorkSpaceTools
 from ..model.curve_ref import PointRef
 from ..stateful_operator.state import state_from_args
 from ..stateful_operator.utilities.register import register_stateops_factory
@@ -60,6 +60,10 @@ class View3D_OT_slvs_add_sketch(Operator, Operator3d):
     bl_idname = Operators.AddSketch
     bl_label = "Add Sketch"
     bl_options = {"UNDO"}
+
+    # Creating a sketch enters sketch mode, so return to the sketch-mode select
+    # tool (not Blender's object select) once done, via the framework setting.
+    return_to_tool = WorkSpaceTools.Select
 
     sketch_state1_doc = [
         "Workplane",

--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -77,11 +77,6 @@ class NodeOperator(Operator3d):
     # Message shown when the resolved target fails is_valid_target().
     invalid_target_msg = "Invalid target object"
 
-    # One-off tools return to Blender's select tool once the modifier is added,
-    # so the node tool doesn't linger (matches Add Sketch). Opt-in per tool; off
-    # for operators invoked without their own workspacetool.
-    return_to_select_tool = False
-
     # Persisted target so the redo panel (which re-runs execute() on a fresh
     # instance, losing the transient pointer state) can re-resolve the object
     # and edit the existing modifier instead of failing. Not SKIP_SAVE: it must
@@ -140,14 +135,6 @@ class NodeOperator(Operator3d):
         the defaults. Override to pull the relevant sockets; base is a no-op.
         """
         pass
-
-    def fini(self, context, succeed):
-        # Return to Blender's select tool after a one-off action, so the node
-        # tool doesn't stay active. Only on success -- a cancel or missed target
-        # keeps the tool so the user can select a target and retry (this is why
-        # the switch lives here and not on cancel, matching Add Sketch).
-        if succeed and self.return_to_select_tool:
-            bpy.ops.wm.tool_set_by_id(name=BLENDER_SELECT_TOOL)
 
     def invoke(self, context, event):
         # Follow the stateful prefill-from-selection flow: if nothing valid is
@@ -245,7 +232,7 @@ class View3D_OT_node_extrude(Operator, NodeOperator):
 
     resources = (("node_groups", "CAD Sketcher Extrude"),)
     NODEGROUP_NAME = "CAD Sketcher Extrude"
-    return_to_select_tool = True
+    return_to_tool = BLENDER_SELECT_TOOL
 
     invalid_target_msg = "Select a sketch or curve to extrude (2D profile)"
 
@@ -302,7 +289,7 @@ class View3D_OT_node_array_linear(Operator, NodeOperator):
 
     NODEGROUP_NAME = "CAD Sketcher Linear Array"
     resources = (("node_groups", "CAD Sketcher Linear Array"),)
-    return_to_select_tool = True
+    return_to_tool = BLENDER_SELECT_TOOL
 
     # Array offset in the object's local space (direction * spacing), captured
     # by a single interactive drag; direction and distance derive from it.
@@ -413,7 +400,7 @@ class View3D_OT_node_revolve(Operator, NodeOperator):
 
     NODEGROUP_NAME = "CAD Sketcher Revolve"
     resources = (("node_groups", "CAD Sketcher Revolve"),)
-    return_to_select_tool = True
+    return_to_tool = BLENDER_SELECT_TOOL
 
     invalid_target_msg = "Select a sketch, curve or mesh profile to revolve"
 

--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -13,7 +13,7 @@ from mathutils import Vector
 from mathutils.geometry import intersect_line_line, intersect_line_plane
 
 from ..assets_manager import load_asset
-from ..declarations import Operators
+from ..declarations import BLENDER_SELECT_TOOL, Operators
 from ..global_data import LIB_NAME
 from ..stateful_operator.state import state_from_args
 from ..stateful_operator.utilities.register import register_stateops_factory
@@ -77,6 +77,11 @@ class NodeOperator(Operator3d):
     # Message shown when the resolved target fails is_valid_target().
     invalid_target_msg = "Invalid target object"
 
+    # One-off tools return to Blender's select tool once the modifier is added,
+    # so the node tool doesn't linger (matches Add Sketch). Opt-in per tool; off
+    # for operators invoked without their own workspacetool.
+    return_to_select_tool = False
+
     # Persisted target so the redo panel (which re-runs execute() on a fresh
     # instance, losing the transient pointer state) can re-resolve the object
     # and edit the existing modifier instead of failing. Not SKIP_SAVE: it must
@@ -135,6 +140,14 @@ class NodeOperator(Operator3d):
         the defaults. Override to pull the relevant sockets; base is a no-op.
         """
         pass
+
+    def fini(self, context, succeed):
+        # Return to Blender's select tool after a one-off action, so the node
+        # tool doesn't stay active. Only on success -- a cancel or missed target
+        # keeps the tool so the user can select a target and retry (this is why
+        # the switch lives here and not on cancel, matching Add Sketch).
+        if succeed and self.return_to_select_tool:
+            bpy.ops.wm.tool_set_by_id(name=BLENDER_SELECT_TOOL)
 
     def invoke(self, context, event):
         # Follow the stateful prefill-from-selection flow: if nothing valid is
@@ -232,6 +245,7 @@ class View3D_OT_node_extrude(Operator, NodeOperator):
 
     resources = (("node_groups", "CAD Sketcher Extrude"),)
     NODEGROUP_NAME = "CAD Sketcher Extrude"
+    return_to_select_tool = True
 
     invalid_target_msg = "Select a sketch or curve to extrude (2D profile)"
 
@@ -288,6 +302,7 @@ class View3D_OT_node_array_linear(Operator, NodeOperator):
 
     NODEGROUP_NAME = "CAD Sketcher Linear Array"
     resources = (("node_groups", "CAD Sketcher Linear Array"),)
+    return_to_select_tool = True
 
     # Array offset in the object's local space (direction * spacing), captured
     # by a single interactive drag; direction and distance derive from it.
@@ -398,6 +413,7 @@ class View3D_OT_node_revolve(Operator, NodeOperator):
 
     NODEGROUP_NAME = "CAD Sketcher Revolve"
     resources = (("node_groups", "CAD Sketcher Revolve"),)
+    return_to_select_tool = True
 
     invalid_target_msg = "Select a sketch, curve or mesh profile to revolve"
 

--- a/stateful_operator/logic.py
+++ b/stateful_operator/logic.py
@@ -37,6 +37,11 @@ class StatefulOperatorLogic(_StateMachineMixin):
     continuous_draw: BoolProperty(name="Continuous Draw", default=False)
 
     executed = False
+    # Tool id to activate once the operator succeeds (see _end). Lets a one-off
+    # tool return to a select tool afterwards instead of lingering; None keeps
+    # the current tool. On failure/cancel the tool is left alone so a missed
+    # pick can be retried.
+    return_to_tool = None
     # Screen coords when a state first runs — used by state_func for delta/scale
     state_init_coords = None
     _last_coords = Vector((0, 0))
@@ -567,6 +572,15 @@ class StatefulOperatorLogic(_StateMachineMixin):
         context.window.cursor_modal_restore()
         if hasattr(self, "fini"):
             self.fini(context, succeede)
+        # One-off tools return to their select tool once done (only on success,
+        # so a missed pick keeps the tool for a retry). The target tool differs
+        # per operator: object tools -> Blender's select, sketch tools -> the
+        # sketch select tool.
+        if succeede and self.return_to_tool:
+            try:
+                bpy.ops.wm.tool_set_by_id(name=self.return_to_tool)
+            except Exception:
+                pass
         self.on_before_redo_states(context)
         context.workspace.status_text_set(None)
 

--- a/testing/test_node_tool_switch.py
+++ b/testing/test_node_tool_switch.py
@@ -1,12 +1,14 @@
-"""One-off node tools return to Blender's select tool after finishing.
+"""One-off tools return to a select tool after finishing.
 
-The interactive tool switch itself (via ``fini`` on success) needs a real modal
-run to observe, so this guards the intent: the tool-backed one-off operators opt
-in, and operators without their own workspacetool do not.
+The switch itself (framework ``_end`` on success) needs a real modal run to
+observe, so this guards the intent: each one-off tool declares which select tool
+it returns to, and operators that should stay active declare none.
 """
 
 from unittest import TestCase
 
+from ..declarations import BLENDER_SELECT_TOOL, WorkSpaceTools
+from ..operators.add_sketch import View3D_OT_slvs_add_sketch
 from ..operators.modifiers import (
     View3D_OT_node_array_linear,
     View3D_OT_node_extrude,
@@ -15,12 +17,21 @@ from ..operators.modifiers import (
 )
 
 
-class TestNodeToolReturnToSelect(TestCase):
-    def test_one_off_tools_opt_in(self):
-        self.assertTrue(View3D_OT_node_extrude.return_to_select_tool)
-        self.assertTrue(View3D_OT_node_revolve.return_to_select_tool)
-        self.assertTrue(View3D_OT_node_array_linear.return_to_select_tool)
+class TestReturnToTool(TestCase):
+    def test_object_node_tools_return_to_blender_select(self):
+        for op in (
+            View3D_OT_node_extrude,
+            View3D_OT_node_revolve,
+            View3D_OT_node_array_linear,
+        ):
+            self.assertEqual(op.return_to_tool, BLENDER_SELECT_TOOL, op.__name__)
 
-    def test_fill_does_not_switch(self):
+    def test_add_sketch_returns_to_sketch_select(self):
+        # Add Sketch enters sketch mode, so it returns to the sketch select tool.
+        self.assertEqual(
+            View3D_OT_slvs_add_sketch.return_to_tool, WorkSpaceTools.Select
+        )
+
+    def test_fill_stays_active(self):
         # Fill has no workspacetool, so it must not steal the active tool.
-        self.assertFalse(View3D_OT_node_fill.return_to_select_tool)
+        self.assertIsNone(View3D_OT_node_fill.return_to_tool)

--- a/testing/test_node_tool_switch.py
+++ b/testing/test_node_tool_switch.py
@@ -1,0 +1,26 @@
+"""One-off node tools return to Blender's select tool after finishing.
+
+The interactive tool switch itself (via ``fini`` on success) needs a real modal
+run to observe, so this guards the intent: the tool-backed one-off operators opt
+in, and operators without their own workspacetool do not.
+"""
+
+from unittest import TestCase
+
+from ..operators.modifiers import (
+    View3D_OT_node_array_linear,
+    View3D_OT_node_extrude,
+    View3D_OT_node_fill,
+    View3D_OT_node_revolve,
+)
+
+
+class TestNodeToolReturnToSelect(TestCase):
+    def test_one_off_tools_opt_in(self):
+        self.assertTrue(View3D_OT_node_extrude.return_to_select_tool)
+        self.assertTrue(View3D_OT_node_revolve.return_to_select_tool)
+        self.assertTrue(View3D_OT_node_array_linear.return_to_select_tool)
+
+    def test_fill_does_not_switch(self):
+        # Fill has no workspacetool, so it must not steal the active tool.
+        self.assertFalse(View3D_OT_node_fill.return_to_select_tool)


### PR DESCRIPTION
Extrude, Revolve and Linear Array are one-off actions, but the tool stays active afterward, inviting an accidental re-trigger. They now switch back to Blender's select tool once the modifier is added, the same way Add Sketch already does.

- Opt-in per operator (return_to_select_tool), on for extrude/revolve/array
- Only on success: a cancel or missed target keeps the tool so you can select and retry (matches Add Sketch's fini)
- Continuous tools (draw line/point/circle/arc/rectangle, trim, bevel, offset) are unchanged
- Fill and Boolean have no workspacetool, so they do not switch

The switch happens in the shared NodeOperator.fini. The actual tool change needs a real modal run to observe, so the test guards the opt-in flags.