### PR TITLE
Build revolve node group from source (fix fill regression #634)

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -78,6 +78,22 @@ def on_load_post(*args):
     except Exception:
         logger.exception("Legacy sketch migration failed")
 
+    # Upgrade a revolve node group baked into the file to the current build, so
+    # existing revolves pick up fixes on open instead of only when re-invoked.
+    # Only touch it when present -- never create it on load for files that have
+    # no revolve. build_revolve_node_group preserves each modifier's settings
+    # across the rebuild (see utilities.revolve_nodes).
+    try:
+        from .utilities.revolve_nodes import (
+            REVOLVE_NODE_GROUP,
+            build_revolve_node_group,
+        )
+
+        if bpy.data.node_groups.get(REVOLVE_NODE_GROUP) is not None:
+            build_revolve_node_group()
+    except Exception:
+        logger.exception("Revolve node group upgrade failed")
+
 
 def on_depsgraph_update(scene, depsgraph):
     from . import global_data

--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -425,7 +425,8 @@ class View3D_OT_node_revolve(Operator, NodeOperator):
     bl_label = "Revolve"
 
     NODEGROUP_NAME = "CAD Sketcher Revolve"
-    resources = (("node_groups", "CAD Sketcher Revolve"),)
+    # Built programmatically (not shipped as an asset); see init()/main().
+    resources = ()
     return_to_tool = BLENDER_SELECT_TOOL
 
     invalid_target_msg = "Select a sketch, curve or mesh profile to revolve"
@@ -471,6 +472,20 @@ class View3D_OT_node_revolve(Operator, NodeOperator):
         # converts mesh edges to a curve, so a poly-line/silhouette mesh works
         # too, matching Blender's Screw modifier.
         return obj is not None and obj.type in {"CURVE", "CURVES", "MESH"}
+
+    @staticmethod
+    def _input_ids(node_group):
+        from ..utilities.revolve_nodes import _input_ids
+
+        return _input_ids(node_group)
+
+    def init(self, context: Context, event: Event):
+        # Build the revolve node group in place of loading an asset.
+        from ..utilities.revolve_nodes import build_revolve_node_group
+
+        build_revolve_node_group()
+        bpy.ops.ed.undo_push(message="Add Revolve")
+        return True
 
     def get_point(self, context, index):
         # The axis is a picked edge, resolved to endpoints in set_props; there
@@ -524,13 +539,20 @@ class View3D_OT_node_revolve(Operator, NodeOperator):
         # Seed the angle/resolution from the existing revolve so re-invoking on
         # the same object continues from its current sweep. The axis is re-picked
         # each run (and flip isn't stored in the modifier), so neither is read.
-        self.angle = get_modifier_input(modifier, "Socket_3")
-        self.angular_resolution = get_modifier_input(modifier, "Socket_4")
+        from ..utilities.revolve_nodes import _input_ids
+
+        ids = _input_ids(modifier.node_group)
+        self.angle = get_modifier_input(modifier, ids["Angle"])
+        self.angular_resolution = get_modifier_input(modifier, ids["Angular Resolution"])
 
     def _has_stored_axis(self):
         return Vector(self.axis_direction).length > 1e-9
 
     def main(self, context):
+        from ..utilities.revolve_nodes import build_revolve_node_group
+
+        build_revolve_node_group()  # ensure it exists on the redo path too
+
         # Need an axis: either freshly picked (interactive) or persisted from a
         # previous run (redo). Without one the modifier would sit on the node
         # group's default axis and generate a bogus revolve.
@@ -565,10 +587,11 @@ class View3D_OT_node_revolve(Operator, NodeOperator):
         final_dir = -direction if self.flip else direction
 
         m = self.modifier
-        set_modifier_input(m, "Socket_1", tuple(origin))  # Axis Origin
-        set_modifier_input(m, "Socket_2", tuple(final_dir))  # Axis Direction
-        set_modifier_input(m, "Socket_3", self.angle)  # Angle
-        set_modifier_input(m, "Socket_4", self.angular_resolution)  # Angular Resolution
+        ids = self._input_ids(m.node_group)
+        set_modifier_input(m, ids["Axis Origin"], tuple(origin))
+        set_modifier_input(m, ids["Axis Direction"], tuple(final_dir))
+        set_modifier_input(m, ids["Angle"], self.angle)
+        set_modifier_input(m, ids["Angular Resolution"], self.angular_resolution)
         return True
 
     def draw_settings(self, context):

--- a/testing/test_migrate_modifiers.py
+++ b/testing/test_migrate_modifiers.py
@@ -104,12 +104,15 @@ class TestMigrateModifiers(Sketch2dTestCase):
             for m in self._sketch_mods()
             if m.node_group.name == "CAD Sketcher Revolve"
         )
-        self.assertAlmostEqual(get_modifier_input(rev, "Socket_3"), math.pi, places=4)
+        from ..utilities.revolve_nodes import _input_ids
+
+        ids = _input_ids(rev.node_group)
+        self.assertAlmostEqual(get_modifier_input(rev, ids["Angle"]), math.pi, places=4)
         # Axis Direction is Y.
-        axis = tuple(get_modifier_input(rev, "Socket_2"))
+        axis = tuple(get_modifier_input(rev, ids["Axis Direction"]))
         self.assertLess(abs(axis[1] - 1.0), 1e-4)
         self.assertAlmostEqual(
-            get_modifier_input(rev, "Socket_4"), math.pi / 12, places=4
+            get_modifier_input(rev, ids["Angular Resolution"]), math.pi / 12, places=4
         )
 
     def _sketch_group_named(self, name):

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -21,7 +21,6 @@ from ..operators.modifiers import (
 
 EXTRUDE = "CAD Sketcher Extrude"
 ARRAY = "CAD Sketcher Linear Array"
-REVOLVE = "CAD Sketcher Revolve"
 
 
 class TestNodeTools(BgsTestCase):
@@ -124,12 +123,16 @@ class TestNodeTools(BgsTestCase):
         return ob
 
     def _revolve(self, ob, angle, angle_step, axis=(0.0, 0.0, 1.0), origin=(0.0, 0.0, 0.0)):
+        from ..utilities.revolve_nodes import _input_ids, build_revolve_node_group
+
+        ng = build_revolve_node_group()
         mod = ob.modifiers.new("rev", "NODES")
-        mod.node_group = bpy.data.node_groups.get(REVOLVE)
-        set_modifier_input(mod, "Socket_1", origin)      # Axis Origin
-        set_modifier_input(mod, "Socket_2", axis)        # Axis Direction
-        set_modifier_input(mod, "Socket_3", angle)       # Angle
-        set_modifier_input(mod, "Socket_4", angle_step)  # Angle Step (max/segment)
+        mod.node_group = ng
+        ids = _input_ids(ng)
+        set_modifier_input(mod, ids["Axis Origin"], origin)
+        set_modifier_input(mod, ids["Axis Direction"], axis)
+        set_modifier_input(mod, ids["Angle"], angle)
+        set_modifier_input(mod, ids["Angular Resolution"], angle_step)
         return mod
 
     def test_revolve_target_gate(self):
@@ -156,7 +159,6 @@ class TestNodeTools(BgsTestCase):
     def test_revolve_mesh_profile(self):
         # A mesh edge-path profile revolves too (Mesh to Curve at the input).
         import math
-        self.assertTrue(am.load_asset(LIB_NAME, "node_groups", REVOLVE))
         ob = self._profile_mesh(n=5, radius=2.0, height=1.0)
         self._revolve(ob, math.tau, math.tau / 16)
         me = self._eval_mesh(ob)
@@ -166,7 +168,6 @@ class TestNodeTools(BgsTestCase):
 
     def test_revolve_creates_surface(self):
         import math
-        self.assertTrue(am.load_asset(LIB_NAME, "node_groups", REVOLVE))
         ob = self._profile_curve(n=5, radius=2.0, height=1.0)
         steps = 16  # angle_step = tau/16 -> ceil(tau / (tau/16)) = 16 steps
         self._revolve(ob, math.tau, math.tau / steps)
@@ -186,7 +187,6 @@ class TestNodeTools(BgsTestCase):
 
     def test_revolve_angle_step_controls_resolution(self):
         import math
-        self.assertTrue(am.load_asset(LIB_NAME, "node_groups", REVOLVE))
         ob = self._profile_curve()
         self._revolve(ob, math.tau, math.tau / 8)   # coarse: ~8 steps
         n_low = len(self._eval_mesh(ob).vertices)
@@ -198,7 +198,6 @@ class TestNodeTools(BgsTestCase):
     def test_revolve_angle_step_scales_with_angle(self):
         # Same angle step -> a quarter turn uses ~1/4 the steps of a full turn.
         import math
-        self.assertTrue(am.load_asset(LIB_NAME, "node_groups", REVOLVE))
         step = math.radians(6)
         ob = self._profile_curve()
         self._revolve(ob, math.tau, step)
@@ -212,30 +211,28 @@ class TestNodeTools(BgsTestCase):
         # A full revolve of a closed profile sweeps its closing segment (cyclic
         # wrap) and welds the seam -> a watertight solid (no boundary edges).
         import math
-        self.assertTrue(am.load_asset(LIB_NAME, "node_groups", REVOLVE))
         ob = self._closed_profile()
         self._revolve(ob, math.tau, math.radians(10))
         me = self._eval_mesh(ob)
         self.assertGreater(len(me.polygons), 0)
         self.assertEqual(self._boundary_edges(me), 0)
 
-    def test_revolve_partial_closed_profile_is_capped(self):
-        # A partial revolve of a closed profile caps both angular ends (filled
-        # in a plane-aligned copy then transformed back), giving a watertight
-        # solid -- no boundary edges/holes.
+    def test_revolve_partial_unfilled_profile_stays_open(self):
+        # A partial revolve of an *unfilled* closed profile has no face to cap
+        # with, so its two angular ends stay open (boundary edges present) -- a
+        # valid surface without end caps, matching the non-filled spec. (End caps
+        # only appear when the profile is filled; see test_revolve_nodes.py.)
         import math
-        self.assertTrue(am.load_asset(LIB_NAME, "node_groups", REVOLVE))
         ob = self._closed_profile()
         self._revolve(ob, math.pi / 2, math.radians(10))
         me = self._eval_mesh(ob)
         self.assertGreater(len(me.polygons), 0)
-        self.assertEqual(self._boundary_edges(me), 0)
+        self.assertGreater(self._boundary_edges(me), 0)
 
     def test_revolve_negative_angle_matches_positive(self):
         # The step count derives from |angle|, so revolving the other direction
         # keeps the same resolution (the per-step angle stays signed).
         import math
-        self.assertTrue(am.load_asset(LIB_NAME, "node_groups", REVOLVE))
         ob = self._profile_curve()
         self._revolve(ob, math.pi / 2, math.radians(10))
         n_pos = len(self._eval_mesh(ob).vertices)
@@ -246,7 +243,6 @@ class TestNodeTools(BgsTestCase):
 
     def test_revolve_partial_angle(self):
         import math
-        self.assertTrue(am.load_asset(LIB_NAME, "node_groups", REVOLVE))
         ob = self._profile_curve(radius=2.0)
         self._revolve(ob, math.pi / 2, math.radians(6))  # quarter turn
         me = self._eval_mesh(ob)
@@ -260,7 +256,6 @@ class TestNodeTools(BgsTestCase):
         # the target + axis from those and edit the *existing* modifier rather
         # than crash or spawn a duplicate.
         import math
-        self.assertTrue(am.load_asset(LIB_NAME, "node_groups", REVOLVE))
         ob = self._profile_mesh(n=3, radius=2.0, height=1.0)
         for o in self.scene.collection.objects:
             o.select_set(False)
@@ -292,13 +287,20 @@ class TestNodeTools(BgsTestCase):
         # + resolution sockets back onto the operator.
         import math
         from ..operators.modifiers import get_modifier_input
-        self.assertTrue(am.load_asset(LIB_NAME, "node_groups", REVOLVE))
+        from ..utilities.revolve_nodes import _input_ids
         ob = self._profile_mesh(n=3)
         mod = self._revolve(ob, math.pi / 3, math.radians(15))
 
         # The version-aware getter round-trips what _revolve set.
-        self.assertAlmostEqual(get_modifier_input(mod, "Socket_3"), math.pi / 3, places=5)
-        self.assertAlmostEqual(get_modifier_input(mod, "Socket_4"), math.radians(15), places=5)
+        ids = _input_ids(mod.node_group)
+        self.assertAlmostEqual(
+            get_modifier_input(mod, ids["Angle"]), math.pi / 3, places=5
+        )
+        self.assertAlmostEqual(
+            get_modifier_input(mod, ids["Angular Resolution"]),
+            math.radians(15),
+            places=5,
+        )
 
         # read_props only assigns self.angle/self.angular_resolution, so a plain
         # stand-in captures them without needing a live modal operator.

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -8,16 +8,16 @@ operators/modifiers.py, asserting the evaluated geometry actually changes.
 import bmesh
 import bpy
 
-from .utils import BgsTestCase
 from .. import assets_manager as am
 from ..global_data import LIB_NAME
 from ..operators.modifiers import (
+    View3D_OT_node_array_linear,
+    View3D_OT_node_extrude,
+    View3D_OT_node_revolve,
     is_2d_profile,
     set_modifier_input,
-    View3D_OT_node_extrude,
-    View3D_OT_node_array_linear,
-    View3D_OT_node_revolve,
 )
+from .utils import BgsTestCase
 
 EXTRUDE = "CAD Sketcher Extrude"
 ARRAY = "CAD Sketcher Linear Array"
@@ -286,6 +286,7 @@ class TestNodeTools(BgsTestCase):
         # from its current values, not the defaults. read_props pulls the angle
         # + resolution sockets back onto the operator.
         import math
+
         from ..operators.modifiers import get_modifier_input
         from ..utilities.revolve_nodes import _input_ids
         ob = self._profile_mesh(n=3)

--- a/testing/test_revolve_nodes.py
+++ b/testing/test_revolve_nodes.py
@@ -52,6 +52,24 @@ def _signed_volume(bm):
     return bm.calc_volume(signed=True)
 
 
+def _incoherent_edges(bm):
+    """Count manifold edges whose two faces wind the same way (inconsistent
+    orientation -- the red/grey face-orientation artifact)."""
+    count = 0
+    for edge in bm.edges:
+        if len(edge.link_faces) != 2:
+            continue
+        dirs = []
+        for face in edge.link_faces:
+            for loop in face.loops:
+                if loop.edge is edge:
+                    dirs.append((loop.vert.index, loop.link_loop_next.vert.index))
+                    break
+        if len(dirs) == 2 and dirs[0] == dirs[1]:
+            count += 1
+    return count
+
+
 class TestRevolveNodeGroup(BgsTestCase):
     # X-axis revolve; profiles sit at +Y so they never cross the axis.
     AXIS_ORIGIN = (0.0, 0.0, 0.0)
@@ -235,10 +253,13 @@ class TestRevolveNodeGroup(BgsTestCase):
         ob.modifiers.new("fill", "NODES").node_group = ng
         return ob
 
-    def test_filled_normals_point_outward_regardless_of_shape(self):
-        # The reporter's regression: the fill boundary loop has no deterministic
-        # winding, so some shapes revolved inside-out (negative volume). The
-        # signed-volume flip must make every filled shape come out solid-outward.
+    def test_filled_normals_coherent_and_outward_any_shape_or_angle(self):
+        # The reporter's regressions: the boundary loop has no deterministic
+        # winding, so (a) the caps came out inconsistently oriented (red/grey
+        # face-orientation) for some shapes, and (b) a negative sweep angle turned
+        # the whole solid inside-out. Canonicalizing the loop winding plus the
+        # signed-volume flip must give a coherent, solid-outward result for every
+        # shape *and* both angle signs.
         shapes = {
             "square": [(-0.4, -0.4), (0.4, -0.4), (0.4, 0.4), (-0.4, 0.4)],
             "square_cw": [(-0.4, -0.4), (-0.4, 0.4), (0.4, 0.4), (0.4, -0.4)],
@@ -252,21 +273,22 @@ class TestRevolveNodeGroup(BgsTestCase):
                 (-0.4, 0.4),
             ],
         }
