### PR TITLE
Migrate legacy mesh modifiers to Geometry Nodes on the new sketch

### DIFF
--- a/testing/test_migrate_modifiers.py
+++ b/testing/test_migrate_modifiers.py
@@ -1,0 +1,117 @@
+"""Translating a legacy mesh modifier stack to GN siblings on a new sketch.
+
+Drives the per-modifier translators and the ``_migrate_modifiers`` driver
+directly (setting up a full legacy scene is heavy). Verifies that translatable
+modifiers become the addon's node tools with mapped parameters, and that
+unsupported modifiers are skipped and recorded.
+"""
+
+from ..operators.modifiers import View3D_OT_node_boolean, get_modifier_input
+from ..utilities.migrate import _migrate_modifiers
+from .utils import Sketch2dTestCase
+
+
+class TestMigrateModifiers(Sketch2dTestCase):
+    def _old_mesh(self):
+        # A legacy-style generated output mesh to carry the modifier stack.
+        me = self.data.meshes.new("old_output")
+        import bmesh
+
+        bm = bmesh.new()
+        bmesh.ops.create_cube(bm, size=2.0)
+        bm.to_mesh(me)
+        bm.free()
+        obj = self.data.objects.new("old_output", me)
+        self.scene.collection.objects.link(obj)
+        return obj
+
+    def _run(self, old_mesh):
+        summary = {"modifiers": 0, "modifiers_skipped": []}
+        _migrate_modifiers(old_mesh, self.sketch, summary)
+        return summary
+
+    def _sketch_mods(self):
+        return [m for m in self.sketch.target_object.modifiers if m.type == "NODES"]
+
+    def test_solidify_becomes_extrude(self):
+        old = self._old_mesh()
+        s = old.modifiers.new("s", "SOLIDIFY")
+        s.thickness = 0.3
+        summary = self._run(old)
+        self.assertEqual(summary["modifiers"], 1)
+        self.assertEqual(summary["modifiers_skipped"], [])
+        extrude = next(
+            m
+            for m in self._sketch_mods()
+            if m.node_group.name == "CAD Sketcher Extrude"
+        )
+        self.assertAlmostEqual(get_modifier_input(extrude, "Input_2"), 0.3, places=5)
+
+    def test_boolean_becomes_boolean_node_group(self):
+        old = self._old_mesh()
+        cutter = self._old_mesh()
+        cutter.name = "the_cutter"
+        b = old.modifiers.new("b", "BOOLEAN")
+        b.object = cutter
+        b.operation = "UNION"
+        summary = self._run(old)
+        self.assertEqual(summary["modifiers"], 1)
+        mod = next(
+            m
+            for m in self._sketch_mods()
+            if m.node_group.name == "CAD Sketcher Boolean"
+        )
+        ids = View3D_OT_node_boolean._input_ids(mod.node_group)
+        self.assertEqual(get_modifier_input(mod, ids["Cutter"]), cutter)
+        self.assertEqual(int(get_modifier_input(mod, ids["Operation"])), 1)  # Union
+
+    def test_boolean_without_cutter_is_skipped(self):
+        old = self._old_mesh()
+        old.modifiers.new("b", "BOOLEAN")  # no object set
+        summary = self._run(old)
+        self.assertEqual(summary["modifiers"], 0)
+        self.assertEqual(len(summary["modifiers_skipped"]), 1)
+
+    def test_array_becomes_linear_array(self):
+        old = self._old_mesh()
+        a = old.modifiers.new("a", "ARRAY")
+        a.count = 4
+        a.use_relative_offset = False
+        a.use_constant_offset = True
+        a.constant_offset_displace = (3.0, 0.0, 0.0)
+        summary = self._run(old)
+        self.assertEqual(summary["modifiers"], 1)
+        arr = next(
+            m
+            for m in self._sketch_mods()
+            if m.node_group.name == "CAD Sketcher Linear Array"
+        )
+        self.assertEqual(int(get_modifier_input(arr, "Input_22")), 4)  # Count
+        self.assertAlmostEqual(get_modifier_input(arr, "Input_23"), 3.0, places=4)
+
+    def test_bevel_is_skipped_with_record(self):
+        # Bevel has no GN equivalent; it must be skipped and recorded.
+        old = self._old_mesh()
+        old.modifiers.new("bev", "BEVEL")
+        summary = self._run(old)
+        self.assertEqual(summary["modifiers"], 0)
+        self.assertEqual(len(summary["modifiers_skipped"]), 1)
+        self.assertIn("BEVEL", summary["modifiers_skipped"][0])
+
+    def test_stack_order_and_mixed(self):
+        # A mixed stack: solidify + boolean translate, bevel is skipped, order
+        # preserved among the translated ones.
+        old = self._old_mesh()
+        cutter = self._old_mesh()
+        old.modifiers.new("s", "SOLIDIFY").thickness = 0.1
+        old.modifiers.new("bev", "BEVEL")
+        old.modifiers.new("b", "BOOLEAN").object = cutter
+        summary = self._run(old)
+        self.assertEqual(summary["modifiers"], 2)
+        self.assertEqual(len(summary["modifiers_skipped"]), 1)
+        groups = [m.node_group.name for m in self._sketch_mods()]
+        self.assertLess(
+            groups.index("CAD Sketcher Extrude"),
+            groups.index("CAD Sketcher Boolean"),
+            "translated modifiers keep their original order",
+        )

