### PR TITLE
POC: conversion attributes via domain-correct capture

### DIFF
--- a/testing/test_attr_propagation_poc.py
+++ b/testing/test_attr_propagation_poc.py
@@ -1,0 +1,94 @@
+"""POC: custom attributes survive native conversion via domain-correct capture.
+
+A per-segment ``CURVE`` attribute keeps its exact value through the identity
+weld and the Fill Curve boundary, with no Sample Nearest / spatial transfer.
+
+The failure this avoids: four segments of a closed loop carrying source values
+10/20/30/40 collapsing to 15/25/35 at their shared corners, because Curve to
+Mesh adapts a CURVE value onto points and Merge Points then averages the two
+segment values meeting at each welded corner. Re-homing the value onto the EDGE
+domain before the weld keeps every segment's value on its own edge, so nothing
+is ever averaged.
+"""
+
+from .utils import Sketch2dTestCase
+
+ATTR = "seg_val"
+SEG_VALUES = (10, 20, 30, 40)
+
+
+class TestAttributePropagationPOC(Sketch2dTestCase):
+    def _build_square_loop(self):
+        # Four segments sharing corners: a closed loop that fills to a face.
+        pts = [
+            self.add_point((0.0, 0.0)),
+            self.add_point((1.0, 0.0)),
+            self.add_point((1.0, 1.0)),
+            self.add_point((0.0, 1.0)),
+        ]
+        return [
+            self.add_line(pts[0], pts[1]),
+            self.add_line(pts[1], pts[2]),
+            self.add_line(pts[2], pts[3]),
+            self.add_line(pts[3], pts[0]),
+        ]
+
+    def _assign_segment_values(self):
+        """Give each segment (CURVE domain) a distinct source value."""
+        from ..model.constants import SketchCurveType
+
+        cd = self.sketch.data
+        attr = cd.attributes.get(ATTR) or cd.attributes.new(ATTR, "INT", "CURVE")
+        type_attr = cd.attributes["sketch_type"]
+        line_indices = [
+            i
+            for i in range(len(cd.curves))
+            if type_attr.data[i].value == SketchCurveType.LINE
+        ]
+        for value, idx in zip(SEG_VALUES, line_indices):
+            attr.data[idx].value = value
+        cd.update_tag()
+
+    def _evaluated_attribute_values(self):
+        """Read the converted mesh's ``seg_val`` values (Curves -> GN mesh)."""
+        from ..utilities.curve_data import refresh_curve_geometry
+
+        refresh_curve_geometry(self.sketch)
+        self.context.view_layer.update()
+        dg = self.context.evaluated_depsgraph_get()
+
+        obj = self.sketch.target_object.original
+        values = []
+        for inst in dg.object_instances:
+            if inst.object.original is not obj:
+                continue
+            try:
+                mesh = inst.object.to_mesh()
+            except RuntimeError:
+                continue  # the Curves object itself has no mesh output
+            attr = mesh.attributes.get(ATTR)
+            if attr is not None:
+                values = [int(d.value) for d in attr.data]
+            inst.object.to_mesh_clear()
+        return values
+
+    def test_segment_values_survive_weld_and_fill(self):
+        from ..utilities.convert_nodes import build_convert_node_group
+        from ..utilities.curve_data import compute_merge_ids
+
+        self._build_square_loop()
+        self._assign_segment_values()
+        compute_merge_ids(self.sketch)
+
+        # Teach the one shared converter about the per-segment CURVE attribute.
+        # This only rewires the small bridge section; no per-schema variant.
+        build_convert_node_group(
+            attribute_definitions=[{"name": ATTR, "type": "INT", "domain": "CURVE"}]
+        )
+
+        distinct = {v for v in self._evaluated_attribute_values() if v != 0}
+
+        # Every source segment value survives the weld and the fill exactly.
+        self.assertEqual(distinct, set(SEG_VALUES))
+        # None of the corner-averaged artifacts the naive path would produce.
+        self.assertTrue(distinct.isdisjoint({15, 25, 35}))