-        for angle in (math.pi, math.tau):
+        for angle in (math.pi / 2, -math.pi / 2, math.tau, -math.tau):
             for name, pts in shapes.items():
                 ob = self._filled_poly(pts)
                 try:
                     self._revolve(ob, angle)
                     bm = _bm(ob)
                     volume = _signed_volume(bm)
+                    incoherent = _incoherent_edges(bm)
                     nonmanifold = _stats(bm)["nonmanifold"]
                     bm.free()
                 finally:
                     bpy.data.objects.remove(ob, do_unlink=True)
-                self.assertGreater(
-                    volume, 0.0, f"{name} at {angle:.2f} rad revolved inside-out"
-                )
-                self.assertEqual(nonmanifold, 0, f"{name} at {angle:.2f} not manifold")
+                where = f"{name} at {angle:.2f} rad"
+                self.assertEqual(incoherent, 0, f"{where}: inconsistent face winding")
+                self.assertGreater(volume, 0.0, f"{where}: revolved inside-out")
+                self.assertEqual(nonmanifold, 0, f"{where}: not manifold")
 
     def test_open_profile_makes_a_cylinder_not_a_closed_band(self):
         # An open profile (a line) must NOT get a wrap column: it sweeps to a tube

--- a/testing/test_revolve_nodes.py
+++ b/testing/test_revolve_nodes.py
@@ -188,6 +188,42 @@ class TestRevolveNodeGroup(BgsTestCase):
         finally:
             bpy.data.objects.remove(ob, do_unlink=True)
 
+    def _face_normals(self, ob):
+        bm = _bm(ob)
+        normals = {
+            tuple(round(c, 4) for c in f.calc_center_median()): f.normal.copy()
+            for f in bm.faces
+        }
+        bm.free()
+        return normals
+
+    def test_unfilled_orientation_matches_filled_both_angle_signs(self):
+        # An open (unfilled) shell must face the same way as the filled solid's
+        # outer surface, and must not flip with the sign of the sweep angle. The
+        # orientation is decided from an internally-capped version, so the shared
+        # lateral faces agree with the filled result for +angle and -angle alike.
+        for angle in (math.pi / 2, -math.pi / 2):
+            filled = self._octagon("NGON")
+            unfilled = self._octagon("NOTHING")
+            try:
+                self._revolve(filled, angle)
+                self._revolve(unfilled, angle)
+                filled_normals = self._face_normals(filled)
+                unfilled_normals = self._face_normals(unfilled)
+            finally:
+                bpy.data.objects.remove(filled, do_unlink=True)
+                bpy.data.objects.remove(unfilled, do_unlink=True)
+            matched = agree = 0
+            for center, normal in unfilled_normals.items():
+                if center in filled_normals:
+                    matched += 1
+                    if normal.dot(filled_normals[center]) > 0.5:
+                        agree += 1
+            self.assertGreater(matched, 0, f"no shared faces at {angle:.2f} rad")
+            self.assertEqual(
+                agree, matched, f"unfilled shell inverted at {angle:.2f} rad"
+            )
+
     def test_fill_does_not_leak_interior_triangulation(self):
         # The #634 core: a *triangulated* fill has interior edges. Sweeping those
         # (the old behavior) made redundant, self-intersecting geometry. The

--- a/testing/test_revolve_nodes.py
+++ b/testing/test_revolve_nodes.py
@@ -45,6 +45,13 @@ def _vertset(bm):
     return {tuple(round(c, 5) for c in v.co) for v in bm.verts}
 
 
+def _signed_volume(bm):
+    """Positive when the closed mesh's normals point outward, negative if
+    inside-out."""
+    bm.normal_update()
+    return bm.calc_volume(signed=True)
+
+
 class TestRevolveNodeGroup(BgsTestCase):
     # X-axis revolve; profiles sit at +Y so they never cross the axis.
     AXIS_ORIGIN = (0.0, 0.0, 0.0)
@@ -169,6 +176,66 @@ class TestRevolveNodeGroup(BgsTestCase):
         finally:
             bpy.data.objects.remove(filled, do_unlink=True)
             bpy.data.objects.remove(unfilled, do_unlink=True)
+
+    def _filled_poly(self, points):
+        """A closed poly profile at +Y with a Fill Curve modifier, so the revolve
+        receives a *triangulated* fill (as the real convert modifier produces)."""
+        cu = bpy.data.curves.new("poly", "CURVE")
+        sp = cu.splines.new("POLY")
+        sp.points.add(len(points) - 1)
+        sp.use_cyclic_u = True
+        for i, (x, y) in enumerate(points):
+            sp.points[i].co = (x, 2.0 + y, 0.0, 1.0)
+        ob = bpy.data.objects.new("poly", cu)
+        self.scene.collection.objects.link(ob)
+
+        ng = bpy.data.node_groups.new("fill", "GeometryNodeTree")
+        ng.interface.new_socket(
+            "Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry"
+        )
+        ng.interface.new_socket(
+            "Geometry", in_out="INPUT", socket_type="NodeSocketGeometry"
+        )
+        gi = ng.nodes.new("NodeGroupInput")
+        go = ng.nodes.new("NodeGroupOutput")
+        fill = ng.nodes.new("GeometryNodeFillCurve")
+        ng.links.new(gi.outputs["Geometry"], fill.inputs["Curve"])
+        ng.links.new(fill.outputs["Mesh"], go.inputs["Geometry"])
+        ob.modifiers.new("fill", "NODES").node_group = ng
+        return ob
+
+    def test_filled_normals_point_outward_regardless_of_shape(self):
+        # The reporter's regression: the fill boundary loop has no deterministic
+        # winding, so some shapes revolved inside-out (negative volume). The
+        # signed-volume flip must make every filled shape come out solid-outward.
+        shapes = {
+            "square": [(-0.4, -0.4), (0.4, -0.4), (0.4, 0.4), (-0.4, 0.4)],
+            "square_cw": [(-0.4, -0.4), (-0.4, 0.4), (0.4, 0.4), (0.4, -0.4)],
+            "triangle": [(0.0, 0.5), (-0.4, -0.3), (0.4, -0.3)],
+            "concave_L": [
+                (-0.4, -0.4),
+                (0.4, -0.4),
+                (0.4, 0.0),
+                (0.0, 0.0),
+                (0.0, 0.4),
+                (-0.4, 0.4),
+            ],
+        }
+        for angle in (math.pi, math.tau):
+            for name, pts in shapes.items():
+                ob = self._filled_poly(pts)
+                try:
+                    self._revolve(ob, angle)
+                    bm = _bm(ob)
+                    volume = _signed_volume(bm)
+                    nonmanifold = _stats(bm)["nonmanifold"]
+                    bm.free()
+                finally:
+                    bpy.data.objects.remove(ob, do_unlink=True)
+                self.assertGreater(
+                    volume, 0.0, f"{name} at {angle:.2f} rad revolved inside-out"
+                )
+                self.assertEqual(nonmanifold, 0, f"{name} at {angle:.2f} not manifold")
 
     def test_open_profile_makes_a_cylinder_not_a_closed_band(self):
         # An open profile (a line) must NOT get a wrap column: it sweeps to a tube