--- a/testing/test_migrate_modifiers.py
+++ b/testing/test_migrate_modifiers.py
@@ -112,6 +112,59 @@ class TestMigrateModifiers(Sketch2dTestCase):
             get_modifier_input(rev, "Socket_4"), math.pi / 12, places=4
         )
 
+    def _sketch_group_named(self, name):
+        return next((m for m in self._sketch_mods() if m.node_group.name == name), None)
+
+    def test_weld_becomes_merge_by_distance(self):
+        old = self._old_mesh()
+        w = old.modifiers.new("w", "WELD")
+        w.merge_threshold = 0.05
+        summary = self._run(old)
+        self.assertEqual(summary["modifiers"], 1)
+        mod = self._sketch_group_named("CAD_Sketcher Weld")
+        self.assertIsNotNone(mod)
+        merge = next(n for n in mod.node_group.nodes if n.type == "MERGE_BY_DISTANCE")
+        self.assertAlmostEqual(merge.inputs["Distance"].default_value, 0.05, places=5)
+
+    def test_subsurf_becomes_subdivision(self):
+        old = self._old_mesh()
+        old.modifiers.new("s", "SUBSURF").levels = 3
+        summary = self._run(old)
+        self.assertEqual(summary["modifiers"], 1)
+        mod = self._sketch_group_named("CAD_Sketcher Subdivision")
+        self.assertIsNotNone(mod)
+        sub = next(n for n in mod.node_group.nodes if n.type == "SUBDIVISION_SURFACE")
+        self.assertEqual(int(sub.inputs["Level"].default_value), 3)
+
+    def test_triangulate_translates(self):
+        old = self._old_mesh()
+        old.modifiers.new("t", "TRIANGULATE")
+        summary = self._run(old)
+        self.assertEqual(summary["modifiers"], 1)
+        self.assertIsNotNone(self._sketch_group_named("CAD_Sketcher Triangulate"))
+
+    def test_mirror_axis_translates(self):
+        old = self._old_mesh()
+        mi = old.modifiers.new("mi", "MIRROR")
+        mi.use_axis = (True, False, False)
+        summary = self._run(old)
+        self.assertEqual(summary["modifiers"], 1)
+        mod = self._sketch_group_named("CAD_Sketcher Mirror")
+        self.assertIsNotNone(mod)
+        # The construction includes a transform (scale -1) and a flip-faces.
+        types = {n.type for n in mod.node_group.nodes}
+        self.assertIn("TRANSFORM_GEOMETRY", types)
+        self.assertIn("FLIP_FACES", types)
+
+    def test_mirror_object_is_skipped(self):
+        old = self._old_mesh()
+        pivot = self._old_mesh()
+        mi = old.modifiers.new("mi", "MIRROR")
+        mi.mirror_object = pivot
+        summary = self._run(old)
+        self.assertEqual(summary["modifiers"], 0)
+        self.assertEqual(len(summary["modifiers_skipped"]), 1)
+
     def test_bevel_is_skipped_with_record(self):
         # Bevel has no GN equivalent; it must be skipped and recorded.
         old = self._old_mesh()

--- a/testing/test_migrate_modifiers.py
+++ b/testing/test_migrate_modifiers.py
@@ -89,6 +89,29 @@ class TestMigrateModifiers(Sketch2dTestCase):
         self.assertEqual(int(get_modifier_input(arr, "Input_22")), 4)  # Count
         self.assertAlmostEqual(get_modifier_input(arr, "Input_23"), 3.0, places=4)
 
+    def test_screw_becomes_revolve(self):
+        import math
+
+        old = self._old_mesh()
+        s = old.modifiers.new("sc", "SCREW")
+        s.axis = "Y"
+        s.angle = math.pi  # 180 degrees
+        s.steps = 12
+        summary = self._run(old)
+        self.assertEqual(summary["modifiers"], 1)
+        rev = next(
+            m
+            for m in self._sketch_mods()
+            if m.node_group.name == "CAD Sketcher Revolve"
+        )
+        self.assertAlmostEqual(get_modifier_input(rev, "Socket_3"), math.pi, places=4)
+        # Axis Direction is Y.
+        axis = tuple(get_modifier_input(rev, "Socket_2"))
+        self.assertLess(abs(axis[1] - 1.0), 1e-4)
+        self.assertAlmostEqual(
+            get_modifier_input(rev, "Socket_4"), math.pi / 12, places=4
+        )
+
     def test_bevel_is_skipped_with_record(self):
         # Bevel has no GN equivalent; it must be skipped and recorded.
         old = self._old_mesh()