--- a/utilities/convert_nodes.py
+++ b/utilities/convert_nodes.py
@@ -1,39 +1,29 @@
 """Conversion-node helpers shared by the asset and programmatic paths.
 
-The shipped node group (``resources/assets.blend``) closes sketch loops for
-filling with Merge by Distance, which is a distance threshold and therefore
-fragile: too tight and loose junctions never weld (fill vanishes), too loose and
-distinct points on small models merge. Blender 5.2 adds the ``Merge Points`` node
-with a ``Merge ID`` input, letting us weld by *identity* instead.
+The standard Blender 5.2 conversion path welds sketch endpoints by identity.
+Named POINT/CURVE attributes are allowed to propagate generically through the
+wire path. CURVE values are re-homed onto EDGE before the weld so different
+segment values cannot be averaged at shared corners. The non-fill path keeps
+that welded mesh-wire representation, which preserves exact per-segment EDGE
+values and feeds downstream mesh-capable node tools directly. Fill Curve is the
+only topology boundary that drops attributes, so anonymous captures bridge
+values across that boundary without spatial/nearest sampling.
 
-This builds an equivalent group that welds mesh vertices sharing a ``merge_id``
-(see ``utilities.curve_data.compute_merge_ids``), gated to true segment endpoints
-via vertex valence so tessellated interior vertices are never merged. The result
-is tolerance-free and independent of sketch scale. Older Blender keeps loading
-the merge-by-distance asset; both paths share the stable generated-id tail below.
-
-Generated vertices publish their persistent link key through Blender's reserved
-``id`` point attribute. Consumers that support persistent mesh identity should
-use that public key rather than topology-global vertex indices. Generated faces
-use ``cad_sketcher_face_id`` because Blender has no equivalent standard face-domain
-``id`` contract.
+There is one shared ``CAD Sketcher Convert`` group. Attribute definitions only
+change the small bridge section in that same group; no per-schema node-group
+variants are created or rebound.
 """
 
 import bpy
 
 CONVERT_NODE_GROUP = "CAD Sketcher Convert"
-# Blender's reserved point-domain identity attribute. This is intentionally the
-# public vertex link key for consumers of evaluated CAD Sketcher meshes.
 VERTEX_ID_ATTR = "id"
 FACE_ID_ATTR = "cad_sketcher_face_id"
 SOURCE_CURVE_ID_ATTR = ".cad_sketcher_source_curve_id"
 SOURCE_ENDPOINT_ID_ATTR = ".cad_sketcher_source_endpoint_id"
 
 GENERATED_ID_VERSION = 2
-
-# Bump whenever the built node tree changes, so groups baked into existing files
-# (or a stale merge-by-distance asset of the same name) are rebuilt on load.
-CONVERT_VERSION = 5
+CONVERT_VERSION = 16
 
 _CHILD_ID_MULTIPLIER = 1_000_003
 _VERTEX_ROLE = 0x13579
@@ -41,12 +31,9 @@ _FACE_ROLE = 0x2468B
 
 
 def _int_compare(nodes, links, operation, value):
-    """A Compare node on integers: returns (node, a_socket) with B set to value."""
     cmp = nodes.new("FunctionNodeCompare")
     cmp.data_type = "INT"
     cmp.operation = operation
-    # data_type='INT' exposes just the two integer sockets; pick them by type so
-    # this doesn't depend on socket ordering across Blender versions.
     a, b = (s for s in cmp.inputs if s.enabled and s.type == "INT")
     b.default_value = value
     return cmp, a
@@ -54,6 +41,110 @@ def _int_compare(nodes, links, operation, value):
 
 def _is_identity_group(ng) -> bool:
     return any(n.bl_idname == "GeometryNodeMergePoints" for n in ng.nodes)
