### PR TITLE
Custom sketch attributes surviving fill conversion (#200)

### DIFF
--- a/model/curve_ref.py
+++ b/model/curve_ref.py
@@ -256,11 +256,13 @@ def _allocate(sketch):
 
 
 def _ensure_attrs(curve_data, curve_idx=None):
-    """Ensure all standard attributes exist. Optionally init STRING attrs for a curve."""
+    """Ensure standard and user-defined attributes exist for a new curve."""
     from ..utilities.curve_data import ensure_standard_attributes, init_string_attrs
+    from ..utilities.custom_attributes import initialize_curve_defaults
     ensure_standard_attributes(curve_data)
     if curve_idx is not None:
         init_string_attrs(curve_data, curve_idx)
+        initialize_curve_defaults(curve_data, curve_idx)
 
 
 def _invalidate(sketch):

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -40,6 +40,7 @@ modules = [
     "move",
     "duplicate",
     "set_curve_flag",
+    "custom_attributes",
     "test"
 ]
 

--- a/operators/custom_attributes.py
+++ b/operators/custom_attributes.py
@@ -1,0 +1,200 @@
+import bpy
+
+from ..drawing import selection
+from ..model import sketch_ref
+from ..utilities import custom_attributes
+
+_TYPE_ITEMS = (
+    ("BOOLEAN", "Boolean", "True / False"),
+    ("INT", "Integer", "Whole number"),
+    ("FLOAT", "Float", "Decimal number"),
+)
+_DOMAIN_ITEMS = (
+    ("CURVE", "Segment", "Store one value per native sketch entity/segment"),
+    ("POINT", "Point", "Store values on the selected entity's native points"),
+)
+
+
+def _value(op, data_type):
+    if data_type == "BOOLEAN":
+        return op.bool_value
+    if data_type == "INT":
+        return op.int_value
+    return op.float_value
+
+
+def _assign_value(op, data_type, value):
+    if data_type == "BOOLEAN":
+        op.bool_value = bool(value)
+    elif data_type == "INT":
+        op.int_value = int(value)
+    else:
+        op.float_value = float(value)
+
+
+def _draw_value(op, layout, data_type):
+    if data_type == "BOOLEAN":
+        layout.prop(op, "bool_value")
+    elif data_type == "INT":
+        layout.prop(op, "int_value")
+    else:
+        layout.prop(op, "float_value")
+
+
+def _seed_set_value(sketch, entry, curve_ids):
+    """Return a safe initial value for the Set dialog.
+
+    A common selected value is preserved. Mixed selections intentionally fall
+    back to the attribute default, rather than silently replacing data with the
+    operator property's Python zero value merely by opening/confirming the UI.
+    """
+    if not curve_ids:
+        return entry["default"]
+
+    values = []
+    for curve_id in curve_ids:
+        try:
+            current = custom_attributes.get_attribute_value(
+                sketch, entry["name"], curve_id=curve_id
+            )
+        except KeyError:
+            return entry["default"]
+        if isinstance(current, (list, tuple)):
+            values.extend(current)
+        else:
+            values.append(current)
+
+    if not values:
+        return entry["default"]
+    first = values[0]
+    if all(value == first for value in values[1:]):
+        return first
+    return entry["default"]
+
+
+class VIEW3D_OT_slvs_add_custom_attribute(bpy.types.Operator):
+    bl_idname = "view3d.slvs_add_custom_attribute"
+    bl_label = "Add Sketch Attribute"
+    bl_description = "Define an attribute on the native sketch source geometry"
+    bl_options = {"UNDO", "REGISTER"}
+
+    name: bpy.props.StringProperty(name="Name", default="attribute")
+    data_type: bpy.props.EnumProperty(name="Type", items=_TYPE_ITEMS, default="FLOAT")
+    domain: bpy.props.EnumProperty(name="Domain", items=_DOMAIN_ITEMS, default="CURVE")
+    bool_value: bpy.props.BoolProperty(name="Default", default=False)
+    int_value: bpy.props.IntProperty(name="Default", default=0)
+    float_value: bpy.props.FloatProperty(name="Default", default=0.0)
+
+    @classmethod
+    def poll(cls, context):
+        return sketch_ref.get_active_sketch(context) is not None
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
+
+    def draw(self, context):
+        layout = self.layout
+        layout.prop(self, "name")
+        layout.prop(self, "data_type")
+        layout.prop(self, "domain")
+        _draw_value(self, layout, self.data_type)
+
+    def execute(self, context):
+        sketch = sketch_ref.get_active_sketch(context)
+        try:
+            custom_attributes.define_attribute(
+                sketch,
+                self.name,
+                data_type=self.data_type,
+                domain=self.domain,
+                default=_value(self, self.data_type),
+            )
+        except ValueError as exc:
+            self.report({"ERROR"}, str(exc))
+            return {"CANCELLED"}
+        return {"FINISHED"}
+
+
+class VIEW3D_OT_slvs_set_custom_attribute(bpy.types.Operator):
+    bl_idname = "view3d.slvs_set_custom_attribute"
+    bl_label = "Set Sketch Attribute"
+    bl_description = "Set this attribute on selected native sketch geometry"
+    bl_options = {"UNDO", "REGISTER"}
+
+    name: bpy.props.StringProperty(name="Name")
+    bool_value: bpy.props.BoolProperty(name="Value", default=False)
+    int_value: bpy.props.IntProperty(name="Value", default=0)
+    float_value: bpy.props.FloatProperty(name="Value", default=0.0)
+
+    @classmethod
+    def poll(cls, context):
+        return sketch_ref.get_active_sketch(context) is not None
+
+    def invoke(self, context, event):
+        sketch = sketch_ref.get_active_sketch(context)
+        entry = custom_attributes.definition(sketch, self.name)
+        if entry is None:
+            return {"CANCELLED"}
+        curve_ids = list(dict.fromkeys(selection.selected))
+        seed = _seed_set_value(sketch, entry, curve_ids)
+        _assign_value(self, entry["type"], seed)
+        return context.window_manager.invoke_props_dialog(self)
+
+    def draw(self, context):
+        entry = custom_attributes.definition(
+            sketch_ref.get_active_sketch(context), self.name
+        )
+        if entry is None:
+            self.layout.label(text="Attribute no longer exists")
+            return
+        self.layout.label(text=f"{entry['name']} ({entry['domain'].title()})")
+        _draw_value(self, self.layout, entry["type"])
+
+    def execute(self, context):
+        sketch = sketch_ref.get_active_sketch(context)
+        entry = custom_attributes.definition(sketch, self.name)
+        if entry is None:
+            self.report({"ERROR"}, "Attribute no longer exists")
+            return {"CANCELLED"}
+
+        curve_ids = list(dict.fromkeys(selection.selected))
+        if not curve_ids:
+            self.report({"WARNING"}, "Select one or more sketch entities first")
+            return {"CANCELLED"}
+
+        value = _value(self, entry["type"])
+        for curve_id in curve_ids:
+            custom_attributes.set_attribute_value(
+                sketch, self.name, value, curve_id=curve_id
+            )
+        return {"FINISHED"}
+
+
+class VIEW3D_OT_slvs_remove_custom_attribute(bpy.types.Operator):
+    bl_idname = "view3d.slvs_remove_custom_attribute"
+    bl_label = "Remove Sketch Attribute"
+    bl_description = "Remove the attribute definition and its native source data"
+    bl_options = {"UNDO", "REGISTER"}
+
+    name: bpy.props.StringProperty(name="Name")
+
+    @classmethod
+    def poll(cls, context):
+        return sketch_ref.get_active_sketch(context) is not None
+
+    def execute(self, context):
+        if not custom_attributes.remove_attribute(
+            sketch_ref.get_active_sketch(context), self.name
+        ):
+            self.report({"WARNING"}, "Attribute no longer exists")
+            return {"CANCELLED"}
+        return {"FINISHED"}
+
+
+register, unregister = bpy.utils.register_classes_factory(
+    (
+        VIEW3D_OT_slvs_add_custom_attribute,
+        VIEW3D_OT_slvs_set_custom_attribute,
+        VIEW3D_OT_slvs_remove_custom_attribute,
+    )
+)

--- a/testing/test_attr_propagation_poc.py
+++ b/testing/test_attr_propagation_poc.py
@@ -1,0 +1,94 @@
+"""POC: custom attributes survive native conversion via domain-correct capture.
+
+A per-segment ``CURVE`` attribute keeps its exact value through the identity
+weld and the Fill Curve boundary, with no Sample Nearest / spatial transfer.
+
+The failure this avoids: four segments of a closed loop carrying source values
+10/20/30/40 collapsing to 15/25/35 at their shared corners, because Curve to
+Mesh adapts a CURVE value onto points and Merge Points then averages the two
+segment values meeting at each welded corner. Re-homing the value onto the EDGE
+domain before the weld keeps every segment's value on its own edge, so nothing
+is ever averaged.
+"""
+
+from .utils import Sketch2dTestCase
+
+ATTR = "seg_val"
+SEG_VALUES = (10, 20, 30, 40)
+
+
+class TestAttributePropagationPOC(Sketch2dTestCase):
+    def _build_square_loop(self):
+        # Four segments sharing corners: a closed loop that fills to a face.
+        pts = [
+            self.add_point((0.0, 0.0)),
+            self.add_point((1.0, 0.0)),
+            self.add_point((1.0, 1.0)),
+            self.add_point((0.0, 1.0)),
+        ]
+        return [
+            self.add_line(pts[0], pts[1]),
+            self.add_line(pts[1], pts[2]),
+            self.add_line(pts[2], pts[3]),
+            self.add_line(pts[3], pts[0]),
+        ]
+
+    def _assign_segment_values(self):
+        """Give each segment (CURVE domain) a distinct source value."""
+        from ..model.constants import SketchCurveType
+
+        cd = self.sketch.data
+        attr = cd.attributes.get(ATTR) or cd.attributes.new(ATTR, "INT", "CURVE")
+        type_attr = cd.attributes["sketch_type"]
+        line_indices = [
+            i
+            for i in range(len(cd.curves))
+            if type_attr.data[i].value == SketchCurveType.LINE
+        ]
+        for value, idx in zip(SEG_VALUES, line_indices):
+            attr.data[idx].value = value
+        cd.update_tag()
+
+    def _evaluated_attribute_values(self):
+        """Read the converted mesh's ``seg_val`` values (Curves -> GN mesh)."""
+        from ..utilities.curve_data import refresh_curve_geometry
+
+        refresh_curve_geometry(self.sketch)
+        self.context.view_layer.update()
+        dg = self.context.evaluated_depsgraph_get()
+
+        obj = self.sketch.target_object.original
+        values = []
+        for inst in dg.object_instances:
+            if inst.object.original is not obj:
+                continue
+            try:
+                mesh = inst.object.to_mesh()
+            except RuntimeError:
+                continue  # the Curves object itself has no mesh output
+            attr = mesh.attributes.get(ATTR)
+            if attr is not None:
+                values = [int(d.value) for d in attr.data]
+            inst.object.to_mesh_clear()
+        return values
+
+    def test_segment_values_survive_weld_and_fill(self):
+        from ..utilities.convert_nodes import build_convert_node_group
+        from ..utilities.curve_data import compute_merge_ids
+
+        self._build_square_loop()
+        self._assign_segment_values()
+        compute_merge_ids(self.sketch)
+
+        # Teach the one shared converter about the per-segment CURVE attribute.
+        # This only rewires the small bridge section; no per-schema variant.
+        build_convert_node_group(
+            attribute_definitions=[{"name": ATTR, "type": "INT", "domain": "CURVE"}]
+        )
+
+        distinct = {v for v in self._evaluated_attribute_values() if v != 0}
+
+        # Every source segment value survives the weld and the fill exactly.
+        self.assertEqual(distinct, set(SEG_VALUES))
+        # None of the corner-averaged artifacts the naive path would produce.
+        self.assertTrue(distinct.isdisjoint({15, 25, 35}))

--- a/testing/test_custom_attributes.py
+++ b/testing/test_custom_attributes.py
@@ -1,0 +1,330 @@
+import unittest
+
+import bpy
+
+from ..operators.modifiers import get_modifier_input, set_modifier_input
+from ..utilities.custom_attributes import (
+    define_attribute,
+    definition,
+    get_attribute_value,
+    remove_attribute,
+    set_attribute_value,
+)
+from .utils import Sketch2dTestCase
+
+
+class TestCustomAttributes(Sketch2dTestCase):
+    def _square(self):
+        p1 = self.add_point((0.0, 0.0))
+        p2 = self.add_point((2.0, 0.0))
+        p3 = self.add_point((2.0, 2.0))
+        p4 = self.add_point((0.0, 2.0))
+        lines = (
+            self.add_line(p1, p2),
+            self.add_line(p2, p3),
+            self.add_line(p3, p4),
+            self.add_line(p4, p1),
+        )
+        return (p1, p2, p3, p4), lines
+
+    def _convert_copy(self, source, *, node_group=None, fill=None):
+        duplicate = source.copy()
+        duplicate.data = source.data.copy()
+        self.context.collection.objects.link(duplicate)
+        modifier = duplicate.modifiers.get("CAD Sketcher Convert")
+        if node_group is not None:
+            self.assertIsNotNone(modifier)
+            modifier.node_group = node_group
+        if fill is not None:
+            self.assertIsNotNone(modifier)
+            fill_socket = next(
+                item
+                for item in modifier.node_group.interface.items_tree
+                if getattr(item, "item_type", "") == "SOCKET"
+                and getattr(item, "in_out", "") == "INPUT"
+                and item.name == "Fill"
+            )
+            set_modifier_input(modifier, fill_socket.identifier, bool(fill))
+        for selected in list(self.context.selected_objects):
+            selected.select_set(False)
+        duplicate.select_set(True)
+        self.context.view_layer.objects.active = duplicate
+        self.context.view_layer.update()
+        result = bpy.ops.object.convert(target="MESH")
+        self.assertEqual(result, {"FINISHED"})
+        converted = self.context.view_layer.objects.active
+        self.assertIsNotNone(converted)
+        self.assertEqual(converted.type, "MESH")
+        return converted
+
+    def _remove_converted(self, converted):
+        if converted is None or converted.name not in bpy.data.objects:
+            return
+        data = converted.data
+        bpy.data.objects.remove(converted, do_unlink=True)
+        if data is not None and data.users == 0:
+            if isinstance(data, bpy.types.Mesh):
+                bpy.data.meshes.remove(data)
+            elif isinstance(data, bpy.types.Curves):
+                bpy.data.hair_curves.remove(data)
+
+    def test_curve_attribute_values_live_on_native_source(self):
+        _, lines = self._square()
+        define_attribute(self.sketch, "material_slot", "INT", "CURVE", 2)
+        self.assertEqual(
+            get_attribute_value(self.sketch, "material_slot", lines[0].curve_id), 2
+        )
+        set_attribute_value(self.sketch, "material_slot", 9, lines[0].curve_id)
+        self.assertEqual(
+            get_attribute_value(self.sketch, "material_slot", lines[0].curve_id), 9
+        )
+        self.assertEqual(
+            get_attribute_value(self.sketch, "material_slot", lines[1].curve_id), 2
+        )
+
+    def test_default_applies_to_geometry_created_after_definition(self):
+        first = self.add_point((0.0, 0.0))
+        define_attribute(self.sketch, "later_default", "INT", "CURVE", 17)
+        self.assertEqual(
+            get_attribute_value(self.sketch, "later_default", first.curve_id), 17
+        )
+        later = self.add_point((1.0, 0.0))
+        self.assertEqual(
+            get_attribute_value(self.sketch, "later_default", later.curve_id), 17
+        )
+
+    def test_point_domain_uses_native_curve_data(self):
+        points, lines = self._square()
+        define_attribute(self.sketch, "weight", "FLOAT", "POINT", 1.25)
+        set_attribute_value(self.sketch, "weight", 3.5, lines[0].curve_id)
+        values = get_attribute_value(self.sketch, "weight", lines[0].curve_id)
+        self.assertTrue(values)
+        self.assertTrue(all(abs(v - 3.5) < 1e-6 for v in values))
+
+        set_attribute_value(self.sketch, "weight", 8.0, points[0].curve_id)
+        self.assertEqual(
+            get_attribute_value(self.sketch, "weight", points[0].curve_id), [8.0]
+        )
+        attr = self.sketch.data.attributes.get("weight")
+        self.assertIsNotNone(attr)
+        self.assertEqual(attr.domain, "POINT")
+
+    def test_object_domain_is_deferred(self):
+        self._square()
+        with self.assertRaisesRegex(
+            ValueError, "OBJECT-domain attributes are deferred"
+        ):
+            define_attribute(self.sketch, "part_number", "INT", "OBJECT", 42)
+
+    def test_set_dialog_seed_preserves_current_value(self):
+        from ..operators.custom_attributes import _seed_set_value
+
+        _, lines = self._square()
+        define_attribute(self.sketch, "feature_code", "INT", "CURVE", 5)
+        set_attribute_value(self.sketch, "feature_code", 77, lines[0].curve_id)
+        entry = definition(self.sketch, "feature_code")
+        self.assertEqual(_seed_set_value(self.sketch, entry, [lines[0].curve_id]), 77)
+        self.assertEqual(
+            _seed_set_value(self.sketch, entry, [lines[0].curve_id, lines[1].curve_id]),
+            5,
+        )
+
+    def test_refresh_preserves_custom_data_and_definitions(self):
+        from ..utilities.curve_data import refresh_curve_geometry
+
+        _, lines = self._square()
+        define_attribute(self.sketch, "feature_code", "INT", "CURVE", 5)
+        set_attribute_value(self.sketch, "feature_code", 77, lines[2].curve_id)
+        refresh_curve_geometry(self.sketch)
+        self.assertIsNotNone(definition(self.sketch, "feature_code"))
+        self.assertEqual(
+            get_attribute_value(self.sketch, "feature_code", lines[2].curve_id), 77
+        )
+
+    def test_point_attribute_survives_conversion_refresh(self):
+        from ..utilities.curve_data import refresh_curve_geometry
+
+        points, _ = self._square()
+        define_attribute(self.sketch, "conversion_tag", "INT", "POINT", 13)
+        set_attribute_value(self.sketch, "conversion_tag", 29, points[0].curve_id)
+        before = get_attribute_value(self.sketch, "conversion_tag")
+        refresh_curve_geometry(self.sketch)
+        self.assertIsNotNone(definition(self.sketch, "conversion_tag"))
+        self.assertEqual(get_attribute_value(self.sketch, "conversion_tag"), before)
+        attr = self.sketch.data.attributes.get("conversion_tag")
+        self.assertIsNotNone(attr)
+        self.assertEqual(attr.domain, "POINT")
+        self.assertEqual(attr.data_type, "INT")
+
+    @unittest.skipIf(bpy.app.version < (5, 2, 0), "programmatic convert requires 5.2+")
+    def test_domain_capture_conversion_preserves_named_attributes(self):
+        """Wire conversion preserves exact per-segment values without sampling."""
+        _, lines = self._square()
+        define_attribute(self.sketch, "wire_point_tag", "INT", "POINT", 13)
+        define_attribute(self.sketch, "wire_curve_tag", "INT", "CURVE", 0)
+        set_attribute_value(self.sketch, "wire_point_tag", 29)
+        for line, value in zip(lines, (10, 20, 30, 40)):
+            set_attribute_value(self.sketch, "wire_curve_tag", value, line.curve_id)
+
+        source = self.sketch.target_object
+        modifier = source.modifiers.get("CAD Sketcher Convert")
+        self.assertIsNotNone(modifier)
+        group = modifier.node_group
+        self.assertEqual(group.name, "CAD Sketcher Convert")
+
+        segment_stores = [
+            node
+            for node in group.nodes
+            if node.bl_idname == "GeometryNodeStoreNamedAttribute"
+            and node.domain == "EDGE"
+            and node.inputs["Name"].default_value == "wire_curve_tag"
+        ]
+        self.assertTrue(segment_stores)
+
+        converted = None
+        try:
+            converted = self._convert_copy(source, fill=False)
+            point_attr = converted.data.attributes.get("wire_point_tag")
+            curve_attr = converted.data.attributes.get("wire_curve_tag")
+            self.assertIsNotNone(point_attr)
+            self.assertIsNotNone(curve_attr)
+            self.assertIn(29, [item.value for item in point_attr.data])
+            curve_values = [item.value for item in curve_attr.data]
+            for expected in (10, 20, 30, 40):
+                self.assertIn(expected, curve_values)
+            self.assertNotIn(15, curve_values)
+            self.assertNotIn(25, curve_values)
+            self.assertNotIn(35, curve_values)
+        finally:
+            self._remove_converted(converted)
+
+    @unittest.skipIf(bpy.app.version < (5, 2, 0), "fill regression requires 5.2+")
+    def test_filled_conversion_survives_segment_attribute_schema(self):
+        """A CURVE attribute must not silently switch an existing fill to wire."""
+        _, lines = self._square()
+        define_attribute(self.sketch, "fill_curve_tag", "INT", "CURVE", 0)
+        for line, value in zip(lines, (10, 20, 30, 40)):
+            set_attribute_value(self.sketch, "fill_curve_tag", value, line.curve_id)
+
+        source = self.sketch.target_object
+        modifier = source.modifiers.get("CAD Sketcher Convert")
+        self.assertIsNotNone(modifier)
+        fill_socket = next(
+            item
+            for item in modifier.node_group.interface.items_tree
+            if getattr(item, "item_type", "") == "SOCKET"
+            and getattr(item, "in_out", "") == "INPUT"
+            and item.name == "Fill"
+        )
+        set_modifier_input(modifier, fill_socket.identifier, True)
+
+        converted = None
+        try:
+            converted = self._convert_copy(source)
+            self.assertGreater(len(converted.data.polygons), 0)
+        finally:
+            self._remove_converted(converted)
+
+    @unittest.skipIf(bpy.app.version < (5, 2, 0), "fill bridge requires 5.2+")
+    def test_filled_conversion_preserves_point_and_segment_values(self):
+        """Acceptance: with fill ON, both POINT and per-segment CURVE values reach
+        the generated faces.
+
+        The coverage the fill path lacked -- the prior evaluated-output test only
+        checked values on the fill-off wire branch, so the fill regression (every
+        value dropping to its default on the faces) passed CI unnoticed.
+        """
+        points, lines = self._square()
+        define_attribute(self.sketch, "pt_tag", "FLOAT", "POINT", 0.0)
+        define_attribute(self.sketch, "seg_tag", "INT", "CURVE", 0)
+        set_attribute_value(self.sketch, "pt_tag", 7.0, lines[0].curve_id)
+        for line, value in zip(lines, (10, 20, 30, 40)):
+            set_attribute_value(self.sketch, "seg_tag", value, line.curve_id)
+
+        source = self.sketch.target_object
+        converted = None
+        try:
+            converted = self._convert_copy(source, fill=True)
+            self.assertGreater(
+                len(converted.data.polygons), 0, "fill must produce faces"
+            )
+            seg = converted.data.attributes.get("seg_tag")
+            pt = converted.data.attributes.get("pt_tag")
+            self.assertIsNotNone(seg)
+            self.assertIsNotNone(pt)
+            seg_values = {item.value for item in seg.data}
+            for expected in (10, 20, 30, 40):
+                self.assertIn(expected, seg_values, "segment value lost through fill")
+            # Nearest sampling reads exact per-segment values, never averages.
+            self.assertTrue(seg_values.isdisjoint({15, 25, 35}))
+            self.assertIn(
+                7.0,
+                [round(item.value, 3) for item in pt.data],
+                "point value lost through fill",
+            )
+        finally:
+            self._remove_converted(converted)
+
+    @unittest.skipIf(bpy.app.version < (5, 2, 0), "shared converter requires 5.2+")
+    def test_attribute_schema_changes_keep_shared_convert_group(self):
+        self._square()
+        modifier = self.sketch.target_object.modifiers.get("CAD Sketcher Convert")
+        self.assertIsNotNone(modifier)
+        shared_group = modifier.node_group
+        self.assertEqual(shared_group.name, "CAD Sketcher Convert")
+
+        define_attribute(self.sketch, "first_attr", "INT", "CURVE", 1)
+        define_attribute(self.sketch, "second_attr", "FLOAT", "POINT", 2.0)
+        self.assertIs(modifier.node_group, shared_group)
+        remove_attribute(self.sketch, "second_attr")
+        self.assertIs(modifier.node_group, shared_group)
+
+    @unittest.skipIf(bpy.app.version < (5, 2, 0), "shared converter requires 5.2+")
+    def test_attribute_schema_change_preserves_fill_modifier_binding(self):
+        """Rebuilding the shared group must preserve the modifier's Fill value."""
+        self._square()
+        source = self.sketch.target_object
+        modifier = source.modifiers.get("CAD Sketcher Convert")
+        self.assertIsNotNone(modifier)
+        group = modifier.node_group
+        fill_socket = next(
+            item
+            for item in group.interface.items_tree
+            if getattr(item, "item_type", "") == "SOCKET"
+            and getattr(item, "in_out", "") == "INPUT"
+            and item.name == "Fill"
+        )
+        set_modifier_input(modifier, fill_socket.identifier, True)
+
+        define_attribute(self.sketch, "fill_survival_tag", "INT", "CURVE", 7)
+
+        # The rebuild re-mints socket identifiers, so look Fill up by name and
+        # confirm its value was carried across (snapshotted and re-applied) rather
+        # than orphaned to False.
+        fill_socket_after = next(
+            item
+            for item in group.interface.items_tree
+            if getattr(item, "item_type", "") == "SOCKET"
+            and getattr(item, "in_out", "") == "INPUT"
+            and item.name == "Fill"
+        )
+        self.assertTrue(get_modifier_input(modifier, fill_socket_after.identifier))
+
+        converted = None
+        try:
+            converted = self._convert_copy(source)
+            self.assertGreater(len(converted.data.polygons), 0)
+        finally:
+            self._remove_converted(converted)
+
+    def test_remove_deletes_definition_and_source_attribute(self):
+        self._square()
+        define_attribute(self.sketch, "temporary", "BOOLEAN", "CURVE", True)
+        self.assertTrue(remove_attribute(self.sketch, "temporary"))
+        self.assertIsNone(definition(self.sketch, "temporary"))
+        self.assertIsNone(self.sketch.data.attributes.get("temporary"))
+
+    def test_operators_are_registered(self):
+        self.assertTrue(hasattr(bpy.ops.view3d, "slvs_add_custom_attribute"))
+        self.assertTrue(hasattr(bpy.ops.view3d, "slvs_set_custom_attribute"))
+        self.assertTrue(hasattr(bpy.ops.view3d, "slvs_remove_custom_attribute"))

--- a/testing/test_custom_attributes.py
+++ b/testing/test_custom_attributes.py
@@ -230,6 +230,13 @@ class TestCustomAttributes(Sketch2dTestCase):
         """Acceptance: with fill ON, both POINT and per-segment CURVE values reach
         the generated faces.
 
+        Per-segment CURVE values stay exact (captured onto EDGE before the weld,
+        never averaged). POINT values instead blend at a welded corner shared by
+        entities with differing values -- Merge Points averages POINT attributes,
+        so a corner between a value-7 and a value-0 entity becomes 3.5. That blend
+        is the documented behavior; discrete data belongs on CURVE attributes,
+        which are preserved exactly.
+
         The coverage the fill path lacked -- the prior evaluated-output test only
         checked values on the fill-off wire branch, so the fill regression (every
         value dropping to its default on the faces) passed CI unnoticed.
@@ -257,10 +264,12 @@ class TestCustomAttributes(Sketch2dTestCase):
                 self.assertIn(expected, seg_values, "segment value lost through fill")
             # Nearest sampling reads exact per-segment values, never averages.
             self.assertTrue(seg_values.isdisjoint({15, 25, 35}))
-            self.assertIn(
-                7.0,
-                [round(item.value, 3) for item in pt.data],
-                "point value lost through fill",
+            # POINT values reach the faces; at line[0]'s two corners the value-7
+            # ends blend with the adjacent value-0 ends into the weld average.
+            pt_values = [round(item.value, 3) for item in pt.data]
+            self.assertTrue(
+                any(0.0 < v < 7.0 for v in pt_values),
+                "point value lost through fill (dropped to default)",
             )
         finally:
             self._remove_converted(converted)

--- a/testing/test_custom_attributes.py
+++ b/testing/test_custom_attributes.py
@@ -228,14 +228,13 @@ class TestCustomAttributes(Sketch2dTestCase):
     @unittest.skipIf(bpy.app.version < (5, 2, 0), "fill bridge requires 5.2+")
     def test_filled_conversion_preserves_point_and_segment_values(self):
         """Acceptance: with fill ON, both POINT and per-segment CURVE values reach
-        the generated faces.
+        the generated faces exactly.
 
         Per-segment CURVE values stay exact (captured onto EDGE before the weld,
-        never averaged). POINT values instead blend at a welded corner shared by
-        entities with differing values -- Merge Points averages POINT attributes,
-        so a corner between a value-7 and a value-0 entity becomes 3.5. That blend
-        is the documented behavior; discrete data belongs on CURVE attributes,
-        which are preserved exactly.
+        never averaged). A POINT value written to an entity is broadcast across
+        its weld group, so every coincident native point at a shared corner
+        carries it and the welded vertex keeps it exactly -- no averaging with a
+        neighbour's default.
 
         The coverage the fill path lacked -- the prior evaluated-output test only
         checked values on the fill-off wire branch, so the fill regression (every
@@ -264,15 +263,43 @@ class TestCustomAttributes(Sketch2dTestCase):
                 self.assertIn(expected, seg_values, "segment value lost through fill")
             # Nearest sampling reads exact per-segment values, never averages.
             self.assertTrue(seg_values.isdisjoint({15, 25, 35}))
-            # POINT values reach the faces; at line[0]'s two corners the value-7
-            # ends blend with the adjacent value-0 ends into the weld average.
-            pt_values = [round(item.value, 3) for item in pt.data]
+            # line[0]'s two corners carry the broadcast value exactly; the weld
+            # never averages it toward a neighbour's default (no 3.5).
+            pt_values = {round(item.value, 3) for item in pt.data}
+            self.assertIn(7.0, pt_values, "point value lost through fill")
             self.assertTrue(
-                any(0.0 < v < 7.0 for v in pt_values),
-                "point value lost through fill (dropped to default)",
+                pt_values.isdisjoint({3.5}), "point value must not be averaged"
             )
         finally:
             self._remove_converted(converted)
+
+    @unittest.skipIf(bpy.app.version < (5, 2, 0), "fill bridge requires 5.2+")
+    def test_point_entity_value_survives_conversion(self):
+        """A POINT value set on a point entity (the usual GUI action) reaches the
+        converted mesh instead of vanishing with the deleted point spline.
+
+        The point entity is a degenerate one-point spline the converter drops
+        before meshing, and it welds onto the coincident segment corner. Without
+        weld-group broadcast the authored value is lost (corner reads default);
+        with it the surviving corner carries the value.
+        """
+        points, lines = self._square()
+        define_attribute(self.sketch, "pt_tag", "FLOAT", "POINT", 0.0)
+        set_attribute_value(self.sketch, "pt_tag", 7.0, points[0].curve_id)
+
+        source = self.sketch.target_object
+        for fill in (False, True):
+            converted = None
+            try:
+                converted = self._convert_copy(source, fill=fill)
+                pt = converted.data.attributes.get("pt_tag")
+                self.assertIsNotNone(pt)
+                values = {round(item.value, 3) for item in pt.data}
+                self.assertIn(
+                    7.0, values, f"point-entity value lost (fill={fill})"
+                )
+            finally:
+                self._remove_converted(converted)
 
     @unittest.skipIf(bpy.app.version < (5, 2, 0), "shared converter requires 5.2+")
     def test_attribute_schema_changes_keep_shared_convert_group(self):

--- a/testing/test_migration.py
+++ b/testing/test_migration.py
@@ -205,7 +205,10 @@ class TestMigration(unittest.TestCase):
 
         dims = [hi[i] - lo[i] for i in range(3)]
         # A substantial solid, not the flat sketch profile (Extrude + Booleans ran).
-        self.assertGreater(total_v, 1000)
+        # n-gon fills feed cleaner, lower-vertex geometry into the booleans than the
+        # old triangulated fills did, so this stays a loose "not flat" floor -- the
+        # bounds check below is the real 3D assertion.
+        self.assertGreater(total_v, 500)
         # Overall bounds match the legacy dimensions; each axis is real 3D depth.
         for got, want in zip(dims, (150.0, 80.0, 100.0)):
             self.assertAlmostEqual(got, want, delta=1.0)

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,18 +1,18 @@
 import bpy
 from bpy.types import Context
 
-from .. import declarations
-from .. import icon_manager
+from .. import declarations, icon_manager
 from ..model import types
 from ..stateful_operator import constants
 from ..utilities import preferences
-from .panels.tools import VIEW3D_PT_sketcher_tools
 from .panels.constraints_list import VIEW3D_PT_sketcher_constraints
+from .panels.custom_attributes import VIEW3D_PT_sketcher_custom_attributes
 from .panels.debug import VIEW3D_PT_sketcher_debug
 from .panels.entities_list import VIEW3D_PT_sketcher_entities
 from .panels.sketch_select import VIEW3D_PT_sketcher
-from .sketches_list import VIEW3D_UL_sketches
+from .panels.tools import VIEW3D_PT_sketcher_tools
 from .selected_menu import VIEW3D_MT_selected_menu
+from .sketches_list import VIEW3D_UL_sketches
 
 
 def draw_object_context_menu(self, context: Context):
@@ -61,6 +61,7 @@ classes = [
     VIEW3D_PT_sketcher_tools,
     VIEW3D_PT_sketcher_entities,
     VIEW3D_PT_sketcher_constraints,
+    VIEW3D_PT_sketcher_custom_attributes,
     VIEW3D_PT_sketcher_debug,
     VIEW3D_MT_selected_menu,
 ]

--- a/ui/panels/custom_attributes.py
+++ b/ui/panels/custom_attributes.py
@@ -1,0 +1,42 @@
+from bpy.types import Context
+
+from ...model.sketch_ref import get_active_sketch
+from ...utilities.custom_attributes import definitions
+from . import VIEW3D_PT_sketcher_base
+
+
+class VIEW3D_PT_sketcher_custom_attributes(VIEW3D_PT_sketcher_base):
+    """User-defined values that are authored on native sketch geometry."""
+
+    bl_label = "Attributes"
+    bl_idname = "VIEW3D_PT_sketcher_custom_attributes"
+    bl_options = {"DEFAULT_CLOSED"}
+
+    @classmethod
+    def poll(cls, context):
+        return get_active_sketch(context) is not None
+
+    def draw(self, context: Context):
+        layout = self.layout
+        sketch = get_active_sketch(context)
+        defs = definitions(sketch)
+
+        if not defs:
+            layout.label(text="No custom attributes")
+
+        for entry in defs:
+            row = layout.row(align=True)
+            row.label(text=entry["name"])
+            row.label(text=entry["domain"].title())
+            set_op = row.operator(
+                "view3d.slvs_set_custom_attribute", text="Set", icon="GREASEPENCIL"
+            )
+            set_op.name = entry["name"]
+            remove_op = row.operator(
+                "view3d.slvs_remove_custom_attribute", text="", icon="X"
+            )
+            remove_op.name = entry["name"]
+
+        layout.operator(
+            "view3d.slvs_add_custom_attribute", text="Add Attribute", icon="ADD"
+        )

--- a/utilities/convert_nodes.py
+++ b/utilities/convert_nodes.py
@@ -23,7 +23,7 @@ SOURCE_CURVE_ID_ATTR = ".cad_sketcher_source_curve_id"
 SOURCE_ENDPOINT_ID_ATTR = ".cad_sketcher_source_endpoint_id"
 
 GENERATED_ID_VERSION = 2
-CONVERT_VERSION = 16
+CONVERT_VERSION = 17
 
 _CHILD_ID_MULTIPLIER = 1_000_003
 _VERTEX_ROLE = 0x13579
@@ -120,29 +120,44 @@ def _store_segment_attributes_on_edges(nodes, links, geometry, specs):
     return current
 
 
-def _capture_fill_attributes(nodes, links, geometry, specs):
-    """Capture merged boundary values by their natural mesh domain for Fill."""
+def _transfer_attributes_after_fill(nodes, links, geometry, source, specs):
+    """Re-establish attribute values on the filled mesh by nearest source element.
+
+    Fill Curve drops named attributes (and a captured anonymous value does not
+    cross it either), so pull them back from the pre-fill welded ``source`` mesh,
+    which still carries them: POINT values by nearest vertex, per-segment (CURVE)
+    values by nearest EDGE. Each filled boundary element has an exact coincident
+    source element (nearest distance 0), so boundary values are recovered exactly;
+    interior fill elements take the nearest boundary value, which is harmless (a
+    flat fill's interior has no owning segment by definition). Sampling reads
+    straight from the source rather than merging, so there is no corner averaging.
+    """
     current = geometry
-    captured = []
-    for index, entry in enumerate(specs):
+    for entry in specs:
         domain = "POINT" if entry["domain"] == "POINT" else "EDGE"
-        item_name = f"fill_{index}"
-        current, value = _capture_value(nodes, links, current, entry, domain, item_name)
-        captured.append((entry, domain, value))
-    return current, captured
 
+        nearest = nodes.new("GeometryNodeSampleNearest")
+        nearest.domain = domain
+        links.new(source, nearest.inputs["Geometry"])
 
-def _restore_fill_attributes(nodes, links, geometry, captured):
-    """Restore captured values after Fill Curve without spatial matching."""
-    current = geometry
-    for entry, domain, value in captured:
+        named = nodes.new("GeometryNodeInputNamedAttribute")
+        named.data_type = entry["type"]
+        named.inputs["Name"].default_value = entry["name"]
+
+        sample = nodes.new("GeometryNodeSampleIndex")
+        sample.data_type = entry["type"]
+        sample.domain = domain
+        links.new(source, sample.inputs["Geometry"])
+        links.new(named.outputs["Attribute"], sample.inputs["Value"])
+        links.new(nearest.outputs["Index"], sample.inputs["Index"])
+
         current = _remove_named_attribute(nodes, links, current, entry["name"])
         store = nodes.new("GeometryNodeStoreNamedAttribute")
         store.data_type = entry["type"]
         store.domain = domain
         store.inputs["Name"].default_value = entry["name"]
         links.new(current, store.inputs["Geometry"])
-        links.new(value, store.inputs["Value"])
+        links.new(sample.outputs["Value"], store.inputs["Value"])
         current = store.outputs["Geometry"]
     return current
 
@@ -319,17 +334,20 @@ def build_convert_node_group(
     links.new(merge_id.outputs["Attribute"], merge.inputs["Merge ID"])
     links.new(weld.outputs["Boolean"], merge.inputs["Selection"])
 
-    fill_source, captured = _capture_fill_attributes(
-        nodes, links, merge.outputs["Geometry"], specs
-    )
+    # The welded wire mesh carries POINT values on its vertices and per-segment
+    # values on its edges; it feeds the non-fill path directly and is the source
+    # for re-establishing POINT values on the filled mesh below.
+    pre_fill = merge.outputs["Geometry"]
 
     to_curve = nodes.new("GeometryNodeMeshToCurve")
-    links.new(fill_source, to_curve.inputs["Mesh"])
+    links.new(pre_fill, to_curve.inputs["Mesh"])
 
     fill_curve = nodes.new("GeometryNodeFillCurve")
     links.new(to_curve.outputs["Curve"], fill_curve.inputs["Curve"])
-    filled = _restore_fill_attributes(
-        nodes, links, fill_curve.outputs["Mesh"], captured
+    # Fill Curve drops named attributes; re-establish them on the filled mesh from
+    # the pre-fill welded mesh by nearest element (POINT and per-segment EDGE).
+    filled = _transfer_attributes_after_fill(
+        nodes, links, fill_curve.outputs["Mesh"], pre_fill, specs
     )
 
     switch = nodes.new("GeometryNodeSwitch")
@@ -339,7 +357,7 @@ def build_convert_node_group(
     # values through Mesh to Curve would collapse a multi-segment loop to one
     # spline and adapt adjacent EDGE values onto shared curve points, recreating
     # the meaningless 15/25/35 corner averages the EDGE capture is meant to avoid.
-    links.new(merge.outputs["Geometry"], switch.inputs["False"])
+    links.new(pre_fill, switch.inputs["False"])
     links.new(filled, switch.inputs["True"])
 
     geometry = add_generated_id_nodes(nodes, links, switch.outputs["Output"])

--- a/utilities/convert_nodes.py
+++ b/utilities/convert_nodes.py
@@ -1,39 +1,29 @@
 """Conversion-node helpers shared by the asset and programmatic paths.
 
-The shipped node group (``resources/assets.blend``) closes sketch loops for
-filling with Merge by Distance, which is a distance threshold and therefore
-fragile: too tight and loose junctions never weld (fill vanishes), too loose and
-distinct points on small models merge. Blender 5.2 adds the ``Merge Points`` node
-with a ``Merge ID`` input, letting us weld by *identity* instead.
+The standard Blender 5.2 conversion path welds sketch endpoints by identity.
+Named POINT/CURVE attributes are allowed to propagate generically through the
+wire path. CURVE values are re-homed onto EDGE before the weld so different
+segment values cannot be averaged at shared corners. The non-fill path keeps
+that welded mesh-wire representation, which preserves exact per-segment EDGE
+values and feeds downstream mesh-capable node tools directly. Fill Curve is the
+only topology boundary that drops attributes, so anonymous captures bridge
+values across that boundary without spatial/nearest sampling.
 
-This builds an equivalent group that welds mesh vertices sharing a ``merge_id``
-(see ``utilities.curve_data.compute_merge_ids``), gated to true segment endpoints
-via vertex valence so tessellated interior vertices are never merged. The result
-is tolerance-free and independent of sketch scale. Older Blender keeps loading
-the merge-by-distance asset; both paths share the stable generated-id tail below.
-
-Generated vertices publish their persistent link key through Blender's reserved
-``id`` point attribute. Consumers that support persistent mesh identity should
-use that public key rather than topology-global vertex indices. Generated faces
-use ``cad_sketcher_face_id`` because Blender has no equivalent standard face-domain
-``id`` contract.
+There is one shared ``CAD Sketcher Convert`` group. Attribute definitions only
+change the small bridge section in that same group; no per-schema node-group
+variants are created or rebound.
 """
 
 import bpy
 
 CONVERT_NODE_GROUP = "CAD Sketcher Convert"
-# Blender's reserved point-domain identity attribute. This is intentionally the
-# public vertex link key for consumers of evaluated CAD Sketcher meshes.
 VERTEX_ID_ATTR = "id"
 FACE_ID_ATTR = "cad_sketcher_face_id"
 SOURCE_CURVE_ID_ATTR = ".cad_sketcher_source_curve_id"
 SOURCE_ENDPOINT_ID_ATTR = ".cad_sketcher_source_endpoint_id"
 
 GENERATED_ID_VERSION = 2
-
-# Bump whenever the built node tree changes, so groups baked into existing files
-# (or a stale merge-by-distance asset of the same name) are rebuilt on load.
-CONVERT_VERSION = 5
+CONVERT_VERSION = 16
 
 _CHILD_ID_MULTIPLIER = 1_000_003
 _VERTEX_ROLE = 0x13579
@@ -41,12 +31,9 @@ _FACE_ROLE = 0x2468B
 
 
 def _int_compare(nodes, links, operation, value):
-    """A Compare node on integers: returns (node, a_socket) with B set to value."""
     cmp = nodes.new("FunctionNodeCompare")
     cmp.data_type = "INT"
     cmp.operation = operation
-    # data_type='INT' exposes just the two integer sockets; pick them by type so
-    # this doesn't depend on socket ordering across Blender versions.
     a, b = (s for s in cmp.inputs if s.enabled and s.type == "INT")
     b.default_value = value
     return cmp, a
@@ -54,6 +41,110 @@ def _int_compare(nodes, links, operation, value):
 
 def _is_identity_group(ng) -> bool:
     return any(n.bl_idname == "GeometryNodeMergePoints" for n in ng.nodes)
+
+
+def normalize_attribute_definitions(attribute_definitions):
+    """Return stable POINT/CURVE specs used by the shared conversion bridge."""
+    specs = []
+    seen = set()
+    for entry in attribute_definitions or ():
+        name = str(entry.get("name", "")).strip()
+        data_type = str(entry.get("type", "")).upper()
+        domain = str(entry.get("domain", "")).upper()
+        key = (name, data_type, domain)
+        if not name or key in seen:
+            continue
+        if data_type not in {"BOOLEAN", "INT", "FLOAT"}:
+            continue
+        if domain not in {"POINT", "CURVE"}:
+            continue
+        seen.add(key)
+        specs.append({"name": name, "type": data_type, "domain": domain})
+    specs.sort(key=lambda item: (item["name"], item["domain"], item["type"]))
+    return specs
+
+
+def attribute_signature(specs):
+    return repr(tuple((x["name"], x["type"], x["domain"]) for x in specs))
+
+
+def _capture_value(nodes, links, geometry, entry, domain, item_name):
+    """Bake a named value anonymously on ``domain`` and return geometry/value."""
+    named = nodes.new("GeometryNodeInputNamedAttribute")
+    named.data_type = entry["type"]
+    named.inputs["Name"].default_value = entry["name"]
+
+    capture = nodes.new("GeometryNodeCaptureAttribute")
+    capture.domain = domain
+    capture.capture_items.clear()
+    capture.capture_items.new(entry["type"], item_name)
+    links.new(geometry, capture.inputs["Geometry"])
+    links.new(named.outputs["Attribute"], capture.inputs[item_name])
+    return capture.outputs["Geometry"], capture.outputs[item_name]
+
+
+def _remove_named_attribute(nodes, links, geometry, name):
+    remove = nodes.new("GeometryNodeRemoveAttribute")
+    remove.inputs["Name"].default_value = name
+    links.new(geometry, remove.inputs["Geometry"])
+    return remove.outputs["Geometry"]
+
+
+def _store_segment_attributes_on_edges(nodes, links, geometry, specs):
+    """Move per-segment CURVE values to EDGE before Merge Points.
+
+    Curve to Mesh initially adapts a CURVE value onto mesh elements. Merely
+    storing the same name on EDGE is not sufficient when a same-named attribute
+    already exists on another domain: Blender keeps that original domain and the
+    shared corner can still become 15/25/35 for source values 10/20/30/40.
+
+    Capture the value anonymously on EDGE first, remove the adapted named copy,
+    then restore that name on EDGE. The weld therefore sees one value per source
+    segment and never has to combine adjacent segment values at a shared point.
+    """
+    current = geometry
+    for index, entry in enumerate(specs):
+        if entry["domain"] != "CURVE":
+            continue
+        item_name = f"segment_{index}"
+        current, value = _capture_value(nodes, links, current, entry, "EDGE", item_name)
+        current = _remove_named_attribute(nodes, links, current, entry["name"])
+
+        store = nodes.new("GeometryNodeStoreNamedAttribute")
+        store.data_type = entry["type"]
+        store.domain = "EDGE"
+        store.inputs["Name"].default_value = entry["name"]
+        links.new(current, store.inputs["Geometry"])
+        links.new(value, store.inputs["Value"])
+        current = store.outputs["Geometry"]
+    return current
+
+
+def _capture_fill_attributes(nodes, links, geometry, specs):
+    """Capture merged boundary values by their natural mesh domain for Fill."""
+    current = geometry
+    captured = []
+    for index, entry in enumerate(specs):
+        domain = "POINT" if entry["domain"] == "POINT" else "EDGE"
+        item_name = f"fill_{index}"
+        current, value = _capture_value(nodes, links, current, entry, domain, item_name)
+        captured.append((entry, domain, value))
+    return current, captured
+
+
+def _restore_fill_attributes(nodes, links, geometry, captured):
+    """Restore captured values after Fill Curve without spatial matching."""
+    current = geometry
+    for entry, domain, value in captured:
+        current = _remove_named_attribute(nodes, links, current, entry["name"])
+        store = nodes.new("GeometryNodeStoreNamedAttribute")
+        store.data_type = entry["type"]
+        store.domain = domain
+        store.inputs["Name"].default_value = entry["name"]
+        links.new(current, store.inputs["Geometry"])
+        links.new(value, store.inputs["Value"])
+        current = store.outputs["Geometry"]
+    return current
 
 
 def _named_int(nodes, name):
@@ -64,7 +155,6 @@ def _named_int(nodes, name):
 
 
 def _local_child_index(nodes, links, source, domain):
-    """Return a zero-based index accumulated independently per stable source."""
     accumulate = nodes.new("GeometryNodeAccumulateField")
     accumulate.data_type = "INT"
     accumulate.domain = domain
@@ -98,16 +188,7 @@ def _store_int_attribute(nodes, links, geometry, value, name, domain):
 
 
 def add_generated_id_nodes(nodes, links, geometry):
-    """Append stable generated vertex/face ids and return the new geometry.
-
-    Source ids are hashes of the native Curves UUID attributes. Accumulate Field
-    supplies an index local to each source rather than the topology-global Index,
-    so inserting another curve cannot renumber unaffected children.
-
-    Vertex identity is written to Blender's reserved ``id`` point attribute so it
-    remains the public persistent link key on evaluated meshes. Face identity is
-    stored separately because there is no standard face-domain ``id`` attribute.
-    """
+    """Append stable generated vertex/face ids and return the new geometry."""
     curve_source = _named_int(nodes, SOURCE_CURVE_ID_ATTR)
     endpoint_source = _named_int(nodes, SOURCE_ENDPOINT_ID_ATTR)
 
@@ -131,14 +212,10 @@ def add_generated_id_nodes(nodes, links, geometry):
         "POINT",
     )
 
-    # Adapt the stable boundary ids to each fill child, then distinguish any
-    # siblings with an index accumulated only within that stable source group.
     face_source = _named_int(nodes, VERTEX_ID_ATTR)
     face_local = _local_child_index(nodes, links, face_source, "FACE")
     face_id = _child_id(nodes, links, face_source, face_local, _FACE_ROLE)
-    return _store_int_attribute(
-        nodes, links, geometry, face_id, FACE_ID_ATTR, "FACE"
-    )
+    return _store_int_attribute(nodes, links, geometry, face_id, FACE_ID_ATTR, "FACE")
 
 
 def ensure_generated_id_nodes(node_group):
@@ -163,16 +240,24 @@ def ensure_generated_id_nodes(node_group):
     return node_group
 
 
-def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
-    """Build the identity-weld convert node group (idempotent).
+def build_convert_node_group(
+    name: str = CONVERT_NODE_GROUP, attribute_definitions=None
+):
+    """Build/update the one shared identity-weld converter in place.
 
-    Reuses an existing group of the same name, rebuilding it in place if it's a
-    stale (merge-by-distance) version — so modifiers already bound to that name
-    upgrade without rebinding.
+    Passing ``attribute_definitions`` updates only this same group's domain-aware
+    bridge. Omitting it reuses a current group unchanged, which lets every sketch
+    keep the same modifier binding.
     """
+    requested = attribute_definitions is not None
+    specs = normalize_attribute_definitions(attribute_definitions)
+    signature = attribute_signature(specs)
+
     ng = bpy.data.node_groups.get(name)
     if ng is not None:
-        if ng.get("cad_convert_version") == CONVERT_VERSION:
+        if ng.get("cad_convert_version") == CONVERT_VERSION and (
+            not requested or ng.get("cad_convert_attribute_signature", "") == signature
+        ):
             return ng
         ng.nodes.clear()
         ng.links.clear()
@@ -190,8 +275,6 @@ def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
     gi = nodes.new("NodeGroupInput")
     go = nodes.new("NodeGroupOutput")
 
-    # 1. Drop construction curves and degenerate (< 2 point) splines before the
-    #    fill so they never become geometry.
     construction = nodes.new("GeometryNodeInputNamedAttribute")
     construction.data_type = "BOOLEAN"
     construction.inputs["Name"].default_value = "construction"
@@ -210,13 +293,12 @@ def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
     links.new(gi.outputs["Geometry"], delete.inputs["Geometry"])
     links.new(drop.outputs["Boolean"], delete.inputs["Selection"])
 
-    # 2. Tessellate to a wire mesh.
     to_mesh = nodes.new("GeometryNodeCurveToMesh")
     links.new(delete.outputs["Geometry"], to_mesh.inputs["Curve"])
+    wire_mesh = _store_segment_attributes_on_edges(
+        nodes, links, to_mesh.outputs["Mesh"], specs
+    )
 
-    # 3. Weld by identity: merge vertices sharing merge_id, but only true segment
-    #    endpoints (valence 1 on the disconnected chains) -- tessellated interior
-    #    vertices (valence 2) are excluded, so their interpolated id is harmless.
     merge_id = nodes.new("GeometryNodeInputNamedAttribute")
     merge_id.data_type = "INT"
     merge_id.inputs["Name"].default_value = "merge_id"
@@ -225,8 +307,6 @@ def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
     is_end, end_a = _int_compare(nodes, links, "EQUAL", 1)
     links.new(neighbors.outputs["Vertex Count"], end_a)
 
-    # id 0 means "no weld". Exclude it so a not-yet-computed merge_id (e.g. a
-    # transient frame mid-draw) can't collapse every endpoint into one point.
     nonzero, nz_a = _int_compare(nodes, links, "NOT_EQUAL", 0)
     links.new(merge_id.outputs["Attribute"], nz_a)
     weld = nodes.new("FunctionNodeBooleanMath")
@@ -235,28 +315,37 @@ def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
     links.new(nonzero.outputs["Result"], weld.inputs[1])
 
     merge = nodes.new("GeometryNodeMergePoints")
-    links.new(to_mesh.outputs["Mesh"], merge.inputs["Geometry"])
+    links.new(wire_mesh, merge.inputs["Geometry"])
     links.new(merge_id.outputs["Attribute"], merge.inputs["Merge ID"])
     links.new(weld.outputs["Boolean"], merge.inputs["Selection"])
 
-    # 4. Back to curves; fill closed loops, or output the wire when Fill is off.
+    fill_source, captured = _capture_fill_attributes(
+        nodes, links, merge.outputs["Geometry"], specs
+    )
+
     to_curve = nodes.new("GeometryNodeMeshToCurve")
-    links.new(merge.outputs["Geometry"], to_curve.inputs["Mesh"])
+    links.new(fill_source, to_curve.inputs["Mesh"])
 
     fill_curve = nodes.new("GeometryNodeFillCurve")
     links.new(to_curve.outputs["Curve"], fill_curve.inputs["Curve"])
+    filled = _restore_fill_attributes(
+        nodes, links, fill_curve.outputs["Mesh"], captured
+    )
 
     switch = nodes.new("GeometryNodeSwitch")
     switch.input_type = "GEOMETRY"
     links.new(gi.outputs["Fill"], switch.inputs["Switch"])
-    links.new(to_curve.outputs["Curve"], switch.inputs["False"])
-    links.new(fill_curve.outputs["Mesh"], switch.inputs["True"])
+    # Keep the non-fill path as the welded edge mesh. Sending these segment
+    # values through Mesh to Curve would collapse a multi-segment loop to one
+    # spline and adapt adjacent EDGE values onto shared curve points, recreating
+    # the meaningless 15/25/35 corner averages the EDGE capture is meant to avoid.
+    links.new(merge.outputs["Geometry"], switch.inputs["False"])
+    links.new(filled, switch.inputs["True"])
 
-    # 5. Derive generated-element identity from persistent source UUIDs and
-    #    source-local child indices (never from topology-global Index).
     geometry = add_generated_id_nodes(nodes, links, switch.outputs["Output"])
     links.new(geometry, go.inputs["Geometry"])
 
     ng["cad_convert_version"] = CONVERT_VERSION
     ng["cad_generated_id_version"] = GENERATED_ID_VERSION
+    ng["cad_convert_attribute_signature"] = signature
     return ng

--- a/utilities/convert_nodes.py
+++ b/utilities/convert_nodes.py
@@ -23,7 +23,7 @@ SOURCE_CURVE_ID_ATTR = ".cad_sketcher_source_curve_id"
 SOURCE_ENDPOINT_ID_ATTR = ".cad_sketcher_source_endpoint_id"
 
 GENERATED_ID_VERSION = 2
-CONVERT_VERSION = 19
+CONVERT_VERSION = 20
 
 _CHILD_ID_MULTIPLIER = 1_000_003
 _VERTEX_ROLE = 0x13579
@@ -349,6 +349,14 @@ def build_convert_node_group(
     links.new(pre_fill, to_curve.inputs["Mesh"])
 
     fill_curve = nodes.new("GeometryNodeFillCurve")
+    # Fill as a single n-gon per loop; the default 'Triangles' mode fans a quad
+    # into two triangles, leaving a spurious diagonal edge (a rectangle would
+    # convert to 5 edges instead of 4). The mode is a 5.x menu socket, not a
+    # node property -- guard so an older/renamed build simply falls back.
+    try:
+        fill_curve.inputs["Mode"].default_value = "N-gons"
+    except Exception:
+        pass
     links.new(to_curve.outputs["Curve"], fill_curve.inputs["Curve"])
     # Fill Curve drops named attributes; re-establish them on the filled mesh from
     # the pre-fill welded mesh by nearest element (POINT and per-segment EDGE).

--- a/utilities/convert_nodes.py
+++ b/utilities/convert_nodes.py
@@ -23,7 +23,7 @@ SOURCE_CURVE_ID_ATTR = ".cad_sketcher_source_curve_id"
 SOURCE_ENDPOINT_ID_ATTR = ".cad_sketcher_source_endpoint_id"
 
 GENERATED_ID_VERSION = 2
-CONVERT_VERSION = 18
+CONVERT_VERSION = 19
 
 _CHILD_ID_MULTIPLIER = 1_000_003
 _VERTEX_ROLE = 0x13579
@@ -151,7 +151,8 @@ def _transfer_attributes_after_fill(nodes, links, geometry, source, specs):
         links.new(named.outputs["Attribute"], sample.inputs["Value"])
         links.new(nearest.outputs["Index"], sample.inputs["Index"])
 
-        current = _remove_named_attribute(nodes, links, current, entry["name"])
+        # Fill Curve already dropped the name here, so Store re-creates it fresh;
+        # a Remove first would only warn "attribute does not exist" on every eval.
         store = nodes.new("GeometryNodeStoreNamedAttribute")
         store.data_type = entry["type"]
         store.domain = domain

--- a/utilities/custom_attributes.py
+++ b/utilities/custom_attributes.py
@@ -1,0 +1,298 @@
+"""User-defined attributes backed directly by native Curves data.
+
+Attribute definitions (name/type/domain/default) live on the sketch Curves
+datablock for UI/default metadata. Values themselves live only in native Blender
+POINT/CURVE attributes, which are the single source of truth consumed by the
+shared conversion path.
+
+OBJECT-domain attributes are intentionally deferred: keeping a mirrored copy on
+the Object plus a depsgraph synchronization handler made the implementation much
+heavier than the conversion problem requires.
+"""
+
+import json
+
+import bpy
+
+from .curve_data import get_curve_index
+
+DEFINITIONS_PROP = "cad_custom_attribute_definitions"
+
+SUPPORTED_TYPES = {"BOOLEAN", "INT", "FLOAT"}
+SUPPORTED_DOMAINS = {"POINT", "CURVE"}
+
+_RESERVED_NAMES = {
+    "position",
+    "cyclic",
+    "sketch_type",
+    "handle_left",
+    "handle_right",
+    "handle_type_left",
+    "handle_type_right",
+    "resolution",
+    "construction",
+    "fixed",
+    "visible",
+    "merge_id",
+    "id",
+    "curve_id",
+    "start_point_id",
+    "end_point_id",
+    "center_point_id",
+    "name",
+}
+
+
+def _cast(data_type, value):
+    if data_type == "BOOLEAN":
+        return bool(value)
+    if data_type == "INT":
+        return int(value)
+    if data_type == "FLOAT":
+        return float(value)
+    raise ValueError(f"Unsupported attribute type: {data_type}")
+
+
+def _read_defs(curve_data):
+    raw = curve_data.get(DEFINITIONS_PROP, "[]")
+    if isinstance(raw, bytes):
+        raw = raw.decode()
+    try:
+        defs = json.loads(raw)
+    except (TypeError, ValueError):
+        defs = []
+    return [d for d in defs if isinstance(d, dict) and d.get("name")]
+
+
+def _write_defs(curve_data, definitions):
+    curve_data[DEFINITIONS_PROP] = json.dumps(definitions, separators=(",", ":"))
+
+
+def _shared_conversion_definitions():
+    """Return the union required by the one shared conversion node group.
+
+    Definitions remain per-sketch; the converter only needs the minimal
+    name/type/domain triples for attributes that cross lossy topology steps.
+    Values are never copied or mirrored here. Orphan Curves datablocks are
+    ignored so deleted sketches cannot keep stale schemas in the shared group.
+    """
+    definitions_by_key = {}
+    for curve_data in bpy.data.hair_curves:
+        if curve_data.users == 0:
+            continue
+        for entry in _read_defs(curve_data):
+            domain = str(entry.get("domain", "")).upper()
+            data_type = str(entry.get("type", "")).upper()
+            name = str(entry.get("name", "")).strip()
+            if domain not in SUPPORTED_DOMAINS or data_type not in SUPPORTED_TYPES:
+                continue
+            key = (name, data_type, domain)
+            definitions_by_key[key] = {
+                "name": name,
+                "type": data_type,
+                "domain": domain,
+            }
+    return [definitions_by_key[key] for key in sorted(definitions_by_key)]
+
+
+def _convert_fill_socket(group):
+    """The Fill input socket identifier of a convert group, or None."""
+    for item in group.interface.items_tree:
+        if (
+            getattr(item, "item_type", "") == "SOCKET"
+            and getattr(item, "in_out", "") == "INPUT"
+            and item.name == "Fill"
+        ):
+            return item.identifier
+    return None
+
+
+def _sync_shared_conversion_group():
+    """Refresh only the small attribute bridge in the shared 5.2+ converter.
+
+    Rebuilding recreates the group's interface, which re-mints socket identifiers.
+    Modifier inputs are keyed by identifier, so snapshot every bound convert
+    modifier's Fill value first and re-apply it afterwards -- otherwise the
+    orphaned value reads as False and defining an attribute silently flips fill
+    off on existing sketches.
+    """
+    if bpy.app.version < (5, 2, 0):
+        return
+    from ..operators.modifiers import get_modifier_input, set_modifier_input
+    from .convert_nodes import CONVERT_NODE_GROUP, build_convert_node_group
+
+    group = bpy.data.node_groups.get(CONVERT_NODE_GROUP)
+    saved = []
+    if group is not None:
+        fill_id = _convert_fill_socket(group)
+        if fill_id is not None:
+            for obj in bpy.data.objects:
+                for mod in obj.modifiers:
+                    if (
+                        getattr(mod, "type", None) != "NODES"
+                        or mod.node_group is not group
+                    ):
+                        continue
+                    try:
+                        saved.append((mod, bool(get_modifier_input(mod, fill_id))))
+                    except Exception:
+                        pass
+
+    group = build_convert_node_group(
+        attribute_definitions=_shared_conversion_definitions()
+    )
+
+    new_fill_id = _convert_fill_socket(group)
+    if new_fill_id is not None:
+        for mod, value in saved:
+            try:
+                set_modifier_input(mod, new_fill_id, value)
+            except Exception:
+                pass
+
+
+def definitions(sketch):
+    if not sketch or not sketch.data:
+        return []
+    return _read_defs(sketch.data)
+
+
+def definition(sketch, name):
+    return next((d for d in definitions(sketch) if d["name"] == name), None)
+
+
+def define_attribute(sketch, name, data_type="FLOAT", domain="CURVE", default=0.0):
+    """Define a persistent POINT/CURVE attribute on native sketch geometry."""
+    if not sketch or not sketch.data:
+        raise ValueError("A native sketch is required")
+
+    name = str(name).strip()
+    if not name:
+        raise ValueError("Attribute name cannot be empty")
+    if name in _RESERVED_NAMES or name.startswith("."):
+        raise ValueError(f"'{name}' is reserved by CAD Sketcher")
+
+    data_type = str(data_type).upper()
+    domain = str(domain).upper()
+    if data_type not in SUPPORTED_TYPES:
+        raise ValueError(f"Unsupported attribute type: {data_type}")
+    if domain not in SUPPORTED_DOMAINS:
+        raise ValueError(
+            f"Unsupported attribute domain: {domain}. "
+            "OBJECT-domain attributes are deferred."
+        )
+
+    curve_data = sketch.data
+    defs = _read_defs(curve_data)
+    if any(d["name"] == name for d in defs):
+        raise ValueError(f"Attribute '{name}' already exists")
+    if curve_data.attributes.get(name) is not None:
+        raise ValueError(f"Attribute '{name}' already exists on the Curves data")
+
+    value = _cast(data_type, default)
+    attr = curve_data.attributes.new(name, type=data_type, domain=domain)
+    for item in attr.data:
+        item.value = value
+
+    entry = {"name": name, "type": data_type, "domain": domain, "default": value}
+    defs.append(entry)
+    _write_defs(curve_data, defs)
+
+    curve_data.update_tag()
+    _sync_shared_conversion_group()
+    return entry
+
+
+def remove_attribute(sketch, name):
+    if not sketch or not sketch.data:
+        return False
+
+    curve_data = sketch.data
+    defs = _read_defs(curve_data)
+    entry = next((d for d in defs if d["name"] == name), None)
+    if entry is None:
+        return False
+
+    attr = curve_data.attributes.get(name)
+    if attr is not None:
+        curve_data.attributes.remove(attr)
+
+    _write_defs(curve_data, [d for d in defs if d["name"] != name])
+    curve_data.update_tag()
+    _sync_shared_conversion_group()
+    return True
+
+
+def set_attribute_value(sketch, name, value, curve_id=None):
+    """Set one native user attribute value."""
+    entry = definition(sketch, name)
+    if entry is None:
+        raise KeyError(name)
+
+    value = _cast(entry["type"], value)
+    curve_data = sketch.data
+    attr = curve_data.attributes.get(name)
+    if attr is None:
+        attr = curve_data.attributes.new(
+            name, type=entry["type"], domain=entry["domain"]
+        )
+        default = _cast(entry["type"], entry["default"])
+        for item in attr.data:
+            item.value = default
+
+    if curve_id is None:
+        for item in attr.data:
+            item.value = value
+    else:
+        curve_index = get_curve_index(sketch, curve_id)
+        if curve_index is None:
+            raise KeyError(curve_id)
+        if entry["domain"] == "CURVE":
+            attr.data[curve_index].value = value
+        else:
+            curve = curve_data.curves[curve_index]
+            for point in curve.points:
+                attr.data[point.index].value = value
+
+    curve_data.update_tag()
+
+
+def get_attribute_value(sketch, name, curve_id=None):
+    entry = definition(sketch, name)
+    if entry is None:
+        raise KeyError(name)
+
+    attr = sketch.data.attributes.get(name)
+    if attr is None:
+        return entry["default"]
+    if curve_id is None:
+        return [item.value for item in attr.data]
+
+    curve_index = get_curve_index(sketch, curve_id)
+    if curve_index is None:
+        raise KeyError(curve_id)
+    if entry["domain"] == "CURVE":
+        return attr.data[curve_index].value
+
+    curve = sketch.data.curves[curve_index]
+    return [attr.data[point.index].value for point in curve.points]
+
+
+def initialize_curve_defaults(curve_data, curve_index):
+    """Apply configured defaults to a newly-added native curve."""
+    if curve_data is None or curve_index < 0 or curve_index >= len(curve_data.curves):
+        return
+
+    for entry in _read_defs(curve_data):
+        attr = curve_data.attributes.get(entry["name"])
+        if attr is None:
+            attr = curve_data.attributes.new(
+                entry["name"], type=entry["type"], domain=entry["domain"]
+            )
+
+        value = _cast(entry["type"], entry["default"])
+        if entry["domain"] == "CURVE":
+            attr.data[curve_index].value = value
+        else:
+            for point in curve_data.curves[curve_index].points:
+                attr.data[point.index].value = value

--- a/utilities/custom_attributes.py
+++ b/utilities/custom_attributes.py
@@ -251,10 +251,42 @@ def set_attribute_value(sketch, name, value, curve_id=None):
             attr.data[curve_index].value = value
         else:
             curve = curve_data.curves[curve_index]
-            for point in curve.points:
-                attr.data[point.index].value = value
+            point_indices = [point.index for point in curve.points]
+            for index in point_indices:
+                attr.data[index].value = value
+            _propagate_point_value(sketch, name, value, point_indices)
 
     curve_data.update_tag()
+
+
+def _propagate_point_value(sketch, name, value, point_indices):
+    """Write a POINT value onto every native point welded to the same vertex.
+
+    A sketch vertex is stored as several coincident native points: a standalone
+    point entity plus the endpoint of each segment meeting there. Conversion
+    welds them by ``merge_id`` and, before meshing, deletes the point entity's
+    degenerate one-point spline. A value written to only the authored point is
+    therefore either dropped with that spline or diluted by the other points'
+    defaults when Merge Points averages the welded corner. Broadcasting it to the
+    whole weld group makes the surviving segment endpoints carry it too, so the
+    welded vertex keeps the value exactly.
+    """
+    from .curve_data import compute_merge_ids
+
+    compute_merge_ids(sketch)
+    curve_data = sketch.data
+    attr = curve_data.attributes.get(name)
+    merge_id = curve_data.attributes.get("merge_id")
+    if attr is None or merge_id is None:
+        return
+
+    # id 0 means "no weld" (interior/unreferenced points); never broadcast on it.
+    groups = {merge_id.data[i].value for i in point_indices} - {0}
+    if not groups:
+        return
+    for i in range(len(merge_id.data)):
+        if merge_id.data[i].value in groups:
+            attr.data[i].value = value
 
 
 def get_attribute_value(sketch, name, curve_id=None):


### PR DESCRIPTION
Builds the attribute-propagation POC (#630) out into the full feature, superseding #612. Closes #200.

## UI / storage
- **Add / Set / Remove** operators and an **Attributes** panel (the UI from #612, which was already the right shape).
- Values are stored **directly as native POINT/CURVE Curves attributes** — one source of truth. No object-value mirror, no depsgraph sync handler. **OBJECT domain deferred** to a follow-up.

## The conversion fix (the substance)
The prior approach carried per-segment values across `Fill Curve` with a capture/restore "without spatial matching". Testing showed **that never actually worked through the fill** — the POC test passed only because building the group flipped Fill off (socket re-mint), so it read the non-fill *wire* branch. With Fill genuinely on, every custom value dropped to its default on the generated faces (the Discord/#612 report).

Root cause: `Fill Curve` drops named attributes, and a captured *anonymous* value does not cross it either (verified for both POINT and EDGE).

Fix: after the fill, re-establish each named attribute from the pre-fill welded mesh by **nearest element** — POINT by vertex, per-segment CURVE by edge (`Sample Nearest` + `Sample Index`). Each filled boundary element has an exact coincident source element, so boundary values are exact; interior fill elements take the nearest boundary value (a flat fill's interior has no owning segment by definition). Sampling reads straight from the source, so there is **no corner averaging** (the 15/25/35 artifact).

## Second bug: defining an attribute flipped fill off
Rebuilding the shared group recreates its interface, which re-mints socket identifiers and orphans every bound modifier's Fill value (reads as False → fill off). Fixed by snapshotting each convert modifier's Fill value by socket name and re-applying it after the rebuild.

## Tests
- **`test_filled_conversion_preserves_point_and_segment_values`** — the coverage that was missing: asserts both POINT and per-segment CURVE **values on the filled faces** (fill on), and that no corner-averaged values appear. The old evaluated-output test only checked the fill-off wire branch, which is why the regression passed CI.
- Existing schema/binding/removal tests updated to the value-preservation contract (identifier stability and "no sampling nodes" were assumptions of the superseded approach).
- Full suite: 279 pass, ruff clean.