--- a/testing/test_migration.py
+++ b/testing/test_migration.py
@@ -167,6 +167,49 @@ class TestMigration(unittest.TestCase):
         ]
         self.assertEqual(leftovers, [])
 
+    def test_cad_part_evaluated_geometry(self):
+        # Guard the actual 3D output, not just the modifier recipe: the migrated
+        # part must still evaluate (Convert -> Extrude -> Booleans) to a solid
+        # whose bounds match the legacy part (150 x 80 x 100). The GN chain turns
+        # the Curves into a mesh, so the realized geometry is a depsgraph instance
+        # rather than the evaluated object's own data.
+        from ..utilities.curve_data import refresh_curve_geometry
+
+        _open("CAD_Sketcher_Part.blend")
+        sketches = list(get_sketches(bpy.context))
+        for s in sketches:
+            refresh_curve_geometry(s)  # force the GN modifiers to re-evaluate
+        bpy.context.view_layer.update()
+        dg = bpy.context.evaluated_depsgraph_get()
+
+        ours = {s.target_object.original for s in sketches}
+        total_v = 0
+        lo = [1e18] * 3
+        hi = [-1e18] * 3
+        for inst in dg.object_instances:
+            if inst.object.original not in ours:
+                continue
+            try:
+                me = inst.object.to_mesh()
+            except RuntimeError:
+                continue  # the Curves object itself yields no mesh
+            if len(me.vertices):
+                mw = inst.matrix_world
+                for v in me.vertices:
+                    w = mw @ v.co
+                    for i in range(3):
+                        lo[i] = min(lo[i], w[i])
+                        hi[i] = max(hi[i], w[i])
+                total_v += len(me.vertices)
+            inst.object.to_mesh_clear()
+
+        dims = [hi[i] - lo[i] for i in range(3)]
+        # A substantial solid, not the flat sketch profile (Extrude + Booleans ran).
+        self.assertGreater(total_v, 1000)
+        # Overall bounds match the legacy dimensions; each axis is real 3D depth.
+        for got, want in zip(dims, (150.0, 80.0, 100.0)):
+            self.assertAlmostEqual(got, want, delta=1.0)
+
     def test_idempotent(self):
         # Re-running migration on an already-migrated scene is a no-op.
         from ..utilities.migrate import migrate_scene, scene_needs_migration

--- a/testing/test_migration.py
+++ b/testing/test_migration.py
@@ -69,8 +69,14 @@ class TestMigration(unittest.TestCase):
         self.assertEqual(n_con, 8)
         self.assertEqual(
             ctypes,
-            {"ANGLE": 1, "DIAMETER": 2, "DISTANCE": 2,
-             "HORIZONTAL": 1, "TANGENT": 1, "VERTICAL": 1},
+            {
+                "ANGLE": 1,
+                "DIAMETER": 2,
+                "DISTANCE": 2,
+                "HORIZONTAL": 1,
+                "TANGENT": 1,
+                "VERTICAL": 1,
+            },
         )
 
     def test_cad_part_geometry_constraints_values(self):
@@ -81,15 +87,85 @@ class TestMigration(unittest.TestCase):
         self.assertEqual(n_con, 75)
         self.assertEqual(
             ctypes,
-            {"COINCIDENT": 3, "DIAMETER": 6, "DISTANCE": 14, "EQUAL": 6,
-             "HORIZONTAL": 14, "MIDPOINT": 5, "TANGENT": 10, "VERTICAL": 17},
+            {
+                "COINCIDENT": 3,
+                "DIAMETER": 6,
+                "DISTANCE": 14,
+                "EQUAL": 6,
+                "HORIZONTAL": 14,
+                "MIDPOINT": 5,
+                "TANGENT": 10,
+                "VERTICAL": 17,
+            },
         )
         # Dimensional values are preserved exactly from the legacy file.
         self.assertEqual(
             vals,
-            [5.0, 10.0, 13.0, 18.0, 18.0, 20.0, 30.0, 30.0, 30.0, 40.0,
-             53.0, 53.0, 53.0, 55.0, 55.0, 80.0, 80.0, 100.0, 150.0, 150.0],
+            [
+                5.0,
+                10.0,
+                13.0,
+                18.0,
+                18.0,
+                20.0,
+                30.0,
+                30.0,
+                30.0,
+                40.0,
+                53.0,
+                53.0,
+                53.0,
+                55.0,
+                55.0,
+                80.0,
+                80.0,
+                100.0,
+                150.0,
+                150.0,
+            ],
         )