--- a/testing/test_revolve_nodes.py
+++ b/testing/test_revolve_nodes.py
@@ -1,0 +1,274 @@
+"""The from-source revolve node group.
+
+Guards the #634 regression: revolving a *filled* sketch used to sweep the
+profile's interior fill triangulation into the surface, producing redundant,
+self-intersecting geometry that broke the result, while the same sketch with fill
+off revolved cleanly. The from-source group normalizes any profile down to its
+boundary loop before sweeping, so the lateral surface is identical whether fill
+was on or off -- fill only adds end caps on a partial turn.
+"""
+
+import math
+
+import bmesh
+import bpy
+
+from ..operators.modifiers import View3D_OT_node_revolve, set_modifier_input
+from ..utilities.revolve_nodes import (
+    REVOLVE_NODE_GROUP,
+    REVOLVE_VERSION,
+    _input_ids,
+    build_revolve_node_group,
+)
+from .utils import BgsTestCase, Sketch2dTestCase
+
+
+def _bm(ob):
+    depsgraph = bpy.context.evaluated_depsgraph_get()
+    mesh = ob.evaluated_get(depsgraph).to_mesh()
+    bm = bmesh.new()
+    if mesh is not None:
+        bm.from_mesh(mesh)
+    return bm
+
+
+def _stats(bm):
+    return {
+        "verts": len(bm.verts),
+        "faces": len(bm.faces),
+        "nonmanifold": sum(1 for e in bm.edges if len(e.link_faces) > 2),
+        "boundary": sum(1 for e in bm.edges if len(e.link_faces) == 1),
+    }
+
+
+def _vertset(bm):
+    return {tuple(round(c, 5) for c in v.co) for v in bm.verts}
+
+
+class TestRevolveNodeGroup(BgsTestCase):
+    # X-axis revolve; profiles sit at +Y so they never cross the axis.
+    AXIS_ORIGIN = (0.0, 0.0, 0.0)
+    AXIS_DIR = (1.0, 0.0, 0.0)
+
+    def _revolve(self, ob, angle, resolution=math.radians(15), axis=None, origin=None):
+        ng = build_revolve_node_group()
+        mod = ob.modifiers.new("Revolve", "NODES")
+        mod.node_group = ng
+        ids = _input_ids(ng)
+        set_modifier_input(mod, ids["Axis Origin"], origin or self.AXIS_ORIGIN)
+        set_modifier_input(mod, ids["Axis Direction"], axis or self.AXIS_DIR)
+        set_modifier_input(mod, ids["Angle"], angle)
+        set_modifier_input(mod, ids["Angular Resolution"], resolution)
+        return mod
+
+    def _octagon(self, fill_type):
+        """A radius-0.5 octagon at +Y (so the X axis is clear of it)."""
+        bpy.ops.mesh.primitive_circle_add(
+            vertices=8, radius=0.5, location=(0, 2, 0), fill_type=fill_type
+        )
+        ob = self.context.active_object
+        bpy.ops.object.transform_apply(location=True, rotation=False, scale=False)
+        return ob
+
+    # -- build / versioning ----------------------------------------------
+
+    def test_group_builds_and_is_versioned(self):
+        group = build_revolve_node_group()
+        self.assertEqual(group.name, REVOLVE_NODE_GROUP)
+        self.assertEqual(group.get("cad_revolve_version"), REVOLVE_VERSION)
+        self.assertTrue(group.is_modifier)
+        self.assertIs(build_revolve_node_group(), group)
+
+    def test_stale_version_rebuilds_in_place(self):
+        group = build_revolve_node_group()
+        group["cad_revolve_version"] = 0
+        again = build_revolve_node_group()
+        self.assertIs(again, group)
+        self.assertEqual(group.get("cad_revolve_version"), REVOLVE_VERSION)
+
+    # -- geometry --------------------------------------------------------
+
+    def test_filled_full_turn_is_watertight_torus_without_caps(self):
+        # A filled profile revolved a full turn closes on itself: watertight, no
+        # non-manifold edges, and no caps needed (the surface is a torus).
+        ob = self._octagon("NGON")
+        try:
+            self._revolve(ob, math.tau)
+            bm = _bm(ob)
+            stats = _stats(bm)
+            bm.free()
+            self.assertGreater(stats["faces"], 0)
+            self.assertEqual(stats["boundary"], 0, "full turn must be closed")
+            self.assertEqual(stats["nonmanifold"], 0)
+        finally:
+            bpy.data.objects.remove(ob, do_unlink=True)
+
+    def test_filled_partial_turn_is_capped_solid(self):
+        # A filled profile revolved a partial turn caps both ends -> watertight
+        # solid, no boundary edges, no non-manifold edges.
+        ob = self._octagon("NGON")
+        try:
+            self._revolve(ob, math.pi)
+            bm = _bm(ob)
+            stats = _stats(bm)
+            bm.free()
+            self.assertEqual(stats["boundary"], 0, "partial fill must be capped")
+            self.assertEqual(stats["nonmanifold"], 0)
+        finally:
+            bpy.data.objects.remove(ob, do_unlink=True)
+
+    def test_unfilled_partial_turn_is_open_shell(self):
+        # An unfilled profile has no face to cap with, so a partial turn is an
+        # open tube: it has boundary edges (the two end rings) but is still a
+        # clean, non-self-intersecting surface.
+        ob = self._octagon("NOTHING")
+        try:
+            self._revolve(ob, math.pi)
+            bm = _bm(ob)
+            stats = _stats(bm)
+            bm.free()
+            self.assertGreater(stats["boundary"], 0, "unfilled ends stay open")
+            self.assertEqual(stats["nonmanifold"], 0)
+        finally:
+            bpy.data.objects.remove(ob, do_unlink=True)
+
+    def test_fill_does_not_leak_interior_triangulation(self):
+        # The #634 core: a *triangulated* fill has interior edges. Sweeping those
+        # (the old behavior) made redundant, self-intersecting geometry. The
+        # boundary-loop normalization must drop them -> zero non-manifold edges.
+        ob = self._octagon("TRIFAN")
+        try:
+            self._revolve(ob, math.pi)
+            bm = _bm(ob)
+            stats = _stats(bm)
+            bm.free()
+            self.assertEqual(
+                stats["nonmanifold"], 0, "interior fill edges must not be swept"
+            )
+        finally:
+            bpy.data.objects.remove(ob, do_unlink=True)
+
+    def test_lateral_surface_identical_with_and_without_fill(self):
+        # The heart of the fix: the swept lateral surface is the same whether the
+        # profile was filled or not. The unfilled result (pure lateral) must be a
+        # vertex-for-vertex subset of the filled one, and the same size.
+        filled = self._octagon("NGON")
+        unfilled = self._octagon("NOTHING")
+        try:
+            self._revolve(filled, math.pi)
+            self._revolve(unfilled, math.pi)
+            bm_f, bm_u = _bm(filled), _bm(unfilled)
+            set_f, set_u = _vertset(bm_f), _vertset(bm_u)
+            stats_f = _stats(bm_f)
+            bm_f.free()
+            bm_u.free()
+            self.assertEqual(len(set_u), len(set_f), "lateral vertex counts differ")
+            self.assertEqual(set_u - set_f, set(), "lateral surfaces differ")
+            # And the fill still added the caps that closed it.
+            self.assertEqual(stats_f["boundary"], 0)
+        finally:
+            bpy.data.objects.remove(filled, do_unlink=True)
+            bpy.data.objects.remove(unfilled, do_unlink=True)
+
+    def test_open_profile_makes_a_cylinder_not_a_closed_band(self):
+        # An open profile (a line) must NOT get a wrap column: it sweeps to a tube
+        # open along its length (a cylinder), never a closed cross-section band.
+        cu = bpy.data.curves.new("line", "CURVE")
+        sp = cu.splines.new("POLY")
+        sp.points.add(4)
+        for i in range(5):
+            sp.points[i].co = (2.0, 0.0, i * 0.25, 1.0)
+        ob = bpy.data.objects.new("line", cu)
+        self.scene.collection.objects.link(ob)
+        try:
+            # 16 steps around Z; 5 profile points -> 5 * 16 verts after welding the
+            # 360 seam, and open top/bottom rings (no wrap column).
+            self._revolve(ob, math.tau, resolution=math.tau / 16, axis=(0.0, 0.0, 1.0))
+            bm = _bm(ob)
+            stats = _stats(bm)
+            bm.free()
+        finally:
+            bpy.data.objects.remove(ob, do_unlink=True)
+        self.assertEqual(stats["verts"], 5 * 16)
+        self.assertEqual(stats["nonmanifold"], 0)
+        self.assertGreater(stats["boundary"], 0, "cylinder ends stay open")
+
+    # -- operator contract -----------------------------------------------
+
+    def test_operator_socket_contract(self):
+        # The names the operator's set_props writes must exist on the group.
+        group = build_revolve_node_group()
+        ids = View3D_OT_node_revolve._input_ids(group)
+        for name in ("Axis Origin", "Axis Direction", "Angle", "Angular Resolution"):
+            self.assertIn(name, ids)
+
+
+class TestRevolveThroughConvert(Sketch2dTestCase):
+    """The gold-standard integration: revolve reads the *real* convert modifier's
+    output, and that output revolves the same whether the sketch's Fill is on or
+    off (bar the caps).
+
+    A native-curves sketch object can't be read with ``to_mesh`` (its evaluated
+    type stays CURVES). So a proxy mesh object pulls the sketch's convert output
+    through an Object Info node -- exactly how the boolean tool consumes a sketch
+    -- and revolves that, which is what the geometry-nodes graph does at runtime.
+    """
+
+    def _revolve_with_fill(self, fill):
+        from ..utilities.curve_data import (
+            CONVERT_MODIFIER_NAME,
+            refresh_curve_geometry,
+        )
+
+        # A fresh sketch each call, with one closed circle at +Y (clear of the X
+        # revolve axis).
+        self.sketch = self.new_sketch()
+        center = self.add_point((0.0, 2.0))
+        self.add_circle(center, 0.5)
+        refresh_curve_geometry(self.sketch)
+
+        sketch_ob = self.sketch.target_object
+        conv = sketch_ob.modifiers.get(CONVERT_MODIFIER_NAME)
+        self.assertIsNotNone(conv)
+        set_modifier_input(conv, _input_ids(conv.node_group)["Fill"], fill)
+
+        # Proxy mesh object: Object Info(sketch) -> revolve group.
+        proxy = bpy.data.objects.new("proxy", bpy.data.meshes.new("proxy"))
+        self.scene.collection.objects.link(proxy)
+        ng = bpy.data.node_groups.new("proxy_revolve", "GeometryNodeTree")
+        ng.interface.new_socket(
+            "Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry"
+        )
+        out = ng.nodes.new("NodeGroupOutput")
+        info = ng.nodes.new("GeometryNodeObjectInfo")
+        info.transform_space = "RELATIVE"
+        info.inputs["Object"].default_value = sketch_ob
+        rev = ng.nodes.new("GeometryNodeGroup")
+        rev.node_tree = build_revolve_node_group()
+        ng.links.new(info.outputs["Geometry"], rev.inputs["Geometry"])
+        rev.inputs["Axis Origin"].default_value = (0.0, 0.0, 0.0)
+        rev.inputs["Axis Direction"].default_value = (1.0, 0.0, 0.0)
+        rev.inputs["Angle"].default_value = math.pi
+        rev.inputs["Angular Resolution"].default_value = math.radians(15)
+        ng.links.new(rev.outputs["Geometry"], out.inputs["Geometry"])
+        proxy.modifiers.new("proxy", "NODES").node_group = ng
+        return _bm(proxy)
+
+    def test_revolve_output_matches_across_fill_toggle(self):
+        bm_fill = self._revolve_with_fill(True)
+        stats_fill = _stats(bm_fill)
+        verts_fill = _vertset(bm_fill)
+        bm_fill.free()
+
+        bm_nofill = self._revolve_with_fill(False)
+        stats_nofill = _stats(bm_nofill)
+        verts_nofill = _vertset(bm_nofill)
+        bm_nofill.free()
+
+        # Both are clean surfaces (no self-intersection from swept fill).
+        self.assertEqual(stats_fill["nonmanifold"], 0)
+        self.assertEqual(stats_nofill["nonmanifold"], 0)
+        # The lateral surface is identical; fill only adds the caps.
+        self.assertEqual(verts_nofill - verts_fill, set(), "lateral surfaces differ")
+        self.assertEqual(stats_fill["boundary"], 0, "filled partial turn is capped")
+        self.assertGreater(stats_nofill["boundary"], 0, "unfilled stays open")

