### PR TITLE
Exclude CLAUDE.md from built extension

### DIFF
--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -56,6 +56,7 @@ paths_exclude_pattern = [
     "/ruff.toml",
     "/.blender_ext/",
     "/.claude/",
+    "/CLAUDE.md",
     "/CONTRIBUTING.md",
     "/.gitignore",
     "/testing/",


### PR DESCRIPTION
`CLAUDE.md` (AI-assistant instructions) has no runtime purpose and was being shipped in the packaged extension. Add it to `paths_exclude_pattern` so the built zip stays lean — follow-up cleanup for the extensions.blender.org submission.