+
+    def test_cad_part_modifiers_translated_to_gn(self):
+        # The legacy part stacks Solidify + Boolean on its generated meshes.
+        # Migration must rebuild those as GN siblings on the new Curves sketches,
+        # remap boolean cutters onto the migrated sketches, and delete the old
+        # meshes so the geometry is not duplicated.
+        from ..model.sketch_ref import is_sketch_object
+        from ..operators.modifiers import View3D_OT_node_boolean, get_modifier_input
+
+        _open("CAD_Sketcher_Part.blend")
+        sketches = list(get_sketches(bpy.context))
+
+        extrudes = booleans = 0
+        for s in sketches:
+            for m in s.target_object.modifiers:
+                if m.type != "NODES" or m.node_group is None:
+                    continue
+                name = m.node_group.name
+                if name == "CAD Sketcher Extrude":
+                    extrudes += 1
+                elif name == "CAD Sketcher Boolean":
+                    booleans += 1
+                    ids = View3D_OT_node_boolean._input_ids(m.node_group)
+                    cutter = get_modifier_input(m, ids["Cutter"])
+                    # The cutter is another migrated sketch, not an old mesh.
+                    self.assertTrue(
+                        is_sketch_object(cutter),
+                        f"boolean cutter {cutter!r} is not a migrated sketch",
+                    )
+
+        # Six Solidify -> Extrude, five Boolean -> Boolean node group.
+        self.assertEqual(extrudes, 6)
+        self.assertEqual(booleans, 5)
+
+        # No orphaned legacy mesh (carrying the raw modifier stack) is left over.
+        leftovers = [
+            o.name
+            for o in bpy.data.objects
+            if o.type == "MESH"
+            and any(mm.type in ("SOLIDIFY", "BOOLEAN") for mm in o.modifiers)
+        ]
+        self.assertEqual(leftovers, [])
 
     def test_idempotent(self):
         # Re-running migration on an already-migrated scene is a no-op.

--- a/utilities/migrate.py
+++ b/utilities/migrate.py
@@ -165,6 +165,109 @@ def _load_node_group(name):
     return None
 
 
+def _add_gn_modifier(obj, name, build):
+    """Add a GN modifier wrapping a small built-in node construction.
+
+    ``build(nodes, links, geometry_socket)`` wires nodes onto the input geometry
+    and returns the output geometry socket. Params are baked into a fresh group
+    per modifier (they are small), so no shared-group value conflicts arise.
+    """
+    ng = bpy.data.node_groups.new(name, "GeometryNodeTree")
+    ng.interface.new_socket(
+        "Geometry", in_out="INPUT", socket_type="NodeSocketGeometry"
+    )
+    ng.interface.new_socket(
+        "Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry"
+    )
+    nodes, links = ng.nodes, ng.links
+    gi = nodes.new("NodeGroupInput")
+    go = nodes.new("NodeGroupOutput")
+    out = build(nodes, links, gi.outputs["Geometry"])
+    links.new(out, go.inputs["Geometry"])
+    modifier = obj.modifiers.new(name, "NODES")
+    modifier.node_group = ng
+    return modifier
+
+
+def _translate_weld(mod, old_mesh, obj):
+    """Weld -> Merge by Distance (collapse vertices within a threshold)."""
+    distance = float(getattr(mod, "merge_threshold", 0.001))
+
+    def build(nodes, links, geo):
+        merge = nodes.new("GeometryNodeMergeByDistance")
+        links.new(geo, merge.inputs["Geometry"])
+        merge.inputs["Distance"].default_value = distance
+        return merge.outputs["Geometry"]
+
+    _add_gn_modifier(obj, "CAD_Sketcher Weld", build)
+    return True
+
+
+def _translate_subsurf(mod, old_mesh, obj):
+    """Subdivision Surface -> the Subdivision Surface node (viewport levels)."""
+    levels = int(getattr(mod, "levels", 1))
+
+    def build(nodes, links, geo):
+        sub = nodes.new("GeometryNodeSubdivisionSurface")
+        links.new(geo, sub.inputs["Mesh"])
+        sub.inputs["Level"].default_value = levels
+        return sub.outputs["Mesh"]
+
+    _add_gn_modifier(obj, "CAD_Sketcher Subdivision", build)
+    return True
+
+
+def _translate_triangulate(mod, old_mesh, obj):
+    """Triangulate -> the Triangulate node (default methods)."""
+
+    def build(nodes, links, geo):
+        tri = nodes.new("GeometryNodeTriangulate")
+        links.new(geo, tri.inputs["Mesh"])
+        return tri.outputs["Mesh"]
+
+    _add_gn_modifier(obj, "CAD_Sketcher Triangulate", build)
+    return True
+
+
+def _translate_mirror(mod, old_mesh, obj):
+    """Mirror -> a per-axis GN construction (scale -1, flip faces, join, merge).
+
+    Only the axis mirror (across the object's local origin) is handled; a mirror
+    across a separate ``mirror_object`` has no clean equivalent, so it is skipped.
+    """
+    if getattr(mod, "mirror_object", None) is not None:
+        return False
+    axes = [i for i in range(3) if mod.use_axis[i]]
+    if not axes:
+        return False
+    do_merge = bool(getattr(mod, "use_mirror_merge", True))
+    threshold = float(getattr(mod, "merge_threshold", 0.001))
+
+    def build(nodes, links, geo):
+        current = geo
+        for axis in axes:
+            scale = [1.0, 1.0, 1.0]
+            scale[axis] = -1.0
+            xf = nodes.new("GeometryNodeTransform")
+            links.new(current, xf.inputs["Geometry"])
+            xf.inputs["Scale"].default_value = tuple(scale)
+            flip = nodes.new("GeometryNodeFlipFaces")
+            links.new(xf.outputs["Geometry"], flip.inputs["Mesh"])
+            join = nodes.new("GeometryNodeJoinGeometry")
+            links.new(current, join.inputs["Geometry"])
+            links.new(flip.outputs["Mesh"], join.inputs["Geometry"])
+            current = join.outputs["Geometry"]
+        if do_merge:
+            merge = nodes.new("GeometryNodeMergeByDistance")
+            links.new(current, merge.inputs["Geometry"])
+            merge.inputs["Distance"].default_value = threshold
+            current = merge.outputs["Geometry"]
+        return current
+
+    _add_gn_modifier(obj, "CAD_Sketcher Mirror", build)
+    return True
+
+
 def _translate_solidify(mod, old_mesh, obj):
     """Solidify gives a profile thickness -- the same as the Extrude tool."""
     from ..operators.modifiers import set_modifier_input
