### PR TITLE
Carry constraints through copy and paste

### DIFF
--- a/operators/copy_paste.py
+++ b/operators/copy_paste.py
@@ -1,17 +1,18 @@
-from copy import deepcopy
-from ..model.sketch_ref import get_active_sketch
-
 import bpy
 from bpy.types import Context, Operator
 from bpy.utils import register_classes_factory
 
 from .. import global_data
-from ..drawing import selection
 from ..declarations import Operators
-from ..model.curve_ref import curve_ref, PointRef, LineRef, ArcRef, CircleRef
+from ..drawing import selection
 from ..model.constants import SketchCurveType
+from ..model.curve_ref import curve_ref
+from ..model.sketch_ref import get_active_sketch
 from ..utilities.curve_data import (
-    get_curve_data, get_uuid, invalidate_curve_id_cache, UUID_FIELDS,
+    UUID_FIELDS,
+    get_curve_data,
+    get_uuid,
+    invalidate_curve_id_cache,
 )
 
 
@@ -25,14 +26,13 @@ def _snapshot_curve(sketch, curve_id):
     # which include the INT identity sub-attributes handled via rel_ids below).
     attrs = {}
     for attr in cd.attributes:
-        if attr.domain == 'CURVE' and not attr.name.startswith('.'):
+        if attr.domain == "CURVE" and not attr.name.startswith("."):
             v = attr.data[idx].value
             attrs[attr.name] = v.decode() if isinstance(v, bytes) else v
 
     # Logical relationship ids (hex), remapped to new ids on paste.
     rel_ids = {
-        field: get_uuid(cd, field, idx)
-        for field in UUID_FIELDS if field != "curve_id"
+        field: get_uuid(cd, field, idx) for field in UUID_FIELDS if field != "curve_id"
     }
 
     n_points = curve_slice.points_length
@@ -40,15 +40,15 @@ def _snapshot_curve(sketch, curve_id):
     positions = []
     point_attrs = {}
     for attr in cd.attributes:
-        if attr.domain == 'POINT':
+        if attr.domain == "POINT":
             point_attrs[attr.name] = []
 
     for i in range(n_points):
         pt_idx = first + i
         positions.append(tuple(cd.points[pt_idx].position))
         for attr in cd.attributes:
-            if attr.domain == 'POINT':
-                if attr.data_type == 'FLOAT_VECTOR':
+            if attr.domain == "POINT":
+                if attr.data_type == "FLOAT_VECTOR":
                     point_attrs[attr.name].append(tuple(attr.data[pt_idx].vector))
                 else:
                     point_attrs[attr.name].append(attr.data[pt_idx].value)
@@ -61,6 +61,93 @@ def _snapshot_curve(sketch, curve_id):
         "point_attrs": point_attrs,
         "n_points": n_points,
     }
+
+
+_CURVE_ID_FIELDS = ("curve_id_1", "curve_id_2", "curve_id_3")
+
+# Never snapshot these: identity (minted fresh per paste), the auto-assigned
+# name, and transient solver state. curve_id_N is the source of truth for a
+# constraint's geometry; the ``*_i`` fields are derived entity/sketch indices
+# whose stale values would drag curve_id_N back to the source on restore.
+_SKIP_CONSTRAINT_PROPS = {"rna_type", "constraint_uid", "name", "failed"}
+
+
+def _constraint_refs(c):
+    """The curve_ids a constraint references (its geometry dependencies)."""
+    return [cid for f in _CURVE_ID_FIELDS if (cid := getattr(c, f, ""))]
+
+
+def snapshot_constraints(sketch, copied_ids):
+    """Snapshot constraints whose every referenced curve was copied.
+
+    Each snapshot keeps the constraint type, its semantic properties and any
+    custom props. ``curve_id_*`` are remapped to the pasted copies on paste, and
+    ``constraint_uid`` is dropped so each paste gets a fresh identity (and, for
+    dimensional constraints, its own value slot rather than sharing the source's).
+    """
+    copied_ids = set(copied_ids)
+    snaps = []
+    for c in sketch.constraints.all:
+        refs = _constraint_refs(c)
+        if not refs or not all(r in copied_ids for r in refs):
+            continue
+        rna_names = {p.identifier for p in c.rna_type.properties}
+        props = {}
+        for prop in c.rna_type.properties:
+            pid = prop.identifier
+            if pid in _SKIP_CONSTRAINT_PROPS or pid.endswith("_i"):
+                continue
+            if prop.is_readonly:
+                continue
+            try:
+                props[pid] = getattr(c, pid)
+            except Exception:
+                continue
+        # Only genuine custom ID-props: c.keys() also lists the backing store of
+        # defined StringProperties (curve_id_*, constraint_uid), and re-applying
+        # those would clobber the remapped/fresh values set above.
+        custom = {k: c[k] for k in c.keys() if k not in rna_names}
+        snaps.append({"type": c.type.lower(), "props": props, "custom": custom})
+    return snaps
+
+
+def paste_constraints(sketch, snaps, id_map):
+    """Recreate snapshotted constraints on the pasted geometry.
+
+    ``id_map`` maps each copied curve_id to its pasted copy. Constraints get a
+    fresh uid (and dimensional value endpoint); the source value is re-applied
+    afterwards so the copy is independent of the original.
+    """
+    sc = sketch.constraints
+    for snap in snaps:
+        coll = getattr(sc, snap["type"], None)
+        if coll is None:
+            continue
+        c = coll.add()
+        deferred_value = None
+        for key, val in snap["props"].items():
+            if key in _CURVE_ID_FIELDS:
+                setattr(c, key, id_map.get(val, "") if val else "")
+            elif key == "value":
+                # A dimensional value lives at scene[slvs:c:uid]; set it only
+                # after the fresh uid + endpoint exist below.
+                deferred_value = val
+            else:
+                try:
+                    setattr(c, key, val)
+                except (AttributeError, TypeError):
+                    pass
+        for key, val in snap["custom"].items():
+            c[key] = val
+
+        # Fresh identity so the copy doesn't share the source's uid (and value).
+        c.constraint_uid = ""
+        sc._init_constraint(c)
+        if deferred_value is not None:
+            try:
+                c.value = deferred_value
+            except (AttributeError, TypeError):
+                pass
 
 
 class View3D_OT_slvs_copy(Operator):