--- a/testing/test_revolve_nodes.py
+++ b/testing/test_revolve_nodes.py
@@ -356,6 +356,7 @@ class TestRevolveThroughConvert(Sketch2dTestCase):
         bm_fill = self._revolve_with_fill(True)
         stats_fill = _stats(bm_fill)
         verts_fill = _vertset(bm_fill)
+        volume_fill = _signed_volume(bm_fill)
         bm_fill.free()
 
         bm_nofill = self._revolve_with_fill(False)
@@ -366,6 +367,8 @@ class TestRevolveThroughConvert(Sketch2dTestCase):
         # Both are clean surfaces (no self-intersection from swept fill).
         self.assertEqual(stats_fill["nonmanifold"], 0)
         self.assertEqual(stats_nofill["nonmanifold"], 0)
+        # The filled solid (caps included) is coherently oriented outward.
+        self.assertGreater(volume_fill, 0.0, "filled revolve is inside-out")
         # The lateral surface is identical; fill only adds the caps.
         self.assertEqual(verts_nofill - verts_fill, set(), "lateral surfaces differ")
         self.assertEqual(stats_fill["boundary"], 0, "filled partial turn is capped")

--- a/testing/test_revolve_nodes.py
+++ b/testing/test_revolve_nodes.py
@@ -93,6 +93,37 @@ class TestRevolveNodeGroup(BgsTestCase):
         self.assertIs(again, group)
         self.assertEqual(group.get("cad_revolve_version"), REVOLVE_VERSION)
 
+    def test_rebuild_preserves_existing_modifier_settings(self):
+        # Rebuilding in place reassigns socket identifiers, so a modifier already
+        # bound to the group (from the old binary asset or a prior version) would
+        # lose its settings unless they are re-applied by name. This is the
+        # migration guarantee for existing files.
+        from ..operators.modifiers import get_modifier_input
+
+        group = build_revolve_node_group()
+        ob = self._octagon("NGON")
+        try:
+            mod = ob.modifiers.new("Revolve", "NODES")
+            mod.node_group = group
+            ids = _input_ids(group)
+            set_modifier_input(mod, ids["Angle"], 1.2345)
+            set_modifier_input(mod, ids["Axis Direction"], (0.0, 1.0, 0.0))
+
+            # Force a rebuild, exactly as an old-asset / stale-version group triggers.
+            group["cad_revolve_version"] = 0
+            rebuilt = build_revolve_node_group()
+            new_ids = _input_ids(rebuilt)
+            # The identifiers really did change (otherwise this proves nothing).
+            self.assertNotEqual(ids["Angle"], new_ids["Angle"])
+            # ...yet the values survived, matched up by socket name.
+            self.assertAlmostEqual(
+                get_modifier_input(mod, new_ids["Angle"]), 1.2345, places=4
+            )
+            axis = tuple(get_modifier_input(mod, new_ids["Axis Direction"]))
+            self.assertAlmostEqual(axis[1], 1.0, places=4)
+        finally:
+            bpy.data.objects.remove(ob, do_unlink=True)
+
     # -- geometry --------------------------------------------------------
 
     def test_filled_full_turn_is_watertight_torus_without_caps(self):

--- a/utilities/migrate.py
+++ b/utilities/migrate.py
@@ -346,6 +346,7 @@ def _translate_screw(mod, old_mesh, obj):
     resolution; ignore the params Revolve has no concept of (helical screw
     offset, iterations, axis-object override)."""
     from ..operators.modifiers import set_modifier_input
+    from .revolve_nodes import _input_ids, build_revolve_node_group
 
     axis_dir = {"X": (1.0, 0.0, 0.0), "Y": (0.0, 1.0, 0.0), "Z": (0.0, 0.0, 1.0)}.get(
         getattr(mod, "axis", "Z")
@@ -353,18 +354,17 @@ def _translate_screw(mod, old_mesh, obj):
     if axis_dir is None:
         return False
 
-    ng = _load_node_group("CAD Sketcher Revolve")
-    if ng is None:
-        return False
+    ng = build_revolve_node_group()
     angle = float(getattr(mod, "angle", 6.283185307179586))
     steps = max(1, int(getattr(mod, "steps", 16)))
 
     m = obj.modifiers.new("CAD_Sketcher Revolve", "NODES")
     m.node_group = ng
-    set_modifier_input(m, "Socket_1", (0.0, 0.0, 0.0))  # Axis Origin (local)
-    set_modifier_input(m, "Socket_2", axis_dir)  # Axis Direction
-    set_modifier_input(m, "Socket_3", angle)  # Angle
-    set_modifier_input(m, "Socket_4", abs(angle) / steps)  # Angular Resolution
+    ids = _input_ids(ng)
+    set_modifier_input(m, ids["Axis Origin"], (0.0, 0.0, 0.0))  # local origin
+    set_modifier_input(m, ids["Axis Direction"], axis_dir)
+    set_modifier_input(m, ids["Angle"], angle)
+    set_modifier_input(m, ids["Angular Resolution"], abs(angle) / steps)
     return True
 
 

--- a/utilities/revolve_nodes.py
+++ b/utilities/revolve_nodes.py
@@ -60,6 +60,59 @@ def _input_ids(node_group):
     }
 
 
+def _snapshot_modifier_inputs(node_group):
+    """Capture every modifier bound to ``node_group`` as (modifier, {name: value}).
+
+    Rebuilding the group in place reassigns socket identifiers, and modifier
+    inputs are keyed by identifier, so their values must be re-applied by the
+    stable socket *name* afterwards -- otherwise upgrading from the old binary
+    asset (or a previous version) silently resets every existing revolve.
+    """
+    from ..operators.modifiers import get_modifier_input
+
+    names = {
+        s.identifier: s.name
+        for s in node_group.interface.items_tree
+        if getattr(s, "in_out", "") == "INPUT"
+    }
+    saved = []
+    for obj in bpy.data.objects:
+        for mod in obj.modifiers:
+            if (
+                getattr(mod, "type", None) != "NODES"
+                or mod.node_group is not node_group
+            ):
+                continue
+            values = {}
+            for identifier, name in names.items():
+                try:
+                    value = get_modifier_input(mod, identifier)
+                except Exception:
+                    continue
+                # Coerce array-likes (vectors) to a plain tuple so the snapshot
+                # survives the interface teardown.
+                values[name] = tuple(value) if hasattr(value, "__len__") else value
+            if values:
+                saved.append((mod, values))
+    return saved
+
+
+def _restore_modifier_inputs(node_group, saved):
+    """Re-apply snapshot values (see ``_snapshot_modifier_inputs``) by name."""
+    from ..operators.modifiers import set_modifier_input
+
+    ids = _input_ids(node_group)
+    for mod, values in saved:
+        for name, value in values.items():
+            identifier = ids.get(name)
+            if identifier is None:
+                continue
+            try:
+                set_modifier_input(mod, identifier, value)
+            except Exception:
+                pass
+
+
 def _math(nodes, links, operation, a=None, b=None):
     """A ShaderNodeMath node; wire/`set` inputs 0 and 1, return the output socket."""
     node = nodes.new("ShaderNodeMath")
@@ -103,6 +156,12 @@ def build_revolve_node_group(name: str = REVOLVE_NODE_GROUP):
 
     if ng.get("cad_revolve_version") == REVOLVE_VERSION:
         return ng
+
+    # Rebuilding replaces the interface, reassigning socket identifiers; preserve
+    # the settings of any modifier already bound to this group (old asset or a
+    # prior version) by re-applying them by socket name after the rebuild.
+    saved = _snapshot_modifier_inputs(ng)
+
     ng.nodes.clear()
     ng.links.clear()
     ng.interface.clear()
@@ -334,5 +393,6 @@ def build_revolve_node_group(name: str = REVOLVE_NODE_GROUP):
     links.new(flipped.outputs["Mesh"], orient.inputs["True"])
     links.new(orient.outputs["Output"], go.inputs["Geometry"])
 
+    _restore_modifier_inputs(ng, saved)
     ng["cad_revolve_version"] = REVOLVE_VERSION
     return ng

--- a/utilities/revolve_nodes.py
+++ b/utilities/revolve_nodes.py
@@ -42,7 +42,7 @@ REVOLVE_NODE_GROUP = "CAD Sketcher Revolve"
 # Bump whenever the built tree changes so groups baked into existing files -- or a
 # stale same-named binary asset -- are rebuilt in place on next use, keeping
 # modifiers bound to the same name.
-REVOLVE_VERSION = 1
+REVOLVE_VERSION = 2
 
 # Weld tolerance for the sweep seams and the cap-to-lateral join. The welded
 # points are produced by the *same* profile sample and rotation, so they are
@@ -286,7 +286,53 @@ def build_revolve_node_group(name: str = REVOLVE_NODE_GROUP):
     weld = nodes.new("GeometryNodeMergeByDistance")
     links.new(result.outputs["Geometry"], weld.inputs["Geometry"])
     weld.inputs["Distance"].default_value = _WELD_DISTANCE
-    links.new(weld.outputs["Geometry"], go.inputs["Geometry"])
+    welded = weld.outputs["Geometry"]
+
+    # 6. Consistent outward normals. The boundary loop that Mesh to Curve extracts
+    #    from a fill triangulation has no deterministic winding, so the swept solid
+    #    can come out inside-out for some profile shapes. For a *filled* profile
+    #    (which yields a closed solid) compute the signed volume via the divergence
+    #    theorem -- sum over faces of dot(centroid, normal) * area -- and flip the
+    #    whole mesh when it is negative, so normals always point outward regardless
+    #    of the profile's shape. Unfilled profiles are an open shell (no meaningful
+    #    volume) and are left as-is.
+    position = nodes.new("GeometryNodeInputPosition")
+    normal = nodes.new("GeometryNodeInputNormal")
+    face_area = nodes.new("GeometryNodeInputMeshFaceArea")
+    flux = nodes.new("ShaderNodeVectorMath")
+    flux.operation = "DOT_PRODUCT"
+    links.new(position.outputs["Position"], flux.inputs[0])
+    links.new(normal.outputs["Normal"], flux.inputs[1])
+    term = _math(
+        nodes, links, "MULTIPLY", a=flux.outputs["Value"], b=face_area.outputs["Area"]
+    )
+    volume = nodes.new("GeometryNodeAttributeStatistic")
+    volume.data_type = "FLOAT"
+    volume.domain = "FACE"
+    links.new(welded, volume.inputs["Geometry"])
+    links.new(term, volume.inputs["Attribute"])
+
+    inside_out = nodes.new("FunctionNodeCompare")
+    inside_out.data_type = "FLOAT"
+    inside_out.operation = "LESS_THAN"
+    va, vb = (s for s in inside_out.inputs if s.enabled and s.type == "VALUE")
+    vb.default_value = 0.0
+    links.new(volume.outputs["Sum"], va)
+
+    flip_needed = nodes.new("FunctionNodeBooleanMath")
+    flip_needed.operation = "AND"
+    links.new(filled.outputs["Result"], flip_needed.inputs[0])
+    links.new(inside_out.outputs["Result"], flip_needed.inputs[1])
+
+    flipped = nodes.new("GeometryNodeFlipFaces")
+    links.new(welded, flipped.inputs["Mesh"])
+
+    orient = nodes.new("GeometryNodeSwitch")
+    orient.input_type = "GEOMETRY"
+    links.new(flip_needed.outputs["Boolean"], orient.inputs["Switch"])
+    links.new(welded, orient.inputs["False"])
+    links.new(flipped.outputs["Mesh"], orient.inputs["True"])
+    links.new(orient.outputs["Output"], go.inputs["Geometry"])
 
     ng["cad_revolve_version"] = REVOLVE_VERSION
     return ng

--- a/utilities/revolve_nodes.py
+++ b/utilities/revolve_nodes.py
@@ -38,9 +38,11 @@ caps (the surface closes on itself), and an unfilled profile has no face to cap
 with -- it stays an open shell. This matches the spec: a non-filled sketch
 revolves to a valid surface, just without end caps.
 
-Finally the signed volume (divergence theorem) decides orientation: a filled
-solid is flipped when it comes out inside-out, so normals always point outward
-regardless of the profile's shape or the *sign* of the sweep angle.
+Finally, orientation is decided from an internally-capped (closed) version of the
+solid via its signed volume (divergence theorem) and the whole result is flipped
+when it comes out inside-out. The same decision drives both the filled solid and
+the unfilled open shell, so normals always point outward regardless of the
+profile's shape or the *sign* of the sweep angle.
 """
 
 import math