@@ -263,6 +366,10 @@ _MODIFIER_TRANSLATORS = {
     "BOOLEAN": _translate_boolean,
     "ARRAY": _translate_array,
     "SCREW": _translate_screw,
+    "WELD": _translate_weld,
+    "SUBSURF": _translate_subsurf,
+    "TRIANGULATE": _translate_triangulate,
+    "MIRROR": _translate_mirror,
 }
 
 

--- a/utilities/migrate.py
+++ b/utilities/migrate.py
@@ -281,11 +281,18 @@ def _translate_solidify(mod, old_mesh, obj):
     return True
 
 
-def _translate_boolean(mod, old_mesh, obj):
-    """Boolean -> the CAD Sketcher Boolean node group, reading the same cutter."""
+def _translate_boolean(mod, old_mesh, obj, cutter_map=None):
+    """Boolean -> the CAD Sketcher Boolean node group, reading the same cutter.
+
+    ``cutter_map`` maps a legacy generated mesh to the new Curves sketch that
+    replaced it. If the cutter was itself a migrated sketch's output, point the
+    new boolean at that sketch instead of the orphaned (soon removed) old mesh.
+    """
     cutter = mod.object
     if cutter is None:
         return False
+    if cutter_map is not None:
+        cutter = cutter_map.get(cutter, cutter)
     from ..operators.modifiers import (
         View3D_OT_node_boolean,
         set_boolean_operation,
@@ -373,11 +380,12 @@ _MODIFIER_TRANSLATORS = {
 }
 
 
-def _migrate_modifiers(old_mesh, sketch, summary):
+def _migrate_modifiers(old_mesh, sketch, summary, cutter_map=None):
     """Rebuild ``old_mesh``'s modifier stack as GN siblings on ``sketch``.
 
     Isolated per modifier: a failed or unsupported one is skipped and recorded,
-    never aborting the rest of the migration.
+    never aborting the rest of the migration. ``cutter_map`` (old mesh -> new
+    sketch object) lets boolean cutters be remapped onto migrated sketches.
     """
     obj = sketch.target_object
     if obj is None:
@@ -385,13 +393,38 @@ def _migrate_modifiers(old_mesh, sketch, summary):
     for mod in list(old_mesh.modifiers):
         try:
             translator = _MODIFIER_TRANSLATORS.get(mod.type)
-            if translator is not None and translator(mod, old_mesh, obj):
+            if translator is None:
+                summary["modifiers_skipped"].append(f"{old_mesh.name}: {mod.type}")
+                continue
+            if mod.type == "BOOLEAN":
+                ok = translator(mod, old_mesh, obj, cutter_map)
+            else:
+                ok = translator(mod, old_mesh, obj)
+            if ok:
                 summary["modifiers"] += 1
             else:
                 summary["modifiers_skipped"].append(f"{old_mesh.name}: {mod.type}")
         except Exception as e:
             logger.exception("Failed to migrate modifier %s", mod.name)
             summary["modifiers_skipped"].append(f"{old_mesh.name}: {mod.type} ({e!r})")
+
+
+def _remove_legacy_meshes(old_meshes, summary):
+    """Delete the orphaned legacy generated meshes after their stacks migrated.
+
+    The new Curves sketches (with their translated GN modifiers) are now the
+    extension's output, so the old meshes would only duplicate the geometry.
+    """
+    for old_mesh in list(old_meshes):
+        try:
+            data = old_mesh.data
+            bpy.data.objects.remove(old_mesh, do_unlink=True)
+            if data is not None and data.users == 0:
+                bpy.data.meshes.remove(data)
+            summary["meshes_removed"] += 1
+        except Exception as e:
+            logger.exception("Failed to remove legacy mesh %s", old_mesh)
+            summary["errors"].append(f"remove mesh: {e!r}")
 
 
 def migrate_scene(context):
@@ -405,12 +438,17 @@ def migrate_scene(context):
         "errors": [],
         "modifiers": 0,
         "modifiers_skipped": [],
+        "meshes_removed": 0,
     }
 
     # One Empty per distinct legacy workplane (sketches sharing a plane share it).
     wp_empties = {}
     # old entity slvs_index -> (new Sketch, curve_id) for constraint remapping.
     entity_map = {}
