### PR TITLE
Boolean tool: multi-cutter support and robustness fixes

### DIFF
--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -732,9 +732,14 @@ class View3D_OT_node_boolean(Operator, NodeOperator):
             return False
         self.cutter_name = cutter.name
         self._cutter = cutter
-        # Reveal the result: a solid cutter sitting over the body would hide it.
-        cutter.display_type = self.cutter_display
         return super().main(context)
+
+    def fini(self, context: Context, succeed: bool):
+        # Reveal the result: a solid cutter sitting over the body would hide it.
+        # Done here, once, rather than in main() -- main() can re-run during the
+        # modal's undo/redo churn, so the display change belongs at completion.
+        if succeed and getattr(self, "_cutter", None) is not None:
+            self._cutter.display_type = self.cutter_display
 
     @staticmethod
     def _input_ids(node_group):

--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -682,19 +682,22 @@ class View3D_OT_node_boolean(Operator, NodeOperator):
         if cutter is None:
             self.report({"WARNING"}, "Pick a cutter object to boolean with")
             return False
-        # The cutter is read through an Object Info node on a modifier that lives
-        # on the body. If the cutter is the body itself, that node reads the
-        # object it is attached to -- a depsgraph dependency cycle that crashes
-        # Blender. Reject it before the modifier is created.
-        if cutter == self.resolved_object():
-            self.report(
-                {"WARNING"}, "The cutter must be a different object than the body"
-            )
-            return False
         # A non-geometry cutter (empty, light, camera) yields no mesh, so the
         # boolean would silently do nothing. Reject it with a clear message.
         if not self.is_valid_target(cutter):
             self.report({"WARNING"}, "The cutter must be a mesh or sketch object")
+            return False
+        # Adding this boolean makes the body read the cutter's geometry (body
+        # depends on cutter). If the cutter already depends on the body through
+        # other CAD Sketcher booleans -- including the cutter being the body
+        # itself -- that closes a depsgraph dependency cycle, which crashes
+        # Blender. Refuse before creating the modifier.
+        body = self.resolved_object()
+        if self._creates_cycle(body, cutter):
+            self.report(
+                {"WARNING"},
+                "That cutter depends on the body; it would create a dependency cycle",
+            )
             return False
         self.cutter_name = cutter.name
         self._cutter = cutter
@@ -709,6 +712,41 @@ class View3D_OT_node_boolean(Operator, NodeOperator):
             for s in node_group.interface.items_tree
             if getattr(s, "in_out", "") == "INPUT"
         }
+
+    @classmethod
+    def _boolean_cutters(cls, obj):
+        """Objects ``obj`` reads as cutters through its CAD Sketcher booleans."""
+        from ..utilities.boolean_nodes import BOOLEAN_NODE_GROUP
+
+        cutters = []
+        for m in obj.modifiers:
+            group = getattr(m, "node_group", None)
+            if m.type != "NODES" or group is None or group.name != BOOLEAN_NODE_GROUP:
+                continue
+            ids = cls._input_ids(group)
+            cutter = get_modifier_input(m, ids["Cutter"])
+            if cutter is not None:
+                cutters.append(cutter)
+        return cutters
+
+    @classmethod
+    def _creates_cycle(cls, body, cutter):
+        """Whether making ``body`` read ``cutter`` closes a boolean dependency
+        cycle, i.e. ``cutter`` already depends (transitively) on ``body``.
+
+        Also true when ``cutter is body`` (a self-reference is a length-0 cycle).
+        """
+        stack = [cutter]
+        seen = set()
+        while stack:
+            obj = stack.pop()
+            if obj == body:
+                return True
+            if obj in seen:
+                continue
+            seen.add(obj)
+            stack.extend(cls._boolean_cutters(obj))
+        return False
 
     def set_props(self):
         m = self.modifier

--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -186,10 +186,19 @@ class NodeOperator(Operator3d):
         bpy.ops.ed.undo_push(message=f'Load Asset "{rName}"')
         return True
 
+    def _modifier_name(self):
+        """Name of this tool's modifier on the target.
+
+        One per object by default (re-invoking edits it). Tools that can stack
+        several instances on one object (e.g. Boolean, one per cutter) override
+        this to return a distinct name per instance.
+        """
+        return f"CAD_Sketcher {self.bl_label}"
+
     def _ensure_modifier(self, context):
         """Create the modifier once, reuse on subsequent calls."""
         ob = self._obj.original