@@ -52,7 +54,7 @@ REVOLVE_NODE_GROUP = "CAD Sketcher Revolve"
 # Bump whenever the built tree changes so groups baked into existing files -- or a
 # stale same-named binary asset -- are rebuilt in place on next use, keeping
 # modifiers bound to the same name.
-REVOLVE_VERSION = 4
+REVOLVE_VERSION = 5
 
 # Weld tolerance for the sweep seams and the cap-to-lateral join. The welded
 # points are produced by the *same* profile sample and rotation, so they are
@@ -396,16 +398,12 @@ def build_revolve_node_group(name: str = REVOLVE_NODE_GROUP):
     pb.default_value = math.tau - 1e-4
     links.new(abs_angle, pa)
 
-    caps_needed = nodes.new("FunctionNodeBooleanMath")
-    caps_needed.operation = "AND"
-    links.new(filled.outputs["Result"], caps_needed.inputs[0])
-    links.new(partial.outputs["Result"], caps_needed.inputs[1])
-
     # Caps fill the (canonicalized) boundary loop the lateral is swept from, so
-    # they weld exactly onto the tube's open ends. Because the loop winding is now
-    # deterministic, the end cap keeps the fill winding and the start cap (at angle
-    # 0) is flipped, so the two caps wind oppositely and stay coherent with the
-    # lateral for every profile shape.
+    # they weld exactly onto the tube's open ends. With the loop winding
+    # deterministic, the end cap keeps the fill winding and the start cap (at
+    # angle 0) is flipped, so the two caps wind oppositely and stay coherent with
+    # the lateral for every profile shape. They close a *partial* turn (a full
+    # turn already closes on itself).
     cap_fill = nodes.new("GeometryNodeFillCurve")
     links.new(profile_curve, cap_fill.inputs["Curve"])
     cap_mesh = cap_fill.outputs["Mesh"]
@@ -427,28 +425,26 @@ def build_revolve_node_group(name: str = REVOLVE_NODE_GROUP):
 
     caps_switch = nodes.new("GeometryNodeSwitch")
     caps_switch.input_type = "GEOMETRY"
-    links.new(caps_needed.outputs["Boolean"], caps_switch.inputs["Switch"])
+    links.new(partial.outputs["Result"], caps_switch.inputs["Switch"])
     links.new(caps.outputs["Geometry"], caps_switch.inputs["True"])
 
-    # 5. Join the caps onto the lateral tube and weld their boundary rings to the
-    #    tube's open ends, giving a closed solid where applicable.
-    result = nodes.new("GeometryNodeJoinGeometry")
-    links.new(lateral, result.inputs["Geometry"])
-    links.new(caps_switch.outputs["Output"], result.inputs["Geometry"])
+    # 5. A closed version (tube + caps) serves as the filled output *and* as the
+    #    reference for deciding orientation. The unfilled output is the bare tube.
+    closed_join = nodes.new("GeometryNodeJoinGeometry")
+    links.new(lateral, closed_join.inputs["Geometry"])
+    links.new(caps_switch.outputs["Output"], closed_join.inputs["Geometry"])
+    closed_weld = nodes.new("GeometryNodeMergeByDistance")
+    links.new(closed_join.outputs["Geometry"], closed_weld.inputs["Geometry"])
+    closed_weld.inputs["Distance"].default_value = _WELD_DISTANCE
+    closed = closed_weld.outputs["Geometry"]
 
-    weld = nodes.new("GeometryNodeMergeByDistance")
-    links.new(result.outputs["Geometry"], weld.inputs["Geometry"])
-    weld.inputs["Distance"].default_value = _WELD_DISTANCE
-    welded = weld.outputs["Geometry"]
-
-    # 6. Consistent outward normals. With the loop winding canonicalized the solid
-    #    is coherently oriented, but whether that coherent orientation faces out or
-    #    in still depends on the profile and the *sign of the sweep angle*. Compute
-    #    the signed volume via the divergence theorem -- sum over faces of
-    #    dot(centroid, normal) * area -- and flip the whole mesh when negative, so
-    #    normals always point outward regardless of shape or angle direction.
-    #    Unfilled profiles are an open shell (no meaningful volume) and are left
-    #    as-is.
+    # 6. Consistent outward normals for BOTH fill states and BOTH angle signs.
+    #    After canonicalization the coherent orientation still faces out or in
+    #    depending on the profile and the sign of the sweep angle. Decide from the
+    #    *closed* solid's signed volume (divergence theorem: sum over faces of
+    #    dot(centroid, normal) * area) and flip when it is inside-out. The same
+    #    decision drives the open shell, so an unfilled revolve keeps a consistent
+    #    orientation regardless of angle direction too.
     position = nodes.new("GeometryNodeInputPosition")
     normal = nodes.new("GeometryNodeInputNormal")
     face_area = nodes.new("GeometryNodeInputMeshFaceArea")
@@ -462,7 +458,7 @@ def build_revolve_node_group(name: str = REVOLVE_NODE_GROUP):
     volume = nodes.new("GeometryNodeAttributeStatistic")
     volume.data_type = "FLOAT"
     volume.domain = "FACE"
-    links.new(welded, volume.inputs["Geometry"])
+    links.new(closed, volume.inputs["Geometry"])
     links.new(term, volume.inputs["Attribute"])
 
     inside_out = nodes.new("FunctionNodeCompare")
@@ -472,18 +468,20 @@ def build_revolve_node_group(name: str = REVOLVE_NODE_GROUP):
     vb.default_value = 0.0
     links.new(volume.outputs["Sum"], va)
 
-    flip_needed = nodes.new("FunctionNodeBooleanMath")
-    flip_needed.operation = "AND"
-    links.new(filled.outputs["Result"], flip_needed.inputs[0])
-    links.new(inside_out.outputs["Result"], flip_needed.inputs[1])
+    # Filled -> the closed solid; unfilled -> the open tube. Both take the flip.
+    output_geo = nodes.new("GeometryNodeSwitch")
+    output_geo.input_type = "GEOMETRY"
+    links.new(filled.outputs["Result"], output_geo.inputs["Switch"])
+    links.new(lateral, output_geo.inputs["False"])
+    links.new(closed, output_geo.inputs["True"])
 
     flipped = nodes.new("GeometryNodeFlipFaces")
-    links.new(welded, flipped.inputs["Mesh"])
+    links.new(output_geo.outputs["Output"], flipped.inputs["Mesh"])
 
     orient = nodes.new("GeometryNodeSwitch")
     orient.input_type = "GEOMETRY"