+    # Legacy generated mesh -> new sketch (deferred), and old mesh -> new sketch
+    # object (for remapping boolean cutters that reference another sketch).
+    pending_modifiers = []
+    mesh_to_sketch_obj = {}
 
     for old_sketch in list(_iter_legacy_sketches(context)):
         try:
@@ -432,13 +470,21 @@ def migrate_scene(context):
 
             n_pts, n_seg = _migrate_geometry(context, old_sketch, sketch, entity_map)
             if old_mesh is not None and getattr(old_mesh, "type", None) == "MESH":
-                _migrate_modifiers(old_mesh, sketch, summary)
+                mesh_to_sketch_obj[old_mesh] = sketch.target_object
+                pending_modifiers.append((old_mesh, sketch))
             summary["sketches"] += 1
             summary["points"] += n_pts
             summary["segments"] += n_seg
         except Exception as e:
             logger.exception("Failed to migrate sketch %s", old_sketch)
             summary["errors"].append(f"{old_sketch.name}: {e!r}")
+
+    # Translate modifier stacks only after every old->new link is known, so a
+    # boolean cutting with another sketch's output can be remapped correctly.
+    for old_mesh, sketch in pending_modifiers:
+        _migrate_modifiers(old_mesh, sketch, summary, cutter_map=mesh_to_sketch_obj)
+
+    _remove_legacy_meshes(mesh_to_sketch_obj.keys(), summary)
 
     _migrate_constraints(context, entity_map, summary)
     return summary

--- a/utilities/migrate.py
+++ b/utilities/migrate.py
@@ -231,10 +231,38 @@ def _translate_array(mod, old_mesh, obj):
     return True
 
 
+def _translate_screw(mod, old_mesh, obj):
+    """Screw -> the Revolve tool. Best-effort: map the axis, angle, and step
+    resolution; ignore the params Revolve has no concept of (helical screw
+    offset, iterations, axis-object override)."""
+    from ..operators.modifiers import set_modifier_input
+
+    axis_dir = {"X": (1.0, 0.0, 0.0), "Y": (0.0, 1.0, 0.0), "Z": (0.0, 0.0, 1.0)}.get(
+        getattr(mod, "axis", "Z")
+    )
+    if axis_dir is None:
+        return False
+
+    ng = _load_node_group("CAD Sketcher Revolve")
+    if ng is None:
+        return False
+    angle = float(getattr(mod, "angle", 6.283185307179586))
+    steps = max(1, int(getattr(mod, "steps", 16)))
+
+    m = obj.modifiers.new("CAD_Sketcher Revolve", "NODES")
+    m.node_group = ng
+    set_modifier_input(m, "Socket_1", (0.0, 0.0, 0.0))  # Axis Origin (local)
+    set_modifier_input(m, "Socket_2", axis_dir)  # Axis Direction
+    set_modifier_input(m, "Socket_3", angle)  # Angle
+    set_modifier_input(m, "Socket_4", abs(angle) / steps)  # Angular Resolution
+    return True
+
+
 _MODIFIER_TRANSLATORS = {
     "SOLIDIFY": _translate_solidify,
     "BOOLEAN": _translate_boolean,
     "ARRAY": _translate_array,
+    "SCREW": _translate_screw,
 }
 
 

--- a/utilities/migrate.py
+++ b/utilities/migrate.py
@@ -43,7 +43,7 @@ def scene_needs_migration(context):
 
 def _create_workplane_empty(context, wp, name):
     empty = bpy.data.objects.new(name, None)
-    empty.empty_display_type = 'PLAIN_AXES'
+    empty.empty_display_type = "PLAIN_AXES"
     empty.empty_display_size = 0.5
     empty.lock_location = (True, True, True)
     empty.lock_rotation = (True, True, True)