-        mod_name = f"CAD_Sketcher {self.bl_label}"
+        mod_name = self._modifier_name()
 
         self.modifier = ob.modifiers.get(mod_name)
         if self.modifier:
@@ -651,6 +660,12 @@ class View3D_OT_node_boolean(Operator, NodeOperator):
         if cutter is None and self.cutter_name:
             cutter = bpy.data.objects.get(self.cutter_name)
         return cutter
+
+    def _modifier_name(self):
+        # One modifier per cutter, so several booleans stack on the same body
+        # instead of overwriting each other. Re-applying with the same cutter
+        # edits its existing modifier (same name); a new cutter adds another.
+        return f"CAD_Sketcher Boolean {self._cutter.name}"
 
     def read_props(self, modifier):
         ids = self._input_ids(modifier.node_group)

--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -676,6 +676,11 @@ class View3D_OT_node_boolean(Operator, NodeOperator):
                 {"WARNING"}, "The cutter must be a different object than the body"
             )
             return False
+        # A non-geometry cutter (empty, light, camera) yields no mesh, so the
+        # boolean would silently do nothing. Reject it with a clear message.
+        if not self.is_valid_target(cutter):
+            self.report({"WARNING"}, "The cutter must be a mesh or sketch object")
+            return False
         self.cutter_name = cutter.name
         self._cutter = cutter
         # Reveal the result: a solid cutter sitting over the body would hide it.