@@ -98,7 +185,12 @@ class View3D_OT_slvs_copy(Operator):
             if snap:
                 buffer.append(snap)
 
-        global_data.COPY_BUFFER = buffer
+        # Snapshot constraints internal to the copied set (all their referenced
+        # curves are copied), so paste carries the relationships too.
+        copied_ids = {snap["curve_id"] for snap in buffer}
+        constraints = snapshot_constraints(sketch, copied_ids)
+
+        global_data.COPY_BUFFER = {"curves": buffer, "constraints": constraints}
         return {"FINISHED"}
 
 
@@ -119,9 +211,16 @@ class View3D_OT_slvs_paste(Operator):
         if not buffer:
             return {"CANCELLED"}
 
+        curves = buffer.get("curves", [])
+        constraint_snaps = buffer.get("constraints", [])
+        if not curves:
+            return {"CANCELLED"}
+
         from ..utilities.curve_data import (
-            _allocate_curve_id, ensure_sketch_curve_object,
-            ensure_standard_attributes, set_attribute,
+            _allocate_curve_id,
+            ensure_sketch_curve_object,
+            ensure_standard_attributes,
+            set_attribute,
         )
 
         curve_data = ensure_sketch_curve_object(sketch)
@@ -130,18 +229,18 @@ class View3D_OT_slvs_paste(Operator):
 
         # Map old curve_ids to new ones
         id_map = {}
-        for snap in buffer:
+        for snap in curves:
             id_map[snap["curve_id"]] = _allocate_curve_id(sketch)
 
         # Create all pasted curves in one shot — calling add_curves/set_types/
         # ensure_standard_attributes per curve is O(curves²) as the sketch grows.
         selection.selected.clear()
         base_idx = len(curve_data.curves)
-        curve_data.add_curves([snap["n_points"] for snap in buffer])
+        curve_data.add_curves([snap["n_points"] for snap in curves])
         curve_data.set_types(type="BEZIER")
         ensure_standard_attributes(curve_data)
 
-        for offset, snap in enumerate(buffer):
+        for offset, snap in enumerate(curves):
             new_cid = id_map[snap["curve_id"]]
 
             curve_idx = base_idx + offset
@@ -175,7 +274,7 @@ class View3D_OT_slvs_paste(Operator):
                     continue
                 for i, val in enumerate(values):
                     pt_idx = curve_slice.points[i].index
-                    if attr.data_type == 'FLOAT_VECTOR':
+                    if attr.data_type == "FLOAT_VECTOR":
                         attr.data[pt_idx].vector = val
                     else:
                         attr.data[pt_idx].value = val
@@ -186,6 +285,10 @@ class View3D_OT_slvs_paste(Operator):
                 selection.selected.append(new_cid)
 
         invalidate_curve_id_cache(sketch)
+
+        # Recreate the copied constraints on the pasted geometry (remapped ids).
+        paste_constraints(sketch, constraint_snaps, id_map)
+
         curve_data.update_tag()
         context.area.tag_redraw()
 

