### PR TITLE
Project Geometry: support projecting a sketch's lines

### DIFF
--- a/operators/project_geometry.py
+++ b/operators/project_geometry.py
@@ -6,22 +6,29 @@ from bpy.utils import register_classes_factory
 from ..declarations import Operators
 from ..model.sketch_ref import get_active_sketch
 from ..utilities.curve_data import refresh_curve_geometry
-from ..utilities.projection_anchor import project_mesh_object
+from ..utilities.projection_anchor import project_curves_object, project_mesh_object
+
+# Object types this tool can project onto the active sketch.
+_MESH_SOURCE = {"MESH"}
+_CURVE_SOURCE = {"CURVES", "CURVE"}
 
 
 class VIEW3D_OT_slvs_project_geometry(Operator):
-    """Project a mesh object's edges onto the active sketch"""
+    """Project a mesh object's edges or a sketch's lines onto the active sketch"""
 
     bl_idname = Operators.ProjectGeometry
     bl_label = "Project Geometry"
     bl_description = (
-        "Project mesh edges onto the active sketch and keep a live source reference"
+        "Project a mesh's edges or another sketch's lines onto the active sketch "
+        "and keep a live source reference"
     )
     bl_options = {"REGISTER", "UNDO"}
 
     source: StringProperty(
         name="Source",
-        description="Mesh object whose edges are projected onto the active sketch",
+        description=(
+            "Mesh or sketch object whose geometry is projected onto the active sketch"
+        ),
         default="",
     )
     construction: BoolProperty(
@@ -37,12 +44,12 @@ class VIEW3D_OT_slvs_project_geometry(Operator):
     def _selected_source(self, context):
         sketch = get_active_sketch(context)
         sketch_ob = sketch.target_object if sketch else None
-        meshes = [
+        candidates = [
             obj
             for obj in context.selected_objects
-            if obj is not sketch_ob and obj.type == "MESH"
+            if obj is not sketch_ob and obj.type in (_MESH_SOURCE | _CURVE_SOURCE)
         ]
-        return meshes[0] if len(meshes) == 1 else None
+        return candidates[0] if len(candidates) == 1 else None
 
     def invoke(self, context: Context, event):
         if not self.source:
@@ -63,20 +70,25 @@ class VIEW3D_OT_slvs_project_geometry(Operator):
             return {"CANCELLED"}
 
         source = bpy.data.objects.get(self.source)
-        if source is None or source.type != "MESH":
-            self.report({"ERROR"}, "Choose a mesh source object")
+        if source is None or source.type not in (_MESH_SOURCE | _CURVE_SOURCE):
+            self.report({"ERROR"}, "Choose a mesh or sketch source object")
             return {"CANCELLED"}
         if source == sketch.target_object:
             self.report({"ERROR"}, "The source cannot be the active sketch")
             return {"CANCELLED"}
 
-        _, lines = project_mesh_object(
-            sketch,
-            source,
-            construction=self.construction,
-        )
+        if source.type in _MESH_SOURCE:
+            _, lines = project_mesh_object(
+                sketch, source, construction=self.construction
+            )
+            empty_msg = "The source mesh has no edges to project"
+        else:
+            _, lines = project_curves_object(
+                sketch, source, construction=self.construction
+            )
+            empty_msg = "The source sketch has no line segments to project"
         if not lines:
-            self.report({"WARNING"}, "The source mesh has no edges to project")
+            self.report({"WARNING"}, empty_msg)
             return {"CANCELLED"}
 
         refresh_curve_geometry(sketch)

--- a/operators/project_geometry.py
+++ b/operators/project_geometry.py
@@ -77,17 +77,20 @@ class VIEW3D_OT_slvs_project_geometry(Operator):
             self.report({"ERROR"}, "The source cannot be the active sketch")
             return {"CANCELLED"}
 
+        skipped = 0
         if source.type in _MESH_SOURCE:
-            _, lines = project_mesh_object(
+            points, lines = project_mesh_object(
                 sketch, source, construction=self.construction
             )
+            summary = f"{len(lines)} edge(s)"
             empty_msg = "The source mesh has no edges to project"
         else:
-            _, lines = project_curves_object(
+            points, lines, skipped = project_curves_object(
                 sketch, source, construction=self.construction
             )
-            empty_msg = "The source sketch has no line segments to project"
-        if not lines:
+            summary = f"{len(lines)} line(s), {len(points)} point(s)"
+            empty_msg = "The source sketch has no lines or points to project"
+        if not points and not lines:
             self.report({"WARNING"}, empty_msg)
             return {"CANCELLED"}
 
@@ -96,10 +99,12 @@ class VIEW3D_OT_slvs_project_geometry(Operator):
 
         global_data.needs_solve = True
         global_data.needs_redraw = True
-        self.report(
-            {"INFO"},
-            f"Projected {len(lines)} edge(s) from {source.name}",
-        )
+        message = f"Projected {summary} from {source.name}"
+        if skipped:
+            # Arcs/circles project to an ellipse on a non-parallel plane, which
+            # has no native representation, so they are left out (see #626).
+            message += f" (skipped {skipped} arc(s)/circle(s), not supported)"
+        self.report({"INFO"}, message)
         return {"FINISHED"}
 
 

--- a/testing/test_projection_anchor.py
+++ b/testing/test_projection_anchor.py
@@ -121,7 +121,7 @@ class TestProjectionAnchor(Sketch2dTestCase):
         # the same XY workplane, so its local coords map straight through.
         src, sp1, sp2 = self._source_sketch_with_line((0.0, 0.0), (2.0, 3.0))
 
-        points, lines = project_curves_object(
+        points, lines, _ = project_curves_object(
             self.sketch, src.target_object, construction=True
         )
         self.assertEqual(len(lines), 1)
@@ -157,6 +157,27 @@ class TestProjectionAnchor(Sketch2dTestCase):
         LineRef.create(src, a, b)
         LineRef.create(src, b, c)
 
-        points, lines = project_curves_object(self.sketch, src.target_object)
+        points, lines, _ = project_curves_object(self.sketch, src.target_object)
         self.assertEqual(len(lines), 2)
         self.assertEqual(len(points), 3, "shared endpoint must not duplicate")
+
+    def test_project_sketch_source_standalone_points_and_skips_curves(self):
+        # A standalone point projects (a point is a point at any angle); an arc
+        # is skipped and counted so the caller can report it.
+        from ..model.curve_ref import PointRef
+
+        src = self.new_sketch()
+        PointRef.create(src, (3.0, 4.0))  # standalone point, no line
+        center = PointRef.create(src, (0.0, 0.0))
+        start = PointRef.create(src, (1.0, 0.0))
+        end = PointRef.create(src, (0.0, 1.0))
+        from ..model.curve_ref import ArcRef
+
+        ArcRef.create(src, center, start, end)  # an arc -> skipped
+
+        points, lines, skipped = project_curves_object(self.sketch, src.target_object)
+        self.assertEqual(len(lines), 0)
+        self.assertGreaterEqual(len(points), 1)
+        # The standalone point landed at its position.
+        self.assertTrue(any((p.co - Vector((3.0, 4.0))).length < 1e-6 for p in points))
+        self.assertEqual(skipped, 1, "the arc must be counted as skipped")

--- a/testing/test_projection_anchor.py
+++ b/testing/test_projection_anchor.py
@@ -7,6 +7,7 @@ from ..utilities.projection_anchor import (
     PROJECT_VERTEX_ID_ATTR,
     PROJECT_VERTEX_INDEX_ATTR,
     VERTEX_ID_ATTR,
+    project_curves_object,
     project_mesh_object,
     refresh_projection_for_sketch,
 )
@@ -104,3 +105,58 @@ class TestProjectionAnchor(Sketch2dTestCase):
         )
 
         self.assertLess((points[1].co - Vector((3.5, 2.5))).length, 1e-5)
+
+    def _source_sketch_with_line(self, p1_co, p2_co):
+        """A second sketch containing one line, to project onto the active one."""
+        from ..model.curve_ref import LineRef, PointRef
+
+        src = self.new_sketch()
+        p1 = PointRef.create(src, p1_co)
+        p2 = PointRef.create(src, p2_co)
+        LineRef.create(src, p1, p2)
+        return src, p1, p2
+
+    def test_project_sketch_source_lines(self):
+        # The active sketch is self.sketch; the source is another sketch sharing
+        # the same XY workplane, so its local coords map straight through.
+        src, sp1, sp2 = self._source_sketch_with_line((0.0, 0.0), (2.0, 3.0))
+
+        points, lines = project_curves_object(
+            self.sketch, src.target_object, construction=True
+        )
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(len(points), 2)
+        self.assertTrue(all(p.fixed for p in points))
+        self.assertTrue(all(p.construction for p in points))
+        self.assertTrue(all(line.construction for line in lines))
+        self.assertLess((points[0].co - Vector((0.0, 0.0))).length, 1e-6)
+        self.assertLess((points[1].co - Vector((2.0, 3.0))).length, 1e-6)
+
+        # The source sketch carries the minted persistent id, and each projected
+        # point stores the binding marker on the active sketch.
+        self.assertIsNotNone(src.target_object.data.attributes.get(VERTEX_ID_ATTR))
+        for point in points:
+            cd, idx, _ = get_curve_data(self.sketch, point.curve_id)
+            self.assertGreater(cd.attributes[PROJECT_VERTEX_ID_ATTR].data[idx].value, 0)
+
+        # Live update: move a source point, the projected point follows.
+        sp2.co = (5.0, 1.0)
+        self.context.view_layer.update()
+        depsgraph = self.context.evaluated_depsgraph_get()
+        refresh_projection_for_sketch(self.sketch, depsgraph, force=True)
+        self.assertLess((points[1].co - Vector((5.0, 1.0))).length, 1e-5)
+
+    def test_project_sketch_source_dedups_shared_endpoints(self):
+        # Two connected lines share a point -> one projected point at the join.
+        from ..model.curve_ref import LineRef, PointRef
+
+        src = self.new_sketch()
+        a = PointRef.create(src, (0.0, 0.0))
+        b = PointRef.create(src, (1.0, 0.0))
+        c = PointRef.create(src, (1.0, 1.0))
+        LineRef.create(src, a, b)
+        LineRef.create(src, b, c)
+
+        points, lines = project_curves_object(self.sketch, src.target_object)
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(len(points), 3, "shared endpoint must not duplicate")

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -76,10 +76,29 @@ def _get_or_add_source_slot(owner, source):
     return len(slots) - 1
 
 
+# Source object types that can drive a projection. A mesh binds to its vertices;
+# a sketch/curve binds to its control points. Both carry the persistent id on the
+# same POINT-domain INT attribute (INT attributes survive edits on either type).
+_MESH_SOURCE = {"MESH"}
+_CURVE_SOURCE = {"CURVES", "CURVE"}
+
+
+def _source_point_index(source, vertex_index):
+    """Local position of source element ``vertex_index`` (mesh vert or curve point)."""
+    if source.type in _MESH_SOURCE:
+        return Vector(source.data.vertices[vertex_index].co)
+    return Vector(source.data.points[vertex_index].position)
+
+
 def bind_projected_point(sketch, point, source, vertex_index):
-    """Bind a native sketch point to a source mesh vertex."""
-    if source is None or source.type != "MESH":
-        raise TypeError("Projected geometry source must be a mesh object")
+    """Bind a native sketch point to a source element.
+
+    The source is a mesh (bind to a vertex) or another sketch/curve (bind to a
+    control point). Both mint the persistent id on the source's POINT-domain
+    ``VERTEX_ID_ATTR`` so the reproject can find the element after edits.
+    """
+    if source is None or source.type not in (_MESH_SOURCE | _CURVE_SOURCE):
+        raise TypeError("Projected geometry source must be a mesh or sketch/curve")
 
     curve_data, curve_index, _ = get_curve_data(sketch, point.curve_id)
     if curve_data is None:
@@ -93,9 +112,9 @@ def bind_projected_point(sketch, point, source, vertex_index):
     attributes[PROJECT_SRC_SLOT_ATTR].data[curve_index].value = source_slot
     attributes[PROJECT_VERTEX_ID_ATTR].data[curve_index].value = vertex_id
     attributes[PROJECT_VERTEX_INDEX_ATTR].data[curve_index].value = int(vertex_index)
-    attributes[PROJECT_LAST_CO_ATTR].data[curve_index].vector = source.data.vertices[
-        vertex_index
-    ].co
+    attributes[PROJECT_LAST_CO_ATTR].data[curve_index].vector = _source_point_index(
+        source, vertex_index
+    )
     return vertex_id
 
 
@@ -153,6 +172,26 @@ def _resolve_evaluated_vertex(eval_ob, vertex_id, fallback_index, last_co):
     return None
 
 
+def _resolve_curve_point(curve_data, vertex_id, fallback_index, last_co):
+    """Position of the source control point bound by ``vertex_id`` (curve source).
+
+    Reads the ORIGINAL curve data (a sketch's control points hold the solved
+    positions), not an evaluated object -- the evaluated geometry of a sketch is
+    its generated mesh, which does not carry the control points.
+    """
+    points = getattr(curve_data, "points", None)
+    if points is None:
+        return None
+    attr = curve_data.attributes.get(VERTEX_ID_ATTR)
+    if attr is not None and attr.domain == "POINT":
+        for i, item in enumerate(attr.data):
+            if int(item.value) == vertex_id and i < len(points):
+                return Vector(points[i].position)
+    if 0 <= fallback_index < len(points):
+        return Vector(points[fallback_index].position)
+    return None
+
+
 def _source_changed(source, changed):
     if changed is None:
         return True
@@ -194,7 +233,8 @@ def refresh_projection_for_sketch(sketch, depsgraph, changed=None, force=False):
         # automatically, so there is no orphan property bookkeeping here.
         if not point.valid:
             continue
-        if source is None or getattr(source, "type", None) != "MESH":
+        source_type = getattr(source, "type", None)
+        if source is None or source_type not in (_MESH_SOURCE | _CURVE_SOURCE):
             continue
         if not (sketch_changed or force or _source_changed(source, changed)):
             continue
@@ -203,25 +243,33 @@ def refresh_projection_for_sketch(sketch, depsgraph, changed=None, force=False):
             # reconciled when Blender emits the update on leaving Edit Mode.
             continue
 
-        eval_ob = source_cache.get(source)
-        if eval_ob is None:
-            eval_ob = source.evaluated_get(depsgraph)
-            source_cache[source] = eval_ob
+        # A mesh source reads its evaluated vertices (deform/modifiers apply); a
+        # sketch/curve source reads its original control points (the solver
+        # writes solved positions there, and its evaluated data is a mesh).
+        if source_type in _MESH_SOURCE:
+            eval_ob = source_cache.get(source)
+            if eval_ob is None:
+                eval_ob = source.evaluated_get(depsgraph)
+                source_cache[source] = eval_ob
+            vertex = _resolve_evaluated_vertex(
+                eval_ob, vertex_id, fallback_index, last_co
+            )
+            if vertex is None:
+                continue
+            source_co = Vector(vertex.co)
+            world = eval_ob.matrix_world @ source_co
+        else:
+            source_co = _resolve_curve_point(
+                source.original.data, vertex_id, fallback_index, last_co
+            )
+            if source_co is None:
+                continue
+            world = source.matrix_world @ source_co
 
-        vertex = _resolve_evaluated_vertex(
-            eval_ob,
-            vertex_id,
-            fallback_index,
-            last_co,
-        )
-        if vertex is None:
-            continue
-
-        world = eval_ob.matrix_world @ vertex.co
         local = owner.matrix_world.inverted() @ world
         new_co = Vector((local.x, local.y))
         if (point.co - new_co).length > 1e-7:
-            updates[curve_id] = (point, new_co, tuple(vertex.co))
+            updates[curve_id] = (point, new_co, tuple(source_co))
 
     if not updates:
         return 0
@@ -315,6 +363,84 @@ def project_mesh_object(sketch, source, construction=True):
                 p2,
                 construction=construction,
                 name="Projected Line",
+            )
+            lines.append(line)
+
+    return points, lines
+
+
+def _source_point_flat_index(source_point):
+    """Flat index of a source PointRef's control point in ``source.data.points``."""
+    if not source_point._resolve():
+        return None
+    return source_point._curve_slice.points[0].index
+
+
+def project_curves_object(sketch, source, construction=True):
+    """Project a source sketch's line segments onto ``sketch`` as live curves.
+
+    Reads the source sketch's line curves and their endpoint points, creating a
+    projected point per shared source point (deduplicated) and a projected line
+    per source segment. Endpoints are fixed; their positions are driven by the
+    source sketch's control points. Points/circles/arcs are not projected in this
+    first slice. Returns ``(points, lines)``.
+    """
+    if source is None or source.type not in _CURVE_SOURCE:
+        raise TypeError("Source must be a sketch or curve object")
+
+    from ..model.constants import SketchCurveType
+    from ..model.curve_ref import LineRef as _LineRef
+    from ..model.sketch_ref import Sketch
+    from ..utilities.curve_data import get_curve_type, read_curve_id_list
+
+    src_sketch = Sketch(source)
+    src_data = source.data
+    owner = sketch.target_object
+    inv = owner.matrix_world.inverted()
+
+    projected_by_src_point = {}
+    points = []
+    lines = []
+
+    def _project_point(src_point):
+        # Deduplicate shared endpoints so coincident source points become one
+        # projected point (and thus a shared line endpoint).
+        src_cid = src_point.curve_id
+        existing = projected_by_src_point.get(src_cid)
+        if existing is not None:
+            return existing
+        flat_index = _source_point_flat_index(src_point)
+        if flat_index is None:
+            return None
+        local = inv @ src_point.location  # source world -> active sketch local
+        projected = PointRef.create(
+            sketch,
+            (local.x, local.y),
+            construction=construction,
+            fixed=True,
+            name="Projected Point",
+        )
+        bind_projected_point(sketch, projected, source, flat_index)
+        projected_by_src_point[src_cid] = projected
+        points.append(projected)
+        return projected
+
+    with batch_update(sketch):
+        for src_cid in read_curve_id_list(src_data):
+            if not src_cid:
+                continue
+            if get_curve_type(src_sketch, src_cid) != SketchCurveType.LINE:
+                continue
+            src_line = _LineRef(src_sketch, src_cid)
+            p1_src, p2_src = src_line.p1, src_line.p2
+            if p1_src is None or p2_src is None:
+                continue
+            p1 = _project_point(p1_src)
+            p2 = _project_point(p2_src)
+            if p1 is None or p2 is None:
+                continue
+            line = LineRef.create(
+                sketch, p1, p2, construction=construction, name="Projected Line"
             )
             lines.append(line)
 

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -382,8 +382,11 @@ def project_curves_object(sketch, source, construction=True):
     Reads the source sketch's line curves and their endpoint points, creating a
     projected point per shared source point (deduplicated) and a projected line
     per source segment. Endpoints are fixed; their positions are driven by the
-    source sketch's control points. Points/circles/arcs are not projected in this
-    first slice. Returns ``(points, lines)``.
+    source sketch's control points. Standalone points and arcs/circles are not
+    projected in this first slice (an arc/circle projects to an ellipse on a
+    non-parallel plane, which has no native representation). Returns
+    ``(points, lines, skipped_curves)`` where ``skipped_curves`` counts the
+    arcs/circles that were not projected, for user feedback.
     """
     if source is None or source.type not in _CURVE_SOURCE:
         raise TypeError("Source must be a sketch or curve object")
@@ -401,6 +404,7 @@ def project_curves_object(sketch, source, construction=True):
     projected_by_src_point = {}
     points = []
     lines = []
+    skipped_curves = 0
 
     def _project_point(src_point):
         # Deduplicate shared endpoints so coincident source points become one
@@ -429,19 +433,26 @@ def project_curves_object(sketch, source, construction=True):
         for src_cid in read_curve_id_list(src_data):
             if not src_cid:
                 continue
-            if get_curve_type(src_sketch, src_cid) != SketchCurveType.LINE:
-                continue
-            src_line = _LineRef(src_sketch, src_cid)
-            p1_src, p2_src = src_line.p1, src_line.p2
-            if p1_src is None or p2_src is None:
-                continue
-            p1 = _project_point(p1_src)
-            p2 = _project_point(p2_src)
-            if p1 is None or p2 is None:
-                continue
-            line = LineRef.create(
-                sketch, p1, p2, construction=construction, name="Projected Line"
-            )
-            lines.append(line)
+            src_type = get_curve_type(src_sketch, src_cid)
+            if src_type == SketchCurveType.LINE:
+                src_line = _LineRef(src_sketch, src_cid)
+                p1_src, p2_src = src_line.p1, src_line.p2
+                if p1_src is None or p2_src is None:
+                    continue
+                p1 = _project_point(p1_src)
+                p2 = _project_point(p2_src)
+                if p1 is None or p2 is None:
+                    continue
+                line = LineRef.create(
+                    sketch, p1, p2, construction=construction, name="Projected Line"
+                )
+                lines.append(line)
+            elif src_type == SketchCurveType.POINT:
+                # A point projects to a point at any angle -- project standalone
+                # points too. Line endpoints are already deduped via curve_id, so
+                # a point that is also an endpoint is not duplicated.
+                _project_point(PointRef(src_sketch, src_cid))
+            elif src_type in (SketchCurveType.ARC, SketchCurveType.CIRCLE):
+                skipped_curves += 1
 
-    return points, lines
+    return points, lines, skipped_curves


### PR DESCRIPTION
Project Geometry can now target another sketch, not just a mesh, so you no longer have to convert a sketch to a mesh first.

## What it does
- The Source picker and selection prefill accept sketch/curve objects as well as meshes.
- A sketch source projects its line segments onto the active sketch: one projected point per source point (shared endpoints deduplicated) and a projected line per segment, as construction geometry by default.
- The projection stays live: each projected point binds to the source sketch's control point, and moving/editing the source updates the projection through the existing depsgraph reproject.

## How it works
The binding reuses the existing anchor machinery. A sketch's control points already carry stable UUIDs, so binding mints the same persistent POINT-domain id used for mesh vertices (INT attributes survive edits on Curves too). One asymmetry: a mesh source is read from its evaluated vertices, but a sketch source is read from its original control points, because a sketch's evaluated geometry is its generated mesh, and the solver writes solved positions to the control points.

## Scope
First slice covers line segments and their endpoints (matching the mesh path, which projects edges + vertices). Arcs, circles, and standalone points are not projected yet.

## Tests
Cover projecting a source sketch's line, the live update when a source point moves, and shared-endpoint deduplication. The existing mesh projection tests are unchanged.