--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -678,7 +678,13 @@ class View3D_OT_node_boolean(Operator, NodeOperator):
         on the redo path where the pointer is gone.
         """
         cutter = getattr(self, "cutter", None)
-        if cutter is None and self.cutter_name:
+        if cutter is not None:
+            # The Object pointer state returns the EVALUATED object (a temporary
+            # depsgraph copy). Assigning that to the modifier's Object input
+            # corrupts ID refcounts ("user decrement error") and setting its
+            # display_type is lost on the next evaluation. Use the original.
+            cutter = cutter.original
+        elif self.cutter_name:
             cutter = bpy.data.objects.get(self.cutter_name)
         return cutter
 
@@ -712,8 +718,12 @@ class View3D_OT_node_boolean(Operator, NodeOperator):
         # depends on cutter). If the cutter already depends on the body through
         # other CAD Sketcher booleans -- including the cutter being the body
         # itself -- that closes a depsgraph dependency cycle, which crashes
-        # Blender. Refuse before creating the modifier.
+        # Blender. Refuse before creating the modifier. Compare originals: the
+        # cutters read off the modifiers are originals, but resolved_object()
+        # may hand back the evaluated body.
         body = self.resolved_object()
+        if body is not None:
+            body = body.original
         if self._creates_cycle(body, cutter):
             self.report(
                 {"WARNING"},

--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -641,6 +641,27 @@ class View3D_OT_node_boolean(Operator, NodeOperator):
         # Object pointer states carry no implicit point.
         return None
 
+    def invoke(self, context, event):
+        # Editing: when the body and the cutter are both preselected and that
+        # cutter already has a boolean on the body, seed the operator from it so
+        # re-invoking edits the existing boolean (like Extrude) instead of
+        # resetting it to defaults. Seeding must happen here, once, before the
+        # redo panel -- doing it in main()/execute() would clobber a redo-panel
+        # edit on the next re-run. The cutter is only known at invoke when it is
+        # preselected, so interactive cutter-picking is always treated as create.
+        selection = self.gather_selection(context)
+        if selection:
+            body = selection[0]
+            for other in selection[1:]:
+                mod = body.modifiers.get(f"CAD_Sketcher Boolean {other.name}")
+                if mod and mod.node_group:
+                    try:
+                        self.read_props(mod)
+                    except Exception:
+                        pass
+                    break
+        return super().invoke(context, event)
+
     def init(self, context: Context, event: Event):
         # Build the boolean node group in place of loading an asset.
         from ..utilities.boolean_nodes import build_boolean_node_group

--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -667,6 +667,15 @@ class View3D_OT_node_boolean(Operator, NodeOperator):
         if cutter is None:
             self.report({"WARNING"}, "Pick a cutter object to boolean with")
             return False
+        # The cutter is read through an Object Info node on a modifier that lives
+        # on the body. If the cutter is the body itself, that node reads the
+        # object it is attached to -- a depsgraph dependency cycle that crashes
+        # Blender. Reject it before the modifier is created.
+        if cutter == self.resolved_object():
+            self.report(
+                {"WARNING"}, "The cutter must be a different object than the body"
+            )
+            return False
         self.cutter_name = cutter.name
         self._cutter = cutter
         # Reveal the result: a solid cutter sitting over the body would hide it.

--- a/testing/test_boolean_nodes.py
+++ b/testing/test_boolean_nodes.py
@@ -239,3 +239,60 @@ class TestBooleanNodeGroup(BgsTestCase):
         finally:
             bpy.data.objects.remove(body, do_unlink=True)
             bpy.data.objects.remove(empty, do_unlink=True)
+
+    def _boolean(self, body, cutter):
+        result = bpy.ops.view3d.slvs_node_boolean(
+            "EXEC_DEFAULT",
+            target_name=body.name,
+            cutter_name=cutter.name,
+            operation="Difference",
+        )
+        self.assertEqual(result, {"FINISHED"})
+
+    def test_multiple_cutters_stack_on_one_body(self):
+        # Two different cutters must produce two boolean modifiers that both
+        # apply, not one that overwrites the other.
+        cutter1 = self._solid_cutter()  # spans [0,2]^3 -> notches the +++ corner
+        cutter2 = self._solid_cutter()  # move it to notch the --- corner
+        for node in cutter2.modifiers[0].node_group.nodes:
+            if node.type == "TRANSFORM_GEOMETRY":
+                node.inputs["Translation"].default_value = (-1.0, -1.0, -1.0)
+        bpy.ops.mesh.primitive_cube_add(size=2.0)
+        body = self.context.active_object
+        body.name = "stack_body"
+        try:
+            self._boolean(body, cutter1)
+            self._boolean(body, cutter2)
+            bool_mods = [
+                m
+                for m in body.modifiers
+                if m.type == "NODES" and m.name.startswith("CAD_Sketcher Boolean")
+            ]
+            self.assertEqual(
+                len(bool_mods), 2, "each cutter should add its own modifier"
+            )
+            # Both notches present: a size-2 cube with two opposite corners cut
+            # has more than the 6 original faces.
+            depsgraph = self.context.evaluated_depsgraph_get()
+            mesh = body.evaluated_get(depsgraph).to_mesh()
+            self.assertGreater(len(mesh.polygons), 9)
+        finally:
+            bpy.data.objects.remove(body, do_unlink=True)
+
+    def test_same_cutter_is_idempotent(self):
+        # Re-applying with the same cutter edits its modifier, not a duplicate.
+        cutter = self._solid_cutter()
+        bpy.ops.mesh.primitive_cube_add(size=2.0)
+        body = self.context.active_object
+        body.name = "idempotent_body"
+        try:
+            self._boolean(body, cutter)
+            self._boolean(body, cutter)
+            bool_mods = [
+                m
+                for m in body.modifiers
+                if m.type == "NODES" and m.name.startswith("CAD_Sketcher Boolean")
+            ]
+            self.assertEqual(len(bool_mods), 1)
+        finally:
+            bpy.data.objects.remove(body, do_unlink=True)

--- a/testing/test_boolean_nodes.py
+++ b/testing/test_boolean_nodes.py
@@ -218,3 +218,24 @@ class TestBooleanNodeGroup(BgsTestCase):
             self.assertNotIn("CAD_Sketcher Boolean", [m.name for m in obj.modifiers])
         finally:
             bpy.data.objects.remove(obj, do_unlink=True)
+
+    def test_non_geometry_cutter_is_rejected(self):
+        # An empty/light/camera cutter has no mesh, so the boolean would silently
+        # do nothing. The operator must refuse it instead.
+        bpy.ops.mesh.primitive_cube_add(size=2.0)
+        body = self.context.active_object
+        body.name = "body_for_empty_cutter"
+        empty = self.data.objects.new("empty_cutter", None)
+        self.scene.collection.objects.link(empty)
+        try:
+            result = bpy.ops.view3d.slvs_node_boolean(
+                "EXEC_DEFAULT",
+                target_name=body.name,
+                cutter_name=empty.name,
+                operation="Difference",
+            )
+            self.assertEqual(result, {"CANCELLED"})
+            self.assertNotIn("CAD_Sketcher Boolean", [m.name for m in body.modifiers])
+        finally:
+            bpy.data.objects.remove(body, do_unlink=True)
+            bpy.data.objects.remove(empty, do_unlink=True)

--- a/testing/test_boolean_nodes.py
+++ b/testing/test_boolean_nodes.py
@@ -249,6 +249,27 @@ class TestBooleanNodeGroup(BgsTestCase):
         )
         self.assertEqual(result, {expect})
 
+    def test_resolve_cutter_returns_original_not_evaluated(self):
+        # The Object pointer state hands back the evaluated object; assigning that
+        # to the modifier corrupts refcounts and its display change is transient.
+        # _resolve_cutter must return the original datablock.
+        cutter = self._solid_cutter()
+        depsgraph = self.context.evaluated_depsgraph_get()
+        evaluated = cutter.evaluated_get(depsgraph)
+        self.assertIsNot(evaluated, cutter)  # sanity: eval copy is distinct
+
+        double = make_operator_double(View3D_OT_node_boolean)
+        # ``cutter`` is a read-only pointer property; drop it so the test can
+        # inject the evaluated object the state would otherwise return.
+        if "cutter" in double.__dict__:
+            delattr(double, "cutter")
+        op = double()
+        op.cutter = evaluated  # simulate the interactive pointer-state value
+        op.cutter_name = ""
+        resolved = op._resolve_cutter(self.context)
+        self.assertIs(resolved, cutter, "must resolve to the original datablock")
+        bpy.data.objects.remove(cutter, do_unlink=True)
+
     def test_read_props_seeds_from_existing_modifier(self):
         # The edit path: invoke seeds the operator from an existing boolean so
         # re-invoking keeps its settings instead of resetting to defaults. Here

--- a/testing/test_boolean_nodes.py
+++ b/testing/test_boolean_nodes.py
@@ -18,7 +18,7 @@ from ..utilities.boolean_nodes import (
     BOOLEAN_VERSION,
     build_boolean_node_group,
 )
-from .utils import BgsTestCase
+from .utils import BgsTestCase, make_operator_double
 
 
 class TestBooleanNodeGroup(BgsTestCase):
@@ -248,6 +248,29 @@ class TestBooleanNodeGroup(BgsTestCase):
             operation="Difference",
         )
         self.assertEqual(result, {expect})
+
+    def test_read_props_seeds_from_existing_modifier(self):
+        # The edit path: invoke seeds the operator from an existing boolean so
+        # re-invoking keeps its settings instead of resetting to defaults. Here
+        # we drive read_props directly (the modal invoke can't run headless).
+        group = build_boolean_node_group()
+        bpy.ops.mesh.primitive_cube_add(size=2.0)
+        body = self.context.active_object
+        try:
+            modifier = body.modifiers.new("CAD_Sketcher Boolean x", "NODES")
+            modifier.node_group = group
+            ids = View3D_OT_node_boolean._input_ids(group)
+            set_boolean_operation(modifier, ids["Operation"], "Intersect")
+            set_modifier_input(modifier, ids["Self Intersection"], False)
+            set_modifier_input(modifier, ids["Hole Tolerant"], True)
+
+            op = make_operator_double(View3D_OT_node_boolean)()
+            op.read_props(modifier)
+            self.assertEqual(op.operation, "Intersect")
+            self.assertFalse(op.self_intersection)
+            self.assertTrue(op.hole_tolerant)
+        finally:
+            bpy.data.objects.remove(body, do_unlink=True)
 
     def test_mutual_cycle_is_rejected(self):
         # A cut by B is fine; then B cut by A would close a dependency cycle

--- a/testing/test_boolean_nodes.py
+++ b/testing/test_boolean_nodes.py
@@ -240,14 +240,33 @@ class TestBooleanNodeGroup(BgsTestCase):
             bpy.data.objects.remove(body, do_unlink=True)
             bpy.data.objects.remove(empty, do_unlink=True)
 
-    def _boolean(self, body, cutter):
+    def _boolean(self, body, cutter, expect="FINISHED"):
         result = bpy.ops.view3d.slvs_node_boolean(
             "EXEC_DEFAULT",
             target_name=body.name,
             cutter_name=cutter.name,
             operation="Difference",
         )
-        self.assertEqual(result, {"FINISHED"})
+        self.assertEqual(result, {expect})
+
+    def test_mutual_cycle_is_rejected(self):
+        # A cut by B is fine; then B cut by A would close a dependency cycle
+        # (A reads B, B reads A) and crash Blender. The second must be refused.
+        bpy.ops.mesh.primitive_cube_add(size=2.0)
+        a = self.context.active_object
+        a.name = "cycle_a"
+        bpy.ops.mesh.primitive_cube_add(size=1.5, location=(1, 0, 0))
+        b = self.context.active_object
+        b.name = "cycle_b"
+        try:
+            self._boolean(a, b)  # A reads B -- ok
+            self._boolean(b, a, expect="CANCELLED")  # B reads A -- would cycle
+            self.assertFalse(
+                any(m.name.startswith("CAD_Sketcher Boolean") for m in b.modifiers)
+            )
+        finally:
+            bpy.data.objects.remove(a, do_unlink=True)
+            bpy.data.objects.remove(b, do_unlink=True)
 
     def test_multiple_cutters_stack_on_one_body(self):
         # Two different cutters must produce two boolean modifiers that both

--- a/testing/test_boolean_nodes.py
+++ b/testing/test_boolean_nodes.py
@@ -199,3 +199,22 @@ class TestBooleanNodeGroup(BgsTestCase):
             self.assertEqual(cutter.display_type, "WIRE")
         finally:
             bpy.data.objects.remove(body, do_unlink=True)
+
+    def test_cutter_equal_body_is_rejected(self):
+        # Using an object as its own cutter makes the Object Info node read the
+        # object the modifier is on -- a depsgraph cycle that crashes Blender.
+        # The operator must refuse it and not add a modifier.
+        bpy.ops.mesh.primitive_cube_add(size=2.0)
+        obj = self.context.active_object
+        obj.name = "self_cutter_body"
+        try:
+            result = bpy.ops.view3d.slvs_node_boolean(
+                "EXEC_DEFAULT",
+                target_name=obj.name,
+                cutter_name=obj.name,
+                operation="Difference",
+            )
+            self.assertEqual(result, {"CANCELLED"})
+            self.assertNotIn("CAD_Sketcher Boolean", [m.name for m in obj.modifiers])
+        finally:
+            bpy.data.objects.remove(obj, do_unlink=True)


### PR DESCRIPTION
Robustness and usability pass on the Boolean tool.

## Crash fixes
- Assigning a picked cutter used the evaluated (depsgraph) object, which corrupted ID refcounts ("ID user decrement error") and made its display change transient. The cutter now resolves to the original datablock.
- Using an object as its own cutter, or picking a cutter that already depends on the body (A cuts B, then B cuts A, and longer chains), closed a depsgraph dependency cycle that crashed Blender. Such cutters are now rejected before the modifier is created.
- A non-geometry cutter (empty, light, camera) has no mesh, so the boolean silently did nothing. It is now rejected with a clear message.

## Multiple booleans per object
- Each cutter gets its own modifier (named per cutter), so several booleans stack on one body instead of overwriting each other. Re-applying the same cutter edits its existing modifier; a new cutter adds another.

## Editing
- When the body and the cutter are both preselected, the operator seeds from the existing boolean so re-invoking edits it (like Extrude) instead of resetting to defaults. Picking a cutter interactively is treated as a new boolean (seeding at invoke needs the cutter to be known up front).

## Cutter display
- The cutter switches to wireframe by default so the result is visible (Wire / Solid). Applied in fini, once at completion, rather than during the modal.

## Tests
Cover the evaluated-vs-original resolution, self/mutual/chain cycle rejection, non-geometry rejection, multi-cutter stacking, same-cutter idempotency, and read_props seeding.