--- a/testing/test_copy_paste.py
+++ b/testing/test_copy_paste.py
@@ -1,0 +1,77 @@
+"""Copy/paste carries the constraints among the copied geometry.
+
+These drive the copy-buffer helpers directly (``snapshot_constraints`` /
+``paste_constraints``) rather than the operators, since paste ends by invoking a
+modal move that has no meaning in the background test harness.
+"""
+
+from ..operators.copy_paste import paste_constraints, snapshot_constraints
+from .utils import Sketch2dTestCase
+
+
+class TestCopyPasteConstraints(Sketch2dTestCase):
+    def test_geometric_constraint_is_carried_to_the_copy(self):
+        p1 = self.add_point((0.0, 0.0))
+        p2 = self.add_point((3.0, 0.0))
+        self.sketch.constraints.add_coincident(
+            curve_id_1=p1.curve_id, curve_id_2=p2.curve_id
+        )
+
+        snaps = snapshot_constraints(self.sketch, {p1.curve_id, p2.curve_id})
+        self.assertEqual([s["type"] for s in snaps], ["coincident"])
+
+        # Simulate the paste: fresh points + the old->new id map.
+        q1 = self.add_point((0.0, 5.0))
+        q2 = self.add_point((3.0, 5.0))
+        id_map = {p1.curve_id: q1.curve_id, p2.curve_id: q2.curve_id}
+
+        before = len(list(self.sketch.constraints.coincident))
+        paste_constraints(self.sketch, snaps, id_map)
+        coincident = list(self.sketch.constraints.coincident)
+
+        self.assertEqual(len(coincident) - before, 1, "the coincidence must be pasted")
+        new = coincident[-1]
+        self.assertEqual(
+            {new.curve_id_1, new.curve_id_2},
+            {q1.curve_id, q2.curve_id},
+            "the pasted constraint must reference the pasted points, not the source",
+        )
+
+    def test_constraint_skipped_when_a_referenced_curve_is_not_copied(self):
+        # Only constraints fully internal to the copied set are carried; a
+        # constraint reaching outside would dangle on paste.
+        p1 = self.add_point((0.0, 0.0))
+        p2 = self.add_point((3.0, 0.0))
+        self.sketch.constraints.add_coincident(
+            curve_id_1=p1.curve_id, curve_id_2=p2.curve_id
+        )
+
+        self.assertEqual(snapshot_constraints(self.sketch, {p1.curve_id}), [])
+        self.assertEqual(
+            len(snapshot_constraints(self.sketch, {p1.curve_id, p2.curve_id})), 1
+        )
+
+    def test_dimensional_value_survives_with_a_fresh_uid(self):
+        p1 = self.add_point((0.0, 0.0))
+        p2 = self.add_point((3.0, 0.0))
+        dist = self.sketch.constraints.add_distance(
+            curve_id_1=p1.curve_id, curve_id_2=p2.curve_id, value=3.0
+        )
+
+        snaps = snapshot_constraints(self.sketch, {p1.curve_id, p2.curve_id})
+
+        q1 = self.add_point((0.0, 5.0))
+        q2 = self.add_point((3.0, 5.0))
+        id_map = {p1.curve_id: q1.curve_id, p2.curve_id: q2.curve_id}
+        paste_constraints(self.sketch, snaps, id_map)
+
+        new = [
+            c
+            for c in self.sketch.constraints.distance
+            if {c.curve_id_1, c.curve_id_2} == {q1.curve_id, q2.curve_id}
+        ]
+        self.assertEqual(len(new), 1, "the distance constraint must be pasted")
+        # Independent identity so the copy's value is its own scene slot.
+        self.assertTrue(new[0].constraint_uid)
+        self.assertNotEqual(new[0].constraint_uid, dist.constraint_uid)
+        self.assertAlmostEqual(new[0].value, 3.0, places=4)


### PR DESCRIPTION
Copy previously stored only geometry (curves, points and their attributes); paste rebuilt that geometry but never the constraints between the copied entities, so pasted geometry came in unconstrained. This carries the constraints along with the copy.

## How it works

- `snapshot_constraints(sketch, copied_ids)` captures every constraint whose referenced curves (`curve_id_1/2/3`) are all in the copied set, so nothing dangles. It records the constraint type, its semantic properties and any genuine custom props, and skips identity/derived/transient fields: `constraint_uid`, `name`, `failed`, and the `*_i` entity/sketch indices.
- `paste_constraints(sketch, snaps, id_map)` recreates them on the pasted geometry, remapping `curve_id_*` through the paste id map, minting a fresh uid per constraint, and re-applying dimensional values afterward so a pasted dimension gets its own value slot instead of sharing the source's.
- The copy buffer is now `{"curves": [...], "constraints": [...]}`; paste reads both and recreates the constraints just before the move.

## Notes

Two subtleties the implementation handles:

- The `*_i` fields are cached entity/sketch indices derived from `curve_id_N` (the source of truth the solver reads). Restoring stale ones would drag `curve_id_N` back to the source geometry, so they are excluded.
- `c.keys()` also lists the backing store of defined StringProperties (`curve_id_1`, `constraint_uid`, ...), so the custom-prop capture keeps only keys that are not RNA-defined, otherwise it would clobber the remapped/fresh values.

## Tests

New `testing/test_copy_paste.py`: a geometric constraint carries to the copy referencing the pasted points; a constraint reaching outside the copied set is skipped; a dimensional constraint keeps its value with an independent uid. Full suite green.