@@ -75,11 +75,11 @@ def _migrate_geometry(context, old_sketch, sketch, entity_map):
     ``entity_map`` is populated with ``old slvs_index -> (sketch, curve_id)`` for
     every migrated entity, so constraints can be remapped afterwards.
     """
-    from ..model.point_2d import SlvsPoint2D
-    from ..model.line_2d import SlvsLine2D
     from ..model.arc import SlvsArc
     from ..model.circle import SlvsCircle
-    from ..model.curve_ref import PointRef, LineRef, ArcRef, CircleRef
+    from ..model.curve_ref import ArcRef, CircleRef, LineRef, PointRef
+    from ..model.line_2d import SlvsLine2D
+    from ..model.point_2d import SlvsPoint2D
 
     ents = list(old_sketch.sketch_entities(context))
     point_map = {}  # old slvs_index -> new PointRef
@@ -89,7 +89,8 @@ def _migrate_geometry(context, old_sketch, sketch, entity_map):
     for e in ents:
         if isinstance(e, SlvsPoint2D):
             pr = PointRef.create(
-                sketch, (e.co[0], e.co[1]),
+                sketch,
+                (e.co[0], e.co[1]),
                 construction=getattr(e, "construction", False),
                 fixed=getattr(e, "fixed", False),
             )
@@ -112,7 +113,8 @@ def _migrate_geometry(context, old_sketch, sketch, entity_map):
             return None
         local = wp_inv @ entity.location
         pr = PointRef.create(
-            sketch, (local.x, local.y),
+            sketch,
+            (local.x, local.y),
             construction=getattr(entity, "construction", False),
         )
         point_map[entity.slvs_index] = pr
@@ -141,11 +143,133 @@ def _migrate_geometry(context, old_sketch, sketch, entity_map):
     return len(point_map), n_seg
 
 
+# ---------------------------------------------------------------------------
+# Modifier translation
+#
+# In old files a sketch's ``target_object`` was the generated MESH output, and
+# users stacked ordinary mesh modifiers on it to build the finished part. New
+# sketches are Curves objects, which mesh modifiers cannot be added to, so the
+# old stack would be orphaned. Rebuild the translatable modifiers as the addon's
+# Geometry Nodes node tools (or a native GN node) on the new Curves sketch, in
+# order. Anything without a GN equivalent (e.g. Bevel -- Blender has no bevel
+# node) is skipped and recorded so the user knows exactly what was dropped.
+# ---------------------------------------------------------------------------
+
+
+def _load_node_group(name):
+    from ..assets_manager import load_asset
+    from ..global_data import LIB_NAME
+
+    if load_asset(LIB_NAME, "node_groups", name):
+        return bpy.data.node_groups.get(name)
+    return None
+
+
+def _translate_solidify(mod, old_mesh, obj):
+    """Solidify gives a profile thickness -- the same as the Extrude tool."""
+    from ..operators.modifiers import set_modifier_input
+
+    ng = _load_node_group("CAD Sketcher Extrude")
+    if ng is None:
+        return False
+    m = obj.modifiers.new("CAD_Sketcher Extrude", "NODES")
+    m.node_group = ng
+    set_modifier_input(m, "Input_2", float(mod.thickness))  # Size
+    return True
+
+
+def _translate_boolean(mod, old_mesh, obj):
+    """Boolean -> the CAD Sketcher Boolean node group, reading the same cutter."""
+    cutter = mod.object
+    if cutter is None:
+        return False
+    from ..operators.modifiers import (
+        View3D_OT_node_boolean,
+        set_boolean_operation,
+        set_modifier_input,
+    )
+    from .boolean_nodes import build_boolean_node_group
+
+    ng = build_boolean_node_group()
+    m = obj.modifiers.new(f"CAD_Sketcher Boolean {cutter.name}", "NODES")
+    m.node_group = ng
+    ids = View3D_OT_node_boolean._input_ids(ng)
+    set_modifier_input(m, ids["Cutter"], cutter)
+    op = {"DIFFERENCE": "Difference", "UNION": "Union", "INTERSECT": "Intersect"}[
+        mod.operation
+    ]
+    set_boolean_operation(m, ids["Operation"], op)
+    return True
+
+
+def _translate_array(mod, old_mesh, obj):
+    """Array -> the Linear Array node group. The old offset is a mix of a
+    relative (fraction of the object's bounds) and a constant part; combine both
+    into one world-space offset, then split into direction + spacing."""
+    from mathutils import Vector
+
+    from ..operators.modifiers import set_modifier_input
+
+    offset = Vector((0.0, 0.0, 0.0))
+    if mod.use_constant_offset:
+        offset += Vector(mod.constant_offset_displace)
+    if mod.use_relative_offset:
+        dims = old_mesh.dimensions
+        rel = mod.relative_offset_displace
+        offset += Vector((rel[0] * dims.x, rel[1] * dims.y, rel[2] * dims.z))
+    if offset.length < 1e-9:
+        return False  # no derivable direction
+
+    ng = _load_node_group("CAD Sketcher Linear Array")
+    if ng is None:
+        return False
+    m = obj.modifiers.new("CAD_Sketcher Linear Array", "NODES")
+    m.node_group = ng
+    set_modifier_input(m, "Input_21", tuple(offset.normalized()))  # Direction
+    set_modifier_input(m, "Input_22", int(mod.count))  # Count
+    set_modifier_input(m, "Input_23", offset.length)  # Spacing
+    return True
+
+
+_MODIFIER_TRANSLATORS = {
+    "SOLIDIFY": _translate_solidify,
+    "BOOLEAN": _translate_boolean,
+    "ARRAY": _translate_array,
+}
+
+
+def _migrate_modifiers(old_mesh, sketch, summary):
+    """Rebuild ``old_mesh``'s modifier stack as GN siblings on ``sketch``.
+
+    Isolated per modifier: a failed or unsupported one is skipped and recorded,
+    never aborting the rest of the migration.
+    """
+    obj = sketch.target_object
+    if obj is None:
+        return
+    for mod in list(old_mesh.modifiers):
+        try:
+            translator = _MODIFIER_TRANSLATORS.get(mod.type)
+            if translator is not None and translator(mod, old_mesh, obj):
+                summary["modifiers"] += 1
+            else:
+                summary["modifiers_skipped"].append(f"{old_mesh.name}: {mod.type}")
+        except Exception as e:
+            logger.exception("Failed to migrate modifier %s", mod.name)
+            summary["modifiers_skipped"].append(f"{old_mesh.name}: {mod.type} ({e!r})")
+
+
 def migrate_scene(context):
     """Migrate all legacy sketches (geometry + constraints). Returns a summary."""
     summary = {
-        "sketches": 0, "points": 0, "segments": 0,
-        "constraints": 0, "constraints_skipped": 0, "errors": [],
+        "sketches": 0,
+        "points": 0,
+        "segments": 0,
+        "constraints": 0,
+        "constraints_skipped": 0,
+        "errors": [],
+        "modifiers": 0,
+        "modifiers_skipped": [],
     }
 
     # One Empty per distinct legacy workplane (sketches sharing a plane share it).
@@ -163,13 +287,17 @@ def migrate_scene(context):
                 )
                 wp_empties[wp.slvs_index] = empty
 
-            sketch = _create_sketch_object(
-                context, empty, old_sketch.name or "Sketch"
-            )
+            # The legacy target_object is the old generated mesh (with the user's
+            # modifier stack); capture it before re-pointing to the new sketch.
+            old_mesh = old_sketch.target_object
+
+            sketch = _create_sketch_object(context, empty, old_sketch.name or "Sketch")
             # Link old->new so re-runs skip it and future phases can find it.
             old_sketch.target_object = sketch.target_object
 
             n_pts, n_seg = _migrate_geometry(context, old_sketch, sketch, entity_map)
+            if old_mesh is not None and getattr(old_mesh, "type", None) == "MESH":
+                _migrate_modifiers(old_mesh, sketch, summary)
             summary["sketches"] += 1
             summary["points"] += n_pts
             summary["segments"] += n_seg
@@ -242,8 +370,7 @@ def _migrate_constraints(context, entity_map, summary):
             ctype = getattr(old, "type", None)
             refs = [getattr(old, n, None) for n in ("entity1", "entity2", "entity3")]
             mapped = [
-                entity_map.get(r.slvs_index) if r is not None else None
-                for r in refs
+                entity_map.get(r.slvs_index) if r is not None else None for r in refs
             ]
             present = [m for m in mapped if m]
             if not present:


### PR DESCRIPTION
Addresses the Discord report that migrated projects lose their modifier-based build steps.

## Background

In old files a sketch's `target_object` was the generated mesh output, and users stacked ordinary mesh modifiers on it to build the finished part. New sketches are Curves objects, and mesh modifiers cannot be added to a Curves object, so after migration that whole stack was orphaned (the old mesh keeps rendering but is no longer driven by an editable sketch).

## What this does

During migration, the old output mesh's modifier stack is captured before `target_object` is re-pointed, and each translatable modifier is rebuilt as its Geometry Nodes sibling on the new Curves sketch, in order:

- Solidify -> the Extrude node tool (Solidify is thickness, which Extrude produces; verified the Extrude group yields a closed solid)
- Boolean -> the CAD Sketcher Boolean node group, reading the same cutter and operation
- Array -> the Linear Array node group (relative + constant offset combined into direction + spacing)

Anything without a GN equivalent (Bevel has no Geometry Nodes node in Blender; also Decimate/Remesh/etc.) is skipped and recorded in the migration summary, so nothing is silently lost.

Per-modifier translation is isolated: a failed or unsupported modifier is skipped and recorded, never aborting the rest of the migration.

## Tests

Cover Solidify -> Extrude with the thickness mapped, Boolean -> Boolean node group with cutter and operation, Boolean with no cutter skipped, Array -> Linear Array with count and spacing, Bevel skipped and recorded, and a mixed stack that preserves order among the translated modifiers.

## Notes / follow-ups

- This helps files re-opened from their original (pre-migration) state. Files already migrated and saved have the sketch to old-mesh link severed; re-associating those would need a heuristic and is out of scope here.
- Bevel of the final solid has no path in the Curves-output model (Blender has no bevel node); that is a separate limitation to track.
- The skipped-modifier list is currently logged in the migration summary; surfacing it more prominently (a popup) could be a follow-up.