-    links.new(flip_needed.outputs["Boolean"], orient.inputs["Switch"])
-    links.new(welded, orient.inputs["False"])
+    links.new(inside_out.outputs["Result"], orient.inputs["Switch"])
+    links.new(output_geo.outputs["Output"], orient.inputs["False"])
     links.new(flipped.outputs["Mesh"], orient.inputs["True"])
     links.new(orient.outputs["Output"], go.inputs["Geometry"])
 

--- a/utilities/revolve_nodes.py
+++ b/utilities/revolve_nodes.py
@@ -1,0 +1,288 @@
+"""Revolve (lathe) node group, built from source.
+
+The shipped revolve was a ~60-node binary asset in ``resources/assets.blend``
+that swept the *profile mesh* directly. That made it depend on how the profile
+was tessellated: a filled sketch (the convert modifier's ``Fill`` on) arrives as
+a triangulated mesh whose interior edges got swept into the surface, producing
+redundant, self-intersecting geometry that broke the result (issue #634). The
+same sketch with ``Fill`` off arrives as a clean boundary curve and revolved
+fine.
+
+This builds an equivalent group programmatically -- versioned in code and rebuilt
+in place when ``REVOLVE_VERSION`` changes, like the boolean and convert groups --
+that first *normalizes* whatever profile it is handed down to a single boundary
+loop, so the swept lateral surface is identical whether ``Fill`` was on or off:
+
+    * a mesh (filled or a wire) -> its boundary edges become a curve
+      (``Mesh to Curve`` selecting edges with fewer than two adjacent faces),
+    * a curve passes straight through,
+
+joined into one boundary curve. Only that loop is swept, so interior fill
+triangulation can never leak into the surface.
+
+The lateral surface is a Grid of ``(P+1) x (steps+1)`` vertices -- ``P`` profile
+points (plus one wrap column to close the loop) by one column per angular step --
+whose every vertex is the matching profile point rotated about the axis by its
+step's angle. ``Merge by Distance`` welds the wrap column and, at a full turn,
+the start/end seam.
+
+End caps are added only when the profile was *filled* and the sweep is a partial
+turn (< 360 deg): the filled face at the start, and a copy rotated to the end.
+A full turn needs no caps (the surface closes on itself), and an unfilled profile
+has no face to cap with -- it stays an open shell. This matches the spec: a
+non-filled sketch revolves to a valid surface, just without end caps.
+"""
+
+import math
+
+import bpy
+
+REVOLVE_NODE_GROUP = "CAD Sketcher Revolve"
+
+# Bump whenever the built tree changes so groups baked into existing files -- or a
+# stale same-named binary asset -- are rebuilt in place on next use, keeping
+# modifiers bound to the same name.
+REVOLVE_VERSION = 1
+
+# Weld tolerance for the sweep seams and the cap-to-lateral join. The welded
+# points are produced by the *same* profile sample and rotation, so they are
+# exactly coincident; any small epsilon collapses them. Kept well below typical
+# sketch feature sizes so distinct profile points are never merged.
+_WELD_DISTANCE = 1e-4
+
+
+def _input_ids(node_group):
+    """Map input socket name -> identifier (values are written by name)."""
+    return {
+        s.name: s.identifier
+        for s in node_group.interface.items_tree
+        if getattr(s, "in_out", "") == "INPUT"
+    }
+
+
+def _math(nodes, links, operation, a=None, b=None):
+    """A ShaderNodeMath node; wire/`set` inputs 0 and 1, return the output socket."""
+    node = nodes.new("ShaderNodeMath")
+    node.operation = operation
+    for index, value in ((0, a), (1, b)):
+        if value is None:
+            continue
+        if isinstance(value, (int, float)):
+            node.inputs[index].default_value = float(value)
+        else:
+            links.new(value, node.inputs[index])
+    return node.outputs[0]
+
+
+def _rotate_about_axis(nodes, links, gi, vector, angle):
+    """VectorRotate ``vector`` about the group's axis by ``angle`` (radians)."""
+    rot = nodes.new("ShaderNodeVectorRotate")
+    rot.rotation_type = "AXIS_ANGLE"
+    links.new(vector, rot.inputs["Vector"])
+    links.new(gi.outputs["Axis Origin"], rot.inputs["Center"])
+    links.new(gi.outputs["Axis Direction"], rot.inputs["Axis"])
+    links.new(angle, rot.inputs["Angle"])
+    return rot.outputs["Vector"]
+
+
+def build_revolve_node_group(name: str = REVOLVE_NODE_GROUP):
+    """Build the from-source revolve group (idempotent).
+
+    Reuses an existing group of the same name, rebuilding it in place when the
+    stored version is stale -- so modifiers already bound to that name (including
+    ones bound to the old binary asset) upgrade without rebinding. Returns the
+    node group.
+    """
+    ng = bpy.data.node_groups.get(name)
+    if ng is None:
+        ng = bpy.data.node_groups.new(name, "GeometryNodeTree")
+
+    # Offer it in the Add Modifier > Geometry Nodes picker (off by default for
+    # API-created groups).
+    ng.is_modifier = True
+
+    if ng.get("cad_revolve_version") == REVOLVE_VERSION:
+        return ng
+    ng.nodes.clear()
+    ng.links.clear()
+    ng.interface.clear()
+
+    iface = ng.interface
+    iface.new_socket("Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry")
+    iface.new_socket("Geometry", in_out="INPUT", socket_type="NodeSocketGeometry")
+    iface.new_socket("Axis Origin", in_out="INPUT", socket_type="NodeSocketVector")
+    axis = iface.new_socket(
+        "Axis Direction", in_out="INPUT", socket_type="NodeSocketVector"
+    )
+    axis.default_value = (0.0, 0.0, 1.0)
+    angle = iface.new_socket("Angle", in_out="INPUT", socket_type="NodeSocketFloat")
+    angle.subtype = "ANGLE"
+    angle.default_value = math.tau
+    resolution = iface.new_socket(
+        "Angular Resolution", in_out="INPUT", socket_type="NodeSocketFloat"
+    )
+    resolution.subtype = "ANGLE"
+    resolution.default_value = math.radians(2)
+    resolution.min_value = math.radians(0.1)
+
+    nodes, links = ng.nodes, ng.links
+    gi = nodes.new("NodeGroupInput")
+    go = nodes.new("NodeGroupOutput")
+
+    # 1. Step count from the sweep angle and the max angle per segment:
+    #    steps = max(1, ceil(|Angle| / Resolution)).
+    abs_angle = _math(nodes, links, "ABSOLUTE", a=gi.outputs["Angle"])
+    # Guard the divide: clamp resolution away from zero (the operator enforces a
+    # positive minimum, but a hand-set 0 would otherwise blow up).
+    safe_res = _math(nodes, links, "MAXIMUM", a=gi.outputs["Angular Resolution"], b=1e-4)
+    steps_raw = _math(nodes, links, "DIVIDE", a=abs_angle, b=safe_res)
+    steps_ceil = _math(nodes, links, "CEIL", a=steps_raw)
+    steps = _math(nodes, links, "MAXIMUM", a=steps_ceil, b=1.0)
+
+    # 2. Normalize the profile to a single boundary curve, independent of whether
+    #    it arrived as a filled mesh, a wire mesh, or a curve.
+    sep = nodes.new("GeometryNodeSeparateComponents")
+    links.new(gi.outputs["Geometry"], sep.inputs["Geometry"])
+
+    # Boundary edges of the mesh part: those with fewer than two adjacent faces
+    # (1 = a fill boundary, 0 = a bare wire). Interior fill edges (2 faces) are
+    # dropped, so tessellation never reaches the sweep.
+    neighbors = nodes.new("GeometryNodeInputMeshEdgeNeighbors")
+    boundary = nodes.new("FunctionNodeCompare")
+    boundary.data_type = "INT"
+    boundary.operation = "LESS_THAN"
+    ba, bb = (s for s in boundary.inputs if s.enabled and s.type == "INT")
+    bb.default_value = 2
+    links.new(neighbors.outputs["Face Count"], ba)
+
+    mesh_to_curve = nodes.new("GeometryNodeMeshToCurve")
+    links.new(sep.outputs["Mesh"], mesh_to_curve.inputs["Mesh"])
+    links.new(boundary.outputs["Result"], mesh_to_curve.inputs["Selection"])
+
+    profile = nodes.new("GeometryNodeJoinGeometry")
+    links.new(mesh_to_curve.outputs["Curve"], profile.inputs["Geometry"])
+    links.new(sep.outputs["Curve"], profile.inputs["Geometry"])
+    profile_curve = profile.outputs["Geometry"]
+
+    # P = boundary-loop point count.
+    domain = nodes.new("GeometryNodeAttributeDomainSize")
+    domain.component = "CURVE"
+    links.new(profile_curve, domain.inputs["Geometry"])
+    point_count = domain.outputs["Point Count"]
+
+    # Whether the profile is a closed loop (cyclic). A closed profile needs one
+    # extra "wrap" column so the last point connects back to the first; an open
+    # profile (a line/arc -> a tube open along its length) must NOT wrap, or it
+    # would sweep a phantom face across the profile ends. Sample spline 0's cyclic
+    # flag (profiles are a single loop); Mesh to Curve sets it for closed
+    # boundaries, and a raw curve carries its own.
+    cyclic = nodes.new("GeometryNodeInputSplineCyclic")
+    is_cyclic = nodes.new("GeometryNodeSampleIndex")
+    is_cyclic.data_type = "BOOLEAN"
+    is_cyclic.domain = "CURVE"
+    links.new(profile_curve, is_cyclic.inputs["Geometry"])
+    links.new(cyclic.outputs["Cyclic"], is_cyclic.inputs["Value"])
+    is_cyclic.inputs["Index"].default_value = 0
+    wrap = nodes.new("GeometryNodeSwitch")
+    wrap.input_type = "INT"
+    links.new(is_cyclic.outputs["Value"], wrap.inputs["Switch"])
+    wrap.inputs["False"].default_value = 0
+    wrap.inputs["True"].default_value = 1
+
+    # 3. Lateral surface: a grid of (P + wrap) x (steps + 1) vertices. The wrap
+    #    column closes a cyclic loop; the extra row carries the final angle.
+    grid_x = _math(nodes, links, "ADD", a=point_count, b=wrap.outputs["Output"])
+    grid_y = _math(nodes, links, "ADD", a=steps, b=1.0)
+    grid = nodes.new("GeometryNodeMeshGrid")
+    grid.inputs["Size X"].default_value = 1.0
+    grid.inputs["Size Y"].default_value = 1.0
+    links.new(grid_x, grid.inputs["Vertices X"])
+    links.new(grid_y, grid.inputs["Vertices Y"])
+
+    # Per-vertex column/row from the grid's UV (0..1 across each axis).
+    uv = nodes.new("ShaderNodeSeparateXYZ")
+    links.new(grid.outputs["UV Map"], uv.inputs["Vector"])
+    # column = round(u * (grid_x - 1)); profile index = column mod P, so on a
+    # cyclic profile the wrap column (P) folds back to point 0.
+    cols_max = _math(nodes, links, "SUBTRACT", a=grid_x, b=1.0)
+    col = _math(nodes, links, "MULTIPLY", a=uv.outputs["X"], b=cols_max)
+    col = _math(nodes, links, "ROUND", a=col)
+    index = _math(nodes, links, "FLOORED_MODULO", a=col, b=point_count)
+    step_angle = _math(nodes, links, "MULTIPLY", a=gi.outputs["Angle"], b=uv.outputs["Y"])
+
+    # Sample the profile point at that index and rotate it to this step's angle.
+    position = nodes.new("GeometryNodeInputPosition")
+    sample = nodes.new("GeometryNodeSampleIndex")
+    sample.data_type = "FLOAT_VECTOR"
+    sample.domain = "POINT"
+    links.new(profile_curve, sample.inputs["Geometry"])
+    links.new(position.outputs["Position"], sample.inputs["Value"])
+    links.new(index, sample.inputs["Index"])
+
+    swept = _rotate_about_axis(nodes, links, gi, sample.outputs["Value"], step_angle)
+    set_pos = nodes.new("GeometryNodeSetPosition")
+    links.new(grid.outputs["Mesh"], set_pos.inputs["Geometry"])
+    links.new(swept, set_pos.inputs["Position"])
+    lateral = set_pos.outputs["Geometry"]
+
+    # 4. End caps: only for a *filled* profile swept a *partial* turn.
+    face_count = nodes.new("GeometryNodeAttributeDomainSize")
+    face_count.component = "MESH"
+    links.new(gi.outputs["Geometry"], face_count.inputs["Geometry"])
+    filled = nodes.new("FunctionNodeCompare")
+    filled.data_type = "INT"
+    filled.operation = "GREATER_THAN"
+    fa, fb = (s for s in filled.inputs if s.enabled and s.type == "INT")
+    fb.default_value = 0
+    links.new(face_count.outputs["Face Count"], fa)
+
+    # Partial turn: |Angle| < tau (with a small margin so a full turn reads as
+    # closed and gets no caps).
+    partial = nodes.new("FunctionNodeCompare")
+    partial.data_type = "FLOAT"
+    partial.operation = "LESS_THAN"
+    pa, pb = (s for s in partial.inputs if s.enabled and s.type == "VALUE")
+    pb.default_value = math.tau - 1e-4
+    links.new(abs_angle, pa)
+
+    caps_needed = nodes.new("FunctionNodeBooleanMath")
+    caps_needed.operation = "AND"
+    links.new(filled.outputs["Result"], caps_needed.inputs[0])
+    links.new(partial.outputs["Result"], caps_needed.inputs[1])
+
+    # Start cap: the filled face at angle 0 (flip so its normal faces outward,
+    # away from the sweep). End cap: the same face rotated to the sweep's end.
+    start_flip = nodes.new("GeometryNodeFlipFaces")
+    links.new(sep.outputs["Mesh"], start_flip.inputs["Mesh"])
+
+    end_position = nodes.new("GeometryNodeInputPosition")
+    end_rot = _rotate_about_axis(
+        nodes, links, gi, end_position.outputs["Position"], gi.outputs["Angle"]
+    )
+    end_cap = nodes.new("GeometryNodeSetPosition")
+    links.new(sep.outputs["Mesh"], end_cap.inputs["Geometry"])
+    links.new(end_rot, end_cap.inputs["Position"])
+
+    caps = nodes.new("GeometryNodeJoinGeometry")
+    links.new(start_flip.outputs["Mesh"], caps.inputs["Geometry"])
+    links.new(end_cap.outputs["Geometry"], caps.inputs["Geometry"])
+
+    caps_switch = nodes.new("GeometryNodeSwitch")
+    caps_switch.input_type = "GEOMETRY"
+    links.new(caps_needed.outputs["Boolean"], caps_switch.inputs["Switch"])
+    links.new(caps.outputs["Geometry"], caps_switch.inputs["True"])
+
+    # 5. Join caps onto the lateral surface and weld all coincident seams (wrap
+    #    column, full-turn start/end, and the cap boundaries onto the lateral
+    #    ends) in one pass, giving a closed solid where applicable.
+    result = nodes.new("GeometryNodeJoinGeometry")
+    links.new(lateral, result.inputs["Geometry"])
+    links.new(caps_switch.outputs["Output"], result.inputs["Geometry"])
+
+    weld = nodes.new("GeometryNodeMergeByDistance")
+    links.new(result.outputs["Geometry"], weld.inputs["Geometry"])
+    weld.inputs["Distance"].default_value = _WELD_DISTANCE
+    links.new(weld.outputs["Geometry"], go.inputs["Geometry"])
+
+    ng["cad_revolve_version"] = REVOLVE_VERSION
+    return ng

--- a/utilities/revolve_nodes.py
+++ b/utilities/revolve_nodes.py
@@ -20,17 +20,27 @@ loop, so the swept lateral surface is identical whether ``Fill`` was on or off:
 joined into one boundary curve. Only that loop is swept, so interior fill
 triangulation can never leak into the surface.
 
-The lateral surface is a Grid of ``(P+1) x (steps+1)`` vertices -- ``P`` profile
-points (plus one wrap column to close the loop) by one column per angular step --
+The loop winding is *canonicalized* first (reversed when its area normal points
+against an axis-derived reference), because ``Mesh to Curve`` hands back the
+boundary with a shape-dependent direction. Without this the swept surface and the
+caps end up inconsistently oriented for some shapes.
+
+The lateral surface is a Grid of ``(P+wrap) x (steps+1)`` vertices -- ``P`` profile
+points (plus one wrap column for a closed loop) by one column per angular step --
 whose every vertex is the matching profile point rotated about the axis by its
 step's angle. ``Merge by Distance`` welds the wrap column and, at a full turn,
 the start/end seam.
 
 End caps are added only when the profile was *filled* and the sweep is a partial
-turn (< 360 deg): the filled face at the start, and a copy rotated to the end.
-A full turn needs no caps (the surface closes on itself), and an unfilled profile
-has no face to cap with -- it stays an open shell. This matches the spec: a
-non-filled sketch revolves to a valid surface, just without end caps.
+turn (< 360 deg): the loop filled at the start (flipped) and a copy filled at the
+end, wound oppositely so both stay coherent with the lateral. A full turn needs no
+caps (the surface closes on itself), and an unfilled profile has no face to cap
+with -- it stays an open shell. This matches the spec: a non-filled sketch
+revolves to a valid surface, just without end caps.
+
+Finally the signed volume (divergence theorem) decides orientation: a filled
+solid is flipped when it comes out inside-out, so normals always point outward
+regardless of the profile's shape or the *sign* of the sweep angle.
 """
 
 import math
@@ -42,7 +52,7 @@ REVOLVE_NODE_GROUP = "CAD Sketcher Revolve"
 # Bump whenever the built tree changes so groups baked into existing files -- or a
 # stale same-named binary asset -- are rebuilt in place on next use, keeping
 # modifiers bound to the same name.
-REVOLVE_VERSION = 2
+REVOLVE_VERSION = 4
 
 # Weld tolerance for the sweep seams and the cap-to-lateral join. The welded
 # points are produced by the *same* profile sample and rotation, so they are
@@ -223,13 +233,84 @@ def build_revolve_node_group(name: str = REVOLVE_NODE_GROUP):
     profile = nodes.new("GeometryNodeJoinGeometry")
     links.new(mesh_to_curve.outputs["Curve"], profile.inputs["Geometry"])
     links.new(sep.outputs["Curve"], profile.inputs["Geometry"])
-    profile_curve = profile.outputs["Geometry"]
+    raw_profile = profile.outputs["Geometry"]
 
     # P = boundary-loop point count.
     domain = nodes.new("GeometryNodeAttributeDomainSize")
     domain.component = "CURVE"
-    links.new(profile_curve, domain.inputs["Geometry"])
+    links.new(raw_profile, domain.inputs["Geometry"])
     point_count = domain.outputs["Point Count"]
+
+    # Canonicalize the loop winding. Mesh to Curve extracts the boundary loop with
+    # a shape-dependent direction, which would leave the swept surface and the
+    # caps inconsistently oriented. Reverse the loop when its area normal points
+    # against a reference derived from the axis, so every profile winds the same
+    # way and a fixed cap orientation is coherent for all shapes.
+    #
+    # Area normal (Newell-style, translation invariant): N = sum_i (p_i - C) x
+    # (p_{i+1} - C), with C the loop centroid.
+    centroid = nodes.new("GeometryNodeAttributeStatistic")
+    centroid.data_type = "FLOAT_VECTOR"
+    centroid.domain = "POINT"
+    loop_pos = nodes.new("GeometryNodeInputPosition")
+    links.new(raw_profile, centroid.inputs["Geometry"])
+    links.new(loop_pos.outputs["Position"], centroid.inputs["Attribute"])
+    centroid_co = centroid.outputs["Mean"]
+
+    loop_index = nodes.new("GeometryNodeInputIndex")
+    next_index = _math(nodes, links, "ADD", a=loop_index.outputs["Index"], b=1.0)
+    next_index = _math(nodes, links, "FLOORED_MODULO", a=next_index, b=point_count)
+    next_pos = nodes.new("GeometryNodeSampleIndex")
+    next_pos.data_type = "FLOAT_VECTOR"
+    next_pos.domain = "POINT"
+    links.new(raw_profile, next_pos.inputs["Geometry"])
+    links.new(loop_pos.outputs["Position"], next_pos.inputs["Value"])
+    links.new(next_index, next_pos.inputs["Index"])
+
+    def _vsub(a, b):
+        n = nodes.new("ShaderNodeVectorMath")
+        n.operation = "SUBTRACT"
+        links.new(a, n.inputs[0])
+        links.new(b, n.inputs[1])
+        return n.outputs["Vector"]
+
+    def _vcross(a, b):
+        n = nodes.new("ShaderNodeVectorMath")
+        n.operation = "CROSS_PRODUCT"
+        links.new(a, n.inputs[0])
+        links.new(b, n.inputs[1])
+        return n.outputs["Vector"]
+
+    edge_term = _vcross(
+        _vsub(loop_pos.outputs["Position"], centroid_co),
+        _vsub(next_pos.outputs["Value"], centroid_co),
+    )
+    area_normal = nodes.new("GeometryNodeAttributeStatistic")
+    area_normal.data_type = "FLOAT_VECTOR"
+    area_normal.domain = "POINT"
+    links.new(raw_profile, area_normal.inputs["Geometry"])
+    links.new(edge_term, area_normal.inputs["Attribute"])
+
+    # Reference: axis x (centroid - axis origin) -- the profile-plane normal for a
+    # profile lying in a plane through the axis (the usual revolve setup).
+    reference = _vcross(
+        gi.outputs["Axis Direction"], _vsub(centroid_co, gi.outputs["Axis Origin"])
+    )
+    orient_dot = nodes.new("ShaderNodeVectorMath")
+    orient_dot.operation = "DOT_PRODUCT"
+    links.new(area_normal.outputs["Sum"], orient_dot.inputs[0])
+    links.new(reference, orient_dot.inputs[1])
+    against = nodes.new("FunctionNodeCompare")
+    against.data_type = "FLOAT"
+    against.operation = "LESS_THAN"
+    ga, gb = (s for s in against.inputs if s.enabled and s.type == "VALUE")
+    gb.default_value = 0.0
+    links.new(orient_dot.outputs["Value"], ga)
+
+    reverse = nodes.new("GeometryNodeReverseCurve")
+    links.new(raw_profile, reverse.inputs["Curve"])
+    links.new(against.outputs["Result"], reverse.inputs["Selection"])
+    profile_curve = reverse.outputs["Curve"]
 
     # Whether the profile is a closed loop (cyclic). A closed profile needs one
     # extra "wrap" column so the last point connects back to the first; an open
@@ -286,7 +367,14 @@ def build_revolve_node_group(name: str = REVOLVE_NODE_GROUP):
     set_pos = nodes.new("GeometryNodeSetPosition")
     links.new(grid.outputs["Mesh"], set_pos.inputs["Geometry"])
     links.new(swept, set_pos.inputs["Position"])
-    lateral = set_pos.outputs["Geometry"]
+    lateral_raw = set_pos.outputs["Geometry"]
+
+    # Weld the swept grid's seams (the wrap column, and the start/end seam at a
+    # full turn) so the lateral tube is clean before capping.
+    lateral_weld = nodes.new("GeometryNodeMergeByDistance")
+    links.new(lateral_raw, lateral_weld.inputs["Geometry"])
+    lateral_weld.inputs["Distance"].default_value = _WELD_DISTANCE
+    lateral = lateral_weld.outputs["Geometry"]
 
     # 4. End caps: only for a *filled* profile swept a *partial* turn.
     face_count = nodes.new("GeometryNodeAttributeDomainSize")
@@ -313,31 +401,37 @@ def build_revolve_node_group(name: str = REVOLVE_NODE_GROUP):
     links.new(filled.outputs["Result"], caps_needed.inputs[0])
     links.new(partial.outputs["Result"], caps_needed.inputs[1])
 
-    # Start cap: the filled face at angle 0 (flip so its normal faces outward,
-    # away from the sweep). End cap: the same face rotated to the sweep's end.
+    # Caps fill the (canonicalized) boundary loop the lateral is swept from, so
+    # they weld exactly onto the tube's open ends. Because the loop winding is now
+    # deterministic, the end cap keeps the fill winding and the start cap (at angle
+    # 0) is flipped, so the two caps wind oppositely and stay coherent with the
+    # lateral for every profile shape.
+    cap_fill = nodes.new("GeometryNodeFillCurve")
+    links.new(profile_curve, cap_fill.inputs["Curve"])
+    cap_mesh = cap_fill.outputs["Mesh"]
+
     start_flip = nodes.new("GeometryNodeFlipFaces")
-    links.new(sep.outputs["Mesh"], start_flip.inputs["Mesh"])
+    links.new(cap_mesh, start_flip.inputs["Mesh"])
 
     end_position = nodes.new("GeometryNodeInputPosition")
     end_rot = _rotate_about_axis(
         nodes, links, gi, end_position.outputs["Position"], gi.outputs["Angle"]
     )
-    end_cap = nodes.new("GeometryNodeSetPosition")
-    links.new(sep.outputs["Mesh"], end_cap.inputs["Geometry"])
-    links.new(end_rot, end_cap.inputs["Position"])
+    end_moved = nodes.new("GeometryNodeSetPosition")
+    links.new(cap_mesh, end_moved.inputs["Geometry"])
+    links.new(end_rot, end_moved.inputs["Position"])
 
     caps = nodes.new("GeometryNodeJoinGeometry")
     links.new(start_flip.outputs["Mesh"], caps.inputs["Geometry"])
-    links.new(end_cap.outputs["Geometry"], caps.inputs["Geometry"])
+    links.new(end_moved.outputs["Geometry"], caps.inputs["Geometry"])
 
     caps_switch = nodes.new("GeometryNodeSwitch")
     caps_switch.input_type = "GEOMETRY"
     links.new(caps_needed.outputs["Boolean"], caps_switch.inputs["Switch"])
     links.new(caps.outputs["Geometry"], caps_switch.inputs["True"])
 
-    # 5. Join caps onto the lateral surface and weld all coincident seams (wrap
-    #    column, full-turn start/end, and the cap boundaries onto the lateral
-    #    ends) in one pass, giving a closed solid where applicable.
+    # 5. Join the caps onto the lateral tube and weld their boundary rings to the
+    #    tube's open ends, giving a closed solid where applicable.
     result = nodes.new("GeometryNodeJoinGeometry")
     links.new(lateral, result.inputs["Geometry"])
     links.new(caps_switch.outputs["Output"], result.inputs["Geometry"])
@@ -347,14 +441,14 @@ def build_revolve_node_group(name: str = REVOLVE_NODE_GROUP):
     weld.inputs["Distance"].default_value = _WELD_DISTANCE
     welded = weld.outputs["Geometry"]
 
-    # 6. Consistent outward normals. The boundary loop that Mesh to Curve extracts
-    #    from a fill triangulation has no deterministic winding, so the swept solid
-    #    can come out inside-out for some profile shapes. For a *filled* profile
-    #    (which yields a closed solid) compute the signed volume via the divergence
-    #    theorem -- sum over faces of dot(centroid, normal) * area -- and flip the
-    #    whole mesh when it is negative, so normals always point outward regardless
-    #    of the profile's shape. Unfilled profiles are an open shell (no meaningful
-    #    volume) and are left as-is.
+    # 6. Consistent outward normals. With the loop winding canonicalized the solid
+    #    is coherently oriented, but whether that coherent orientation faces out or
+    #    in still depends on the profile and the *sign of the sweep angle*. Compute
+    #    the signed volume via the divergence theorem -- sum over faces of
+    #    dot(centroid, normal) * area -- and flip the whole mesh when negative, so
+    #    normals always point outward regardless of shape or angle direction.
+    #    Unfilled profiles are an open shell (no meaningful volume) and are left
+    #    as-is.
     position = nodes.new("GeometryNodeInputPosition")
     normal = nodes.new("GeometryNodeInputNormal")
     face_area = nodes.new("GeometryNodeInputMeshFaceArea")

--- a/utilities/revolve_nodes.py
+++ b/utilities/revolve_nodes.py
@@ -134,7 +134,9 @@ def build_revolve_node_group(name: str = REVOLVE_NODE_GROUP):
     abs_angle = _math(nodes, links, "ABSOLUTE", a=gi.outputs["Angle"])
     # Guard the divide: clamp resolution away from zero (the operator enforces a
     # positive minimum, but a hand-set 0 would otherwise blow up).
-    safe_res = _math(nodes, links, "MAXIMUM", a=gi.outputs["Angular Resolution"], b=1e-4)
+    safe_res = _math(
+        nodes, links, "MAXIMUM", a=gi.outputs["Angular Resolution"], b=1e-4
+    )
     steps_raw = _math(nodes, links, "DIVIDE", a=abs_angle, b=safe_res)
     steps_ceil = _math(nodes, links, "CEIL", a=steps_raw)
     steps = _math(nodes, links, "MAXIMUM", a=steps_ceil, b=1.0)
@@ -208,7 +210,9 @@ def build_revolve_node_group(name: str = REVOLVE_NODE_GROUP):
     col = _math(nodes, links, "MULTIPLY", a=uv.outputs["X"], b=cols_max)
     col = _math(nodes, links, "ROUND", a=col)
     index = _math(nodes, links, "FLOORED_MODULO", a=col, b=point_count)
-    step_angle = _math(nodes, links, "MULTIPLY", a=gi.outputs["Angle"], b=uv.outputs["Y"])
+    step_angle = _math(
+        nodes, links, "MULTIPLY", a=gi.outputs["Angle"], b=uv.outputs["Y"]
+    )
 
     # Sample the profile point at that index and rotate it to this step's angle.
     position = nodes.new("GeometryNodeInputPosition")


### PR DESCRIPTION
Replaces the binary revolve asset with a programmatic node group, matching the boolean/convert groups (versioned in code, rebuilt in place on version bump).

## Why
Revolving a **filled** sketch swept the profile's interior fill triangulation into the surface, producing redundant, self-intersecting geometry that broke the result (#634). The same sketch with fill off revolved cleanly.

## What changed

**Profile normalization.** The group reduces any profile to a single boundary loop before sweeping:
- a mesh (filled or wire) → its boundary edges become a curve (`Mesh to Curve` on edges with < 2 adjacent faces, dropping interior fill edges),
- a curve passes straight through (`Separate Components` + join).

So the swept lateral surface is **identical whether fill was on or off**. Open profiles (a line → cylinder) are detected as non-cyclic and don't get a wrap column.

**Coherent, outward normals (shape- and angle-sign-independent).** `Mesh to Curve` hands back the boundary loop with a shape-dependent winding direction, which left the swept surface and the caps inconsistently oriented (the red/grey face-orientation artifact), and made a negative sweep angle turn the whole solid inside-out. The group now:
1. **canonicalizes the loop winding** — reverses it when its area normal (Newell-style, translation-invariant) points against an axis-derived reference, so every profile winds the same way;
2. fills the caps from that same canonical loop (start flipped, end kept) so the two caps stay coherent with the lateral for every shape;
3. runs a **signed-volume** pass (divergence theorem) that flips the whole solid when it comes out inside-out — so normals point outward regardless of profile shape or the *sign* of the angle.

End caps are added only when the profile is *filled* and the turn is partial (< 360°); a full turn needs none, and an unfilled profile stays an open shell.

**Migration / upgrade path.**
- `SCREW` modifier → Revolve translation (`_translate_screw`) uses the built group and resolves sockets by name.
- Rebuilding the group reassigns socket identifiers, so any modifier already bound to it (old asset or a previous version) has its settings snapshotted by socket **name** and re-applied after the rebuild — existing revolves keep their axis/angle/resolution.
- A revolve group baked into a file is upgraded on **file load** (`on_load_post`), so existing revolves pick up fixes on open instead of only when re-invoked.

## Tests
`testing/test_revolve_nodes.py` (new): fill-on vs fill-off give an identical lateral surface (node-group level and through the real convert modifier); filled partial turn is a capped watertight solid; unfilled partial turn is a clean open shell; a triangulated fill doesn't leak interior edges (#634 guard); **filled result is coherently oriented and solid-outward for every shape — square/concave/both windings — at both positive and negative angles**; open profile → cylinder; the group builds/versions/rebuilds and preserves existing modifier settings. Existing revolve tests and the screw-migration test were moved onto the code path. Full suite: 281 pass; ruff clean.

## Follow-up
The `CAD Sketcher Revolve` node group still ships (unused) in `resources/assets.blend`; it can be dropped from the asset file in a separate cleanup.