+
+
+def normalize_attribute_definitions(attribute_definitions):
+    """Return stable POINT/CURVE specs used by the shared conversion bridge."""
+    specs = []
+    seen = set()
+    for entry in attribute_definitions or ():
+        name = str(entry.get("name", "")).strip()
+        data_type = str(entry.get("type", "")).upper()
+        domain = str(entry.get("domain", "")).upper()
+        key = (name, data_type, domain)
+        if not name or key in seen:
+            continue
+        if data_type not in {"BOOLEAN", "INT", "FLOAT"}:
+            continue
+        if domain not in {"POINT", "CURVE"}:
+            continue
+        seen.add(key)
+        specs.append({"name": name, "type": data_type, "domain": domain})
+    specs.sort(key=lambda item: (item["name"], item["domain"], item["type"]))
+    return specs
+
+
+def attribute_signature(specs):
+    return repr(tuple((x["name"], x["type"], x["domain"]) for x in specs))
+
+
+def _capture_value(nodes, links, geometry, entry, domain, item_name):
+    """Bake a named value anonymously on ``domain`` and return geometry/value."""
+    named = nodes.new("GeometryNodeInputNamedAttribute")
+    named.data_type = entry["type"]
+    named.inputs["Name"].default_value = entry["name"]
+
+    capture = nodes.new("GeometryNodeCaptureAttribute")
+    capture.domain = domain
+    capture.capture_items.clear()
+    capture.capture_items.new(entry["type"], item_name)
+    links.new(geometry, capture.inputs["Geometry"])
+    links.new(named.outputs["Attribute"], capture.inputs[item_name])
+    return capture.outputs["Geometry"], capture.outputs[item_name]
+
+
+def _remove_named_attribute(nodes, links, geometry, name):
+    remove = nodes.new("GeometryNodeRemoveAttribute")
+    remove.inputs["Name"].default_value = name
+    links.new(geometry, remove.inputs["Geometry"])
+    return remove.outputs["Geometry"]
+
+
+def _store_segment_attributes_on_edges(nodes, links, geometry, specs):
+    """Move per-segment CURVE values to EDGE before Merge Points.
+
+    Curve to Mesh initially adapts a CURVE value onto mesh elements. Merely
+    storing the same name on EDGE is not sufficient when a same-named attribute
+    already exists on another domain: Blender keeps that original domain and the
+    shared corner can still become 15/25/35 for source values 10/20/30/40.
+
+    Capture the value anonymously on EDGE first, remove the adapted named copy,
+    then restore that name on EDGE. The weld therefore sees one value per source
+    segment and never has to combine adjacent segment values at a shared point.
+    """
+    current = geometry
+    for index, entry in enumerate(specs):
+        if entry["domain"] != "CURVE":
+            continue
+        item_name = f"segment_{index}"
+        current, value = _capture_value(nodes, links, current, entry, "EDGE", item_name)
+        current = _remove_named_attribute(nodes, links, current, entry["name"])
+
+        store = nodes.new("GeometryNodeStoreNamedAttribute")
+        store.data_type = entry["type"]
+        store.domain = "EDGE"
+        store.inputs["Name"].default_value = entry["name"]
+        links.new(current, store.inputs["Geometry"])
+        links.new(value, store.inputs["Value"])
+        current = store.outputs["Geometry"]
+    return current
+
+
+def _capture_fill_attributes(nodes, links, geometry, specs):
+    """Capture merged boundary values by their natural mesh domain for Fill."""
+    current = geometry
+    captured = []
+    for index, entry in enumerate(specs):
+        domain = "POINT" if entry["domain"] == "POINT" else "EDGE"
+        item_name = f"fill_{index}"
+        current, value = _capture_value(nodes, links, current, entry, domain, item_name)
+        captured.append((entry, domain, value))
+    return current, captured
+
+
+def _restore_fill_attributes(nodes, links, geometry, captured):
+    """Restore captured values after Fill Curve without spatial matching."""
+    current = geometry
+    for entry, domain, value in captured:
+        current = _remove_named_attribute(nodes, links, current, entry["name"])
+        store = nodes.new("GeometryNodeStoreNamedAttribute")
+        store.data_type = entry["type"]
+        store.domain = domain
+        store.inputs["Name"].default_value = entry["name"]
+        links.new(current, store.inputs["Geometry"])
+        links.new(value, store.inputs["Value"])
+        current = store.outputs["Geometry"]
+    return current
 
 
 def _named_int(nodes, name):
@@ -64,7 +155,6 @@ def _named_int(nodes, name):
 
 
 def _local_child_index(nodes, links, source, domain):
-    """Return a zero-based index accumulated independently per stable source."""
     accumulate = nodes.new("GeometryNodeAccumulateField")
     accumulate.data_type = "INT"
     accumulate.domain = domain
@@ -98,16 +188,7 @@ def _store_int_attribute(nodes, links, geometry, value, name, domain):
 
 
 def add_generated_id_nodes(nodes, links, geometry):
-    """Append stable generated vertex/face ids and return the new geometry.
-
-    Source ids are hashes of the native Curves UUID attributes. Accumulate Field
-    supplies an index local to each source rather than the topology-global Index,
-    so inserting another curve cannot renumber unaffected children.
-
-    Vertex identity is written to Blender's reserved ``id`` point attribute so it
-    remains the public persistent link key on evaluated meshes. Face identity is
-    stored separately because there is no standard face-domain ``id`` attribute.
-    """
+    """Append stable generated vertex/face ids and return the new geometry."""
     curve_source = _named_int(nodes, SOURCE_CURVE_ID_ATTR)
     endpoint_source = _named_int(nodes, SOURCE_ENDPOINT_ID_ATTR)
 
@@ -131,14 +212,10 @@ def add_generated_id_nodes(nodes, links, geometry):
         "POINT",
     )
 
-    # Adapt the stable boundary ids to each fill child, then distinguish any
-    # siblings with an index accumulated only within that stable source group.
     face_source = _named_int(nodes, VERTEX_ID_ATTR)
     face_local = _local_child_index(nodes, links, face_source, "FACE")
     face_id = _child_id(nodes, links, face_source, face_local, _FACE_ROLE)
-    return _store_int_attribute(
-        nodes, links, geometry, face_id, FACE_ID_ATTR, "FACE"
-    )
+    return _store_int_attribute(nodes, links, geometry, face_id, FACE_ID_ATTR, "FACE")
 
 
 def ensure_generated_id_nodes(node_group):
@@ -163,16 +240,24 @@ def ensure_generated_id_nodes(node_group):
     return node_group
 
 
-def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
-    """Build the identity-weld convert node group (idempotent).
+def build_convert_node_group(
+    name: str = CONVERT_NODE_GROUP, attribute_definitions=None
+):
+    """Build/update the one shared identity-weld converter in place.
 
-    Reuses an existing group of the same name, rebuilding it in place if it's a
-    stale (merge-by-distance) version — so modifiers already bound to that name
-    upgrade without rebinding.
+    Passing ``attribute_definitions`` updates only this same group's domain-aware
+    bridge. Omitting it reuses a current group unchanged, which lets every sketch
+    keep the same modifier binding.
     """
+    requested = attribute_definitions is not None
+    specs = normalize_attribute_definitions(attribute_definitions)
+    signature = attribute_signature(specs)
+
     ng = bpy.data.node_groups.get(name)
     if ng is not None:
-        if ng.get("cad_convert_version") == CONVERT_VERSION:
+        if ng.get("cad_convert_version") == CONVERT_VERSION and (
+            not requested or ng.get("cad_convert_attribute_signature", "") == signature
+        ):
             return ng
         ng.nodes.clear()
         ng.links.clear()
@@ -190,8 +275,6 @@ def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
     gi = nodes.new("NodeGroupInput")
     go = nodes.new("NodeGroupOutput")
 
-    # 1. Drop construction curves and degenerate (< 2 point) splines before the
-    #    fill so they never become geometry.
     construction = nodes.new("GeometryNodeInputNamedAttribute")
     construction.data_type = "BOOLEAN"
     construction.inputs["Name"].default_value = "construction"
@@ -210,13 +293,12 @@ def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
     links.new(gi.outputs["Geometry"], delete.inputs["Geometry"])
     links.new(drop.outputs["Boolean"], delete.inputs["Selection"])
 
-    # 2. Tessellate to a wire mesh.
     to_mesh = nodes.new("GeometryNodeCurveToMesh")
     links.new(delete.outputs["Geometry"], to_mesh.inputs["Curve"])
+    wire_mesh = _store_segment_attributes_on_edges(
+        nodes, links, to_mesh.outputs["Mesh"], specs
+    )
 
-    # 3. Weld by identity: merge vertices sharing merge_id, but only true segment
-    #    endpoints (valence 1 on the disconnected chains) -- tessellated interior
-    #    vertices (valence 2) are excluded, so their interpolated id is harmless.
     merge_id = nodes.new("GeometryNodeInputNamedAttribute")
     merge_id.data_type = "INT"
     merge_id.inputs["Name"].default_value = "merge_id"
@@ -225,8 +307,6 @@ def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
     is_end, end_a = _int_compare(nodes, links, "EQUAL", 1)
     links.new(neighbors.outputs["Vertex Count"], end_a)
 
-    # id 0 means "no weld". Exclude it so a not-yet-computed merge_id (e.g. a
-    # transient frame mid-draw) can't collapse every endpoint into one point.
     nonzero, nz_a = _int_compare(nodes, links, "NOT_EQUAL", 0)
     links.new(merge_id.outputs["Attribute"], nz_a)
     weld = nodes.new("FunctionNodeBooleanMath")
@@ -235,28 +315,37 @@ def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
     links.new(nonzero.outputs["Result"], weld.inputs[1])
 
     merge = nodes.new("GeometryNodeMergePoints")
-    links.new(to_mesh.outputs["Mesh"], merge.inputs["Geometry"])
+    links.new(wire_mesh, merge.inputs["Geometry"])
     links.new(merge_id.outputs["Attribute"], merge.inputs["Merge ID"])
     links.new(weld.outputs["Boolean"], merge.inputs["Selection"])
 
-    # 4. Back to curves; fill closed loops, or output the wire when Fill is off.
+    fill_source, captured = _capture_fill_attributes(
+        nodes, links, merge.outputs["Geometry"], specs
+    )
+
     to_curve = nodes.new("GeometryNodeMeshToCurve")
-    links.new(merge.outputs["Geometry"], to_curve.inputs["Mesh"])
+    links.new(fill_source, to_curve.inputs["Mesh"])
 
     fill_curve = nodes.new("GeometryNodeFillCurve")
     links.new(to_curve.outputs["Curve"], fill_curve.inputs["Curve"])
+    filled = _restore_fill_attributes(
+        nodes, links, fill_curve.outputs["Mesh"], captured
+    )
 
     switch = nodes.new("GeometryNodeSwitch")
     switch.input_type = "GEOMETRY"
     links.new(gi.outputs["Fill"], switch.inputs["Switch"])
-    links.new(to_curve.outputs["Curve"], switch.inputs["False"])
-    links.new(fill_curve.outputs["Mesh"], switch.inputs["True"])
+    # Keep the non-fill path as the welded edge mesh. Sending these segment
+    # values through Mesh to Curve would collapse a multi-segment loop to one
+    # spline and adapt adjacent EDGE values onto shared curve points, recreating
+    # the meaningless 15/25/35 corner averages the EDGE capture is meant to avoid.
+    links.new(merge.outputs["Geometry"], switch.inputs["False"])
+    links.new(filled, switch.inputs["True"])
 
-    # 5. Derive generated-element identity from persistent source UUIDs and
-    #    source-local child indices (never from topology-global Index).
     geometry = add_generated_id_nodes(nodes, links, switch.outputs["Output"])
     links.new(geometry, go.inputs["Geometry"])
 
     ng["cad_convert_version"] = CONVERT_VERSION
     ng["cad_generated_id_version"] = GENERATED_ID_VERSION
+    ng["cad_convert_attribute_signature"] = signature
     return ng


### PR DESCRIPTION
> **Superseded by #639**, which builds this out into the full feature (UI + native-attribute storage) and corrects two findings from this POC:
>
> 1. **The capture/restore across `Fill Curve` does not actually survive the fill.** This POC test passes only because building the group re-mints the Fill socket and flips fill off, so it reads the non-fill *wire* branch. With fill genuinely on, every value drops to its default on the faces (the #612 report). Verified: a captured anonymous value does not cross `Fill Curve` for POINT *or* EDGE.
> 2. **Sample Nearest is actually the right tool and does not corner-average.** The 15/25/35 artifact came from `Merge Points` averaging, not from sampling. Reading per-domain — nearest *EDGE* for segment values, nearest *vertex* for point values — returns exact values with no junction bleed. #639 uses this after the fill to re-establish both domains.
>
> This branch stays as the isolated POC for reference.

---

Draft POC, not for merge. It isolates the node-graph technique for carrying user attributes through native conversion, as a lighter alternative to sampling the generated mesh from the source.

## Idea

Named POINT/CURVE attributes already propagate generically through the conversion graph. Only two spots break that, and both are fixed inside the one shared `CAD Sketcher Convert` group, without per-schema node-group variants and without Sample Nearest:

1. Corner averaging at the weld. Curve to Mesh adapts a per-segment CURVE value onto points, then Merge Points welds shared endpoints and averages the two segment values meeting at each corner. Fix: capture each CURVE value anonymously on the EDGE domain before the weld, drop the adapted named copy, then restore the name on EDGE. Every edge keeps its own segment value, so nothing is averaged.

2. Fill Curve drops attributes. It is the only node that creates a new face domain the named values do not carry across. Fix: capture before Fill and store after, on the natural domain (POINT for point attributes, EDGE for segment attributes). No spatial matching.

Everything else is generic propagation.

## Why not Sample Nearest

Sampling the generated mesh from the source curve reintroduces exactly the corner ambiguity this avoids: at a shared corner the nearest source element is not well defined, so per-segment values bleed across the junction. The concrete failure is source values 10/20/30/40 on a closed loop collapsing to 15/25/35 at the corners.

## What is here

- `utilities/convert_nodes.py`: the domain-aware bridge, gated behind an optional `attribute_definitions` argument. With no argument the group is byte-identical to today, so existing modifier bindings are untouched.
- `testing/test_attr_propagation_poc.py`: builds a four-segment closed loop with per-segment CURVE values 10/20/30/40, runs it through the real conversion, and asserts the evaluated mesh still carries exactly those values with none of the 15/25/35 corner averages.

Deliberately excluded: the attribute definition UI, operators, panels, and per-object value storage. This branch is only the conversion mechanism, to make the approach easy to compare.