### PR TITLE
Boolean directly from the Extrude and Revolve tools

### DIFF
--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -3,12 +3,21 @@ import math
 import bpy
 from bpy.props import (
     BoolProperty,
+    CollectionProperty,
+    EnumProperty,
     FloatProperty,
     FloatVectorProperty,
     IntProperty,
     StringProperty,
 )
-from bpy.types import Context, Event, MeshEdge, Object, Operator
+from bpy.types import (
+    Context,
+    Event,
+    MeshEdge,
+    Object,
+    Operator,
+    PropertyGroup,
+)
 from mathutils import Vector
 from mathutils.geometry import intersect_line_line, intersect_line_plane
 
@@ -151,6 +160,128 @@ def apply_boolean(
     set_modifier_input(mod, ids["Self Intersection"], self_intersection)
     set_modifier_input(mod, ids["Hole Tolerant"], hole_tolerant)
     return mod
+
+
+class BooleanTargetItem(PropertyGroup):
+    """One auto-detected boolean target, toggled in the extrude/revolve redo panel."""
+
+    name: StringProperty()
+    enabled: BoolProperty(name="Enabled", default=True)
+
+
+# Redo-panel enum for the tool boolean. "None" leaves the tool a plain solid.
+BOOLEAN_TOOL_OPERATIONS = (
+    ("None", "None", "Do not boolean; just build the solid"),
+    ("Difference", "Difference", "Subtract the solid from the targets"),
+    ("Union", "Union", "Merge the solid into the targets"),
+    ("Intersect", "Intersect", "Keep only the overlap with the targets"),
+)
+
+
+class BooleanFromToolMixin:
+    """Boolean an extrude/revolve solid into auto-detected targets.
+
+    Mixed into the extrude and revolve operators. The concrete operator declares
+    the three properties below (so they register on that operator) and calls
+    ``reset_booleans`` from ``init``, ``finish_booleans`` from ``fini`` and
+    ``draw_boolean_settings`` from ``draw_settings``:
+
+        operation: EnumProperty(items=BOOLEAN_TOOL_OPERATIONS, default="Difference")
+        boolean_targets: CollectionProperty(type=BooleanTargetItem)
+        boolean_detected: BoolProperty(default=False, options={"HIDDEN"})
+    """
+
+    def reset_booleans(self):
+        """Clear detection state for a fresh interactive run (call from init).
+
+        Detection runs once per operation; the redo panel then edits the result.
+        init runs on invoke but not on the redo re-execute, so resetting here
+        preserves the user's redo-panel edits while a new invocation redetects.
+        """
+        self.boolean_detected = False
+        self.boolean_targets.clear()
+
+    def _boolean_offset(self):
+        # Extrude orients the default mode by its offset sign; revolve has none.
+        return getattr(self, "offset", 0.0)
+
+    def finish_booleans(self, context):
+        """Detect targets once, then apply/remove the per-target booleans.
+
+        The cutter is this tool's own object: its evaluated solid is read by the
+        boolean group through Object Info.
+        """
+        cutter = getattr(self, "_obj", None) or self.resolved_object()
+        if cutter is None:
+            return
+        cutter = cutter.original
+
+        from ..model.sketch_ref import Sketch
+        from ..utilities.boolean_targets import (
+            default_operation,
+            detect_targets,
+            sketch_source_body,
+        )
+
+        sketch = Sketch(cutter) if cutter.type == "CURVES" else None
+
+        if not self.boolean_detected:
+            # The solid must be evaluated before the overlap test can see it.
+            context.view_layer.update()
+            targets = detect_targets(context, cutter, sketch)
+            has_source = sketch is not None and sketch_source_body(sketch) is not None
+            self.operation = default_operation(self._boolean_offset(), has_source)
+            self.boolean_targets.clear()
+            for obj in targets:
+                item = self.boolean_targets.add()
+                item.name = obj.name
+                item.enabled = True
+            self.boolean_detected = True
+
+        self._apply_boolean_targets(cutter)
+
+    def _apply_boolean_targets(self, cutter):
+        name = boolean_modifier_name(cutter)
+        applied = False
+        for item in self.boolean_targets:
+            body = bpy.data.objects.get(item.name)
+            if body is None:
+                continue
+            existing = body.modifiers.get(name)
+            if self.operation != "None" and item.enabled:
+                apply_boolean(body, cutter, self.operation)
+                applied = True
+            elif existing is not None:
+                # Excluded (or operation set to None): drop the boolean again.
+                body.modifiers.remove(existing)
+        # A solid cutter sitting over the bodies would hide the result -- wireframe
+        # it, matching the standalone Boolean tool.
+        if applied:
+            cutter.display_type = "WIRE"
+
+    def draw_boolean_settings(self, layout):
+        layout.separator()
+        layout.prop(self, "operation", text="Boolean")
+        if self.operation != "None" and len(self.boolean_targets):
+            box = layout.box()
+            box.label(text="Targets")
+            for item in self.boolean_targets:
+                row = box.row(align=True)
+                row.prop(item, "enabled", text="")
+                row.label(text=item.name)
+
+
+# Shared property annotations for the two boolean-capable tools; spread into each
+# operator's class body so they register on that operator (Blender collects an
+# operator's own annotations, not a mixin's).
+def _boolean_tool_annotations():
+    return {
+        "operation": EnumProperty(
+            name="Boolean", items=BOOLEAN_TOOL_OPERATIONS, default="Difference"
+        ),
+        "boolean_targets": CollectionProperty(type=BooleanTargetItem),
+        "boolean_detected": BoolProperty(default=False, options={"HIDDEN"}),
+    }
 
 
 BASE_STATES = (
@@ -334,7 +465,7 @@ class View3D_OT_node_fill(Operator, NodeOperator):
         return "Fill Mesh and Curve"
 
 
-class View3D_OT_node_extrude(Operator, NodeOperator):
+class View3D_OT_node_extrude(Operator, BooleanFromToolMixin, NodeOperator):
     """Add an extrude modifier node group"""
 
     bl_idname = Operators.NodeExtrude
@@ -374,6 +505,16 @@ class View3D_OT_node_extrude(Operator, NodeOperator):
         delta = (mat @ Vector(pos)).z
         return delta
 
+    def init(self, context: Context, event: Event):
+        if not super().init(context, event):
+            return False
+        self.reset_booleans()
+        return True
+
+    def fini(self, context: Context, succeede: bool):
+        if succeede:
+            self.finish_booleans(context)
+
     def set_props(self):
         m = self.modifier
         set_modifier_input(m, "Input_2", self.offset)  # Size
@@ -389,6 +530,7 @@ class View3D_OT_node_extrude(Operator, NodeOperator):
         sub = layout.column()
         sub.enabled = self.asymmetry
         sub.prop(self, "asymmetry_distance")
+        self.draw_boolean_settings(layout)
 
 
 class View3D_OT_node_array_linear(Operator, NodeOperator):
@@ -502,7 +644,7 @@ class View3D_OT_node_array_linear(Operator, NodeOperator):
         sub.prop(self, "merge_distance")
 
 
-class View3D_OT_node_revolve(Operator, NodeOperator):
+class View3D_OT_node_revolve(Operator, BooleanFromToolMixin, NodeOperator):
     """Revolve a 2D profile around a picked axis"""
 
     bl_idname = Operators.NodeRevolve
@@ -569,7 +711,12 @@ class View3D_OT_node_revolve(Operator, NodeOperator):
 
         build_revolve_node_group()
         bpy.ops.ed.undo_push(message="Add Revolve")
+        self.reset_booleans()
         return True
+
+    def fini(self, context: Context, succeede: bool):
+        if succeede:
+            self.finish_booleans(context)
 
     def get_point(self, context, index):
         # The axis is a picked edge, resolved to endpoints in set_props; there
@@ -627,7 +774,9 @@ class View3D_OT_node_revolve(Operator, NodeOperator):
 
         ids = _input_ids(modifier.node_group)
         self.angle = get_modifier_input(modifier, ids["Angle"])
-        self.angular_resolution = get_modifier_input(modifier, ids["Angular Resolution"])
+        self.angular_resolution = get_modifier_input(
+            modifier, ids["Angular Resolution"]
+        )
 
     def _has_stored_axis(self):
         return Vector(self.axis_direction).length > 1e-9
@@ -684,6 +833,7 @@ class View3D_OT_node_revolve(Operator, NodeOperator):
         row.prop(self, "angle")
         row.prop(self, "flip", text="", icon="ARROW_LEFTRIGHT")
         layout.prop(self, "angular_resolution")
+        self.draw_boolean_settings(layout)
 
 
 class View3D_OT_node_boolean(Operator, NodeOperator):
@@ -866,7 +1016,13 @@ class View3D_OT_node_boolean(Operator, NodeOperator):
         layout.prop(self, "hole_tolerant")
 
 
-register, unregister = register_stateops_factory(
+# Give the boolean-capable tools their shared boolean properties. Injected here
+# (not on the mixin) so they register on each operator: Blender collects an
+# operator's own annotations, not those of a non-registered base class.
+for _cls in (View3D_OT_node_extrude, View3D_OT_node_revolve):
+    _cls.__annotations__.update(_boolean_tool_annotations())
+
+_stateops_register, _stateops_unregister = register_stateops_factory(
     (
         View3D_OT_node_extrude,
         View3D_OT_node_array_linear,
@@ -874,3 +1030,14 @@ register, unregister = register_stateops_factory(
         View3D_OT_node_boolean,
     )
 )
+
+
+def register():
+    # BooleanTargetItem must exist before the operators' CollectionProperty binds.
+    bpy.utils.register_class(BooleanTargetItem)
+    _stateops_register()
+
+
+def unregister():
+    _stateops_unregister()
+    bpy.utils.unregister_class(BooleanTargetItem)

--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -192,11 +192,11 @@ class BooleanFromToolMixin:
     """
 
     def reset_booleans(self):
-        """Clear detection state for a fresh interactive run (call from init).
+        """Clear boolean state for a fresh interactive run (call from init).
 
-        Detection runs once per operation; the redo panel then edits the result.
-        init runs on invoke but not on the redo re-execute, so resetting here
-        preserves the user's redo-panel edits while a new invocation redetects.
+        init runs on invoke but not on the redo re-execute, so clearing here lets
+        a new invocation start clean while the redo panel keeps the user's edits
+        (their per-target toggles and operation override) across re-runs.
         """
         self.boolean_detected = False
         self.boolean_targets.clear()
@@ -206,10 +206,13 @@ class BooleanFromToolMixin:
         return getattr(self, "offset", 0.0)
 
     def finish_booleans(self, context):
-        """Detect targets once, then apply/remove the per-target booleans.
+        """Re-detect targets, then apply/remove the per-target booleans.
 
         The cutter is this tool's own object: its evaluated solid is read by the
-        boolean group through Object Info.
+        boolean group through Object Info. Detection re-runs on every execute (so a
+        redo that lengthens the extrude picks up bodies it now reaches), but the
+        user's per-target toggles are carried over, and the default operation is
+        seeded only on the first run so a manual override sticks.
         """
         cutter = getattr(self, "_obj", None) or self.resolved_object()
         if cutter is None:
@@ -225,38 +228,48 @@ class BooleanFromToolMixin:
 
         sketch = Sketch(cutter) if cutter.type == "CURVES" else None
 
+        # The solid must be evaluated before the overlap test can see it.
+        context.view_layer.update()
+        targets = detect_targets(context, cutter, sketch)
+
         if not self.boolean_detected:
-            # The solid must be evaluated before the overlap test can see it.
-            context.view_layer.update()
-            targets = detect_targets(context, cutter, sketch)
             has_source = sketch is not None and sketch_source_body(sketch) is not None
             self.operation = default_operation(self._boolean_offset(), has_source)
-            self.boolean_targets.clear()
-            for obj in targets:
-                item = self.boolean_targets.add()
-                item.name = obj.name
-                item.enabled = True
             self.boolean_detected = True
+
+        # Preserve exclusions across redo while adding newly-overlapping bodies; a
+        # target that drops out of detection loses its (now moot) boolean anyway.
+        prev_enabled = {item.name: item.enabled for item in self.boolean_targets}
+        self.boolean_targets.clear()
+        for obj in targets:
+            item = self.boolean_targets.add()
+            item.name = obj.name
+            item.enabled = prev_enabled.get(obj.name, True)
 
         self._apply_boolean_targets(cutter)
 
     def _apply_boolean_targets(self, cutter):
         name = boolean_modifier_name(cutter)
-        applied = False
+        enabled_bodies = set()
         for item in self.boolean_targets:
             body = bpy.data.objects.get(item.name)
             if body is None:
                 continue
-            existing = body.modifiers.get(name)
             if self.operation != "None" and item.enabled:
                 apply_boolean(body, cutter, self.operation)
-                applied = True
-            elif existing is not None:
-                # Excluded (or operation set to None): drop the boolean again.
-                body.modifiers.remove(existing)
+                enabled_bodies.add(body)
+        # Strip this cutter's boolean from every other body, so excluding a target,
+        # setting the operation to None, or a shorter extrude no longer reaching a
+        # body all remove its (now stale) boolean -- even if it left the list.
+        for body in bpy.data.objects:
+            if body in enabled_bodies:
+                continue
+            mod = body.modifiers.get(name)
+            if mod is not None:
+                body.modifiers.remove(mod)
         # A solid cutter sitting over the bodies would hide the result -- wireframe
         # it, matching the standalone Boolean tool.
-        if applied:
+        if enabled_bodies:
             cutter.display_type = "WIRE"
 
     def draw_boolean_settings(self, layout):

--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -69,6 +69,90 @@ def get_boolean_operation(modifier, identifier):
     return BOOLEAN_OPERATIONS[0]
 
 
+def boolean_modifier_name(cutter):
+    """Name of the boolean modifier that cuts ``cutter`` on a body.
+
+    One modifier per cutter, so several booleans stack on the same body instead
+    of overwriting each other.
+    """
+    return f"CAD_Sketcher Boolean {cutter.name}"
+
+
+def boolean_input_ids(node_group):
+    """Map ``{socket name: identifier}`` for the boolean group's inputs."""
+    return {
+        s.name: s.identifier
+        for s in node_group.interface.items_tree
+        if getattr(s, "in_out", "") == "INPUT"
+    }
+
+
+def boolean_cutters(obj):
+    """Objects ``obj`` reads as cutters through its CAD Sketcher booleans."""
+    from ..utilities.boolean_nodes import BOOLEAN_NODE_GROUP
+
+    cutters = []
+    for m in obj.modifiers:
+        group = getattr(m, "node_group", None)
+        if m.type != "NODES" or group is None or group.name != BOOLEAN_NODE_GROUP:
+            continue
+        cutter = get_modifier_input(m, boolean_input_ids(group)["Cutter"])
+        if cutter is not None:
+            cutters.append(cutter)
+    return cutters
+
+
+def creates_boolean_cycle(body, cutter):
+    """Whether making ``body`` read ``cutter`` closes a boolean dependency cycle.
+
+    True when ``cutter`` already depends (transitively) on ``body`` through other
+    CAD Sketcher booleans, including ``cutter is body`` (a length-0 cycle). Adding
+    such a modifier would close a depsgraph cycle, which crashes Blender.
+    """
+    stack = [cutter]
+    seen = set()
+    while stack:
+        obj = stack.pop()
+        if obj == body:
+            return True
+        if obj in seen:
+            continue
+        seen.add(obj)
+        stack.extend(boolean_cutters(obj))
+    return False
+
+
+def apply_boolean(
+    body, cutter, operation="Difference", self_intersection=True, hole_tolerant=False
+):
+    """Add or update a nondestructive boolean of ``cutter`` on ``body``.
+
+    Reuses the per-cutter modifier if it already exists (so re-applying edits it),
+    otherwise creates one. Returns the modifier, or None if the link would create
+    a dependency cycle. ``body`` and ``cutter`` must be original (not evaluated)
+    objects. The shared entry point for the Boolean tool and for the extrude /
+    revolve tools that boolean their result directly.
+    """
+    from ..utilities.boolean_nodes import build_boolean_node_group
+
+    if creates_boolean_cycle(body, cutter):
+        return None
+
+    ng = build_boolean_node_group()
+    name = boolean_modifier_name(cutter)
+    mod = body.modifiers.get(name)
+    if mod is None:
+        mod = body.modifiers.new(name, "NODES")
+    mod.node_group = ng
+
+    ids = boolean_input_ids(ng)
+    set_modifier_input(mod, ids["Cutter"], cutter)
+    set_boolean_operation(mod, ids["Operation"], operation)
+    set_modifier_input(mod, ids["Self Intersection"], self_intersection)
+    set_modifier_input(mod, ids["Hole Tolerant"], hole_tolerant)
+    return mod
+
+
 BASE_STATES = (
     state_from_args(
         "Object",
@@ -715,10 +799,10 @@ class View3D_OT_node_boolean(Operator, NodeOperator):
         # One modifier per cutter, so several booleans stack on the same body
         # instead of overwriting each other. Re-applying with the same cutter
         # edits its existing modifier (same name); a new cutter adds another.
-        return f"CAD_Sketcher Boolean {self._cutter.name}"
+        return boolean_modifier_name(self._cutter)
 
     def read_props(self, modifier):
-        ids = self._input_ids(modifier.node_group)
+        ids = boolean_input_ids(modifier.node_group)
         self.operation = get_boolean_operation(modifier, ids["Operation"])
         self.self_intersection = get_modifier_input(modifier, ids["Self Intersection"])
         self.hole_tolerant = get_modifier_input(modifier, ids["Hole Tolerant"])
@@ -747,7 +831,7 @@ class View3D_OT_node_boolean(Operator, NodeOperator):
         body = self.resolved_object()
         if body is not None:
             body = body.original
-        if self._creates_cycle(body, cutter):
+        if creates_boolean_cycle(body, cutter):
             self.report(
                 {"WARNING"},
                 "That cutter depends on the body; it would create a dependency cycle",
@@ -764,52 +848,9 @@ class View3D_OT_node_boolean(Operator, NodeOperator):
         if succeed and getattr(self, "_cutter", None) is not None:
             self._cutter.display_type = self.cutter_display
 
-    @staticmethod
-    def _input_ids(node_group):
-        return {
-            s.name: s.identifier
-            for s in node_group.interface.items_tree
-            if getattr(s, "in_out", "") == "INPUT"
-        }
-
-    @classmethod
-    def _boolean_cutters(cls, obj):
-        """Objects ``obj`` reads as cutters through its CAD Sketcher booleans."""
-        from ..utilities.boolean_nodes import BOOLEAN_NODE_GROUP
-
-        cutters = []
-        for m in obj.modifiers:
-            group = getattr(m, "node_group", None)
-            if m.type != "NODES" or group is None or group.name != BOOLEAN_NODE_GROUP:
-                continue
-            ids = cls._input_ids(group)
-            cutter = get_modifier_input(m, ids["Cutter"])
-            if cutter is not None:
-                cutters.append(cutter)
-        return cutters
-
-    @classmethod
-    def _creates_cycle(cls, body, cutter):
-        """Whether making ``body`` read ``cutter`` closes a boolean dependency
-        cycle, i.e. ``cutter`` already depends (transitively) on ``body``.
-
-        Also true when ``cutter is body`` (a self-reference is a length-0 cycle).
-        """
-        stack = [cutter]
-        seen = set()
-        while stack:
-            obj = stack.pop()
-            if obj == body:
-                return True
-            if obj in seen:
-                continue
-            seen.add(obj)
-            stack.extend(cls._boolean_cutters(obj))
-        return False
-
     def set_props(self):
         m = self.modifier
-        ids = self._input_ids(m.node_group)
+        ids = boolean_input_ids(m.node_group)
         set_modifier_input(m, ids["Cutter"], self._cutter)
         set_boolean_operation(m, ids["Operation"], self.operation)
         set_modifier_input(m, ids["Self Intersection"], self.self_intersection)

--- a/stateful_operator/invoke_op.py
+++ b/stateful_operator/invoke_op.py
@@ -1,6 +1,6 @@
 import bpy
-from bpy.types import Operator, Context
 from bpy.props import StringProperty
+from bpy.types import Context, Operator
 
 from .constants import Operators
 
@@ -28,7 +28,13 @@ class View3D_OT_invoke_tool(Operator):
             if p.startswith("_"):
                 continue
 
-            default = props.rna_type.properties[p].default
+            prop = props.rna_type.properties[p]
+            # Collection/pointer properties have no ``default`` and can't be
+            # forwarded as invoke options anyway; skip them (e.g. the extrude /
+            # revolve boolean-target collection).
+            if not hasattr(prop, "default"):
+                continue
+            default = prop.default
             value = getattr(props, p)
 
             # NOTE: Setting all values might mess around with operators that check
@@ -43,7 +49,10 @@ class View3D_OT_invoke_tool(Operator):
 
         parts = self.operator.split(".", 1)
         if len(parts) != 2:
-            self.report({"ERROR"}, f"Invalid operator id '{self.operator}': expected 'module.name'")
+            self.report(
+                {"ERROR"},
+                f"Invalid operator id '{self.operator}': expected 'module.name'",
+            )
             return {"CANCELLED"}
 
         module = getattr(bpy.ops, parts[0], None)

--- a/testing/test_boolean_nodes.py
+++ b/testing/test_boolean_nodes.py
@@ -10,6 +10,7 @@ import bpy
 
 from ..operators.modifiers import (
     View3D_OT_node_boolean,
+    boolean_input_ids,
     set_boolean_operation,
     set_modifier_input,
 )
@@ -150,7 +151,7 @@ class TestBooleanNodeGroup(BgsTestCase):
         # driving them the way it does must produce a real cut. Guards against the
         # operator and the group drifting apart.
         group = build_boolean_node_group()
-        ids = View3D_OT_node_boolean._input_ids(group)
+        ids = boolean_input_ids(group)
         for name in ("Cutter", "Operation", "Self Intersection", "Hole Tolerant"):
             self.assertIn(name, ids)
 
@@ -280,7 +281,7 @@ class TestBooleanNodeGroup(BgsTestCase):
         try:
             modifier = body.modifiers.new("CAD_Sketcher Boolean x", "NODES")
             modifier.node_group = group
-            ids = View3D_OT_node_boolean._input_ids(group)
+            ids = boolean_input_ids(group)
             set_boolean_operation(modifier, ids["Operation"], "Intersect")
             set_modifier_input(modifier, ids["Self Intersection"], False)
             set_modifier_input(modifier, ids["Hole Tolerant"], True)

--- a/testing/test_boolean_targets.py
+++ b/testing/test_boolean_targets.py
@@ -1,0 +1,81 @@
+"""Auto-detection of boolean targets and the default operation."""
+
+import types
+
+from ..utilities.boolean_targets import (
+    default_operation,
+    overlapping_bodies,
+    sketch_source_body,
+)
+from ..utilities.face_anchor import KEY_SOURCE
+from .utils import BgsTestCase
+
+# Cube surface as 6 quads over vertices ordered by (x<y<z) sign bits.
+_CUBE_FACES = [
+    (0, 1, 3, 2),
+    (4, 6, 7, 5),
+    (0, 4, 5, 1),
+    (2, 3, 7, 6),
+    (0, 2, 6, 4),
+    (1, 5, 7, 3),
+]
+
+
+class TestBooleanTargets(BgsTestCase):
+    def _box(self, name, center, half=1.0):
+        cx, cy, cz = center
+        verts = [
+            (cx + sx * half, cy + sy * half, cz + sz * half)
+            for sx in (-1, 1)
+            for sy in (-1, 1)
+            for sz in (-1, 1)
+        ]
+        me = self.data.meshes.new(name)
+        me.from_pydata(verts, [], _CUBE_FACES)
+        me.update()
+        ob = self.data.objects.new(name, me)
+        self.scene.collection.objects.link(ob)
+        self.context.view_layer.update()
+        return ob
+
+    def test_overlapping_bodies_finds_only_intersecting(self):
+        cutter = self._box("Cutter", (0, 0, 0))  # [-1,1]^3
+        overlap = self._box("Overlap", (1, 1, 1))  # [0,2]^3, interpenetrates
+        far = self._box("Far", (10, 0, 0))  # disjoint
+        depsgraph = self.context.evaluated_depsgraph_get()
+
+        hits = overlapping_bodies(cutter, [overlap, far], depsgraph)
+        self.assertEqual(hits, [overlap])
+
+    def test_overlap_ignores_a_profile_with_no_solid(self):
+        # A flat profile (no faces) can't participate: no BVH, no overlap.
+        cutter = self._box("Cutter2", (0, 0, 0))
+        me = self.data.meshes.new("FlatEdge")
+        me.from_pydata([(0.0, 0.0, 0.0), (0.5, 0.0, 0.0)], [(0, 1)], [])
+        me.update()
+        flat = self.data.objects.new("FlatEdge", me)
+        self.scene.collection.objects.link(flat)
+        self.context.view_layer.update()
+        depsgraph = self.context.evaluated_depsgraph_get()
+
+        self.assertEqual(overlapping_bodies(cutter, [flat], depsgraph), [])
+
+    def test_sketch_source_body_from_workplane_anchor(self):
+        body = self._box("Body", (0, 0, 0))
+        wp = self.data.objects.new("WP", None)  # empty
+        self.scene.collection.objects.link(wp)
+        wp[KEY_SOURCE] = body
+        sketch = types.SimpleNamespace(workplane_object=wp, target_object=None)
+
+        self.assertIs(sketch_source_body(sketch), body)
+
+        # No anchor -> None.
+        bare = types.SimpleNamespace(workplane_object=None, target_object=None)
+        self.assertIsNone(sketch_source_body(bare))
+
+    def test_default_operation_heuristic(self):
+        # Push out from the sketched face adds material; push in removes it.
+        self.assertEqual(default_operation(1.0, has_source_body=True), "Union")
+        self.assertEqual(default_operation(-1.0, has_source_body=True), "Difference")
+        # Without a source body to orient against, default to a cut.
+        self.assertEqual(default_operation(1.0, has_source_body=False), "Difference")

--- a/testing/test_boolean_targets.py
+++ b/testing/test_boolean_targets.py
@@ -143,3 +143,31 @@ class TestBooleanTargets(BgsTestCase):
             "the overlapping body must receive the cutter's boolean",
         )
         self.assertIsNone(far.modifiers.get(boolean_modifier_name(cutter)))
+
+    def test_apply_targets_strips_stale_boolean_from_dropped_body(self):
+        # On a redo re-run a body may leave the target list (a shorter extrude no
+        # longer reaches it, or the user excluded it). _apply_boolean_targets must
+        # remove its now-stale boolean even though it is not iterated as a target.
+        from ..operators.modifiers import (
+            BooleanFromToolMixin,
+            apply_boolean,
+            boolean_modifier_name,
+        )
+
+        cutter = self._box("Cutter", (0, 0, 0))
+        keep = self._box("Keep", (1, 1, 1))
+        dropped = self._box("Dropped", (1, 1, 1))
+        # Both start out carrying the cutter's boolean (from a previous run).
+        apply_boolean(keep, cutter, "Difference")
+        apply_boolean(dropped, cutter, "Difference")
+
+        # This run's targets list only mentions "keep"; "dropped" is gone from it.
+        item = types.SimpleNamespace(name="Keep", enabled=True)
+        fake = types.SimpleNamespace(operation="Difference", boolean_targets=[item])
+        BooleanFromToolMixin._apply_boolean_targets(fake, cutter)
+
+        name = boolean_modifier_name(cutter)
+        self.assertIsNotNone(keep.modifiers.get(name), "kept target stays booleaned")
+        self.assertIsNone(
+            dropped.modifiers.get(name), "dropped body's stale boolean is removed"
+        )

--- a/testing/test_boolean_targets.py
+++ b/testing/test_boolean_targets.py
@@ -79,3 +79,26 @@ class TestBooleanTargets(BgsTestCase):
         self.assertEqual(default_operation(-1.0, has_source_body=True), "Difference")
         # Without a source body to orient against, default to a cut.
         self.assertEqual(default_operation(1.0, has_source_body=False), "Difference")
+
+    def test_detect_then_apply_adds_boolean_to_overlapping_body(self):
+        # The core of finish_booleans: auto-detected targets get a boolean of the
+        # cutter (here without a source body, so overlap alone drives it).
+        from ..operators.modifiers import apply_boolean, boolean_modifier_name
+        from ..utilities.boolean_targets import detect_targets
+
+        cutter = self._box("Cutter", (0, 0, 0))  # [-1,1]^3
+        body = self._box("Body", (1, 1, 1))  # overlaps
+        far = self._box("Far", (10, 0, 0))  # does not
+
+        targets = detect_targets(self.context, cutter, None)
+        self.assertIn(body, targets)
+        self.assertNotIn(far, targets)
+        self.assertNotIn(cutter, targets)
+
+        for t in targets:
+            apply_boolean(t, cutter, "Difference")
+        self.assertIsNotNone(
+            body.modifiers.get(boolean_modifier_name(cutter)),
+            "the overlapping body must receive the cutter's boolean",
+        )
+        self.assertIsNone(far.modifiers.get(boolean_modifier_name(cutter)))

--- a/testing/test_boolean_targets.py
+++ b/testing/test_boolean_targets.py
@@ -38,6 +38,31 @@ class TestBooleanTargets(BgsTestCase):
         self.context.view_layer.update()
         return ob
 
+    def _gn_solid(self, name, center, half=1.0):
+        """A Curves object whose GN modifier OUTPUTS a cube.
+
+        Mimics an extruded/revolved sketch: the solid is Geometry-Nodes output on
+        a non-mesh object, so ``to_mesh``/``new_from_object`` raise on it and
+        detection must read the GN mesh from the depsgraph instance instead.
+        """
+        curves = self.data.hair_curves.new(name)
+        obj = self.data.objects.new(name, curves)
+        self.scene.collection.objects.link(obj)
+        ng = self.data.node_groups.new(name + "_ng", "GeometryNodeTree")
+        ng.interface.new_socket(
+            "Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry"
+        )
+        out = ng.nodes.new("NodeGroupOutput")
+        cube = ng.nodes.new("GeometryNodeMeshCube")
+        cube.inputs["Size"].default_value = (2 * half, 2 * half, 2 * half)
+        xf = ng.nodes.new("GeometryNodeTransform")
+        xf.inputs["Translation"].default_value = center
+        ng.links.new(cube.outputs["Mesh"], xf.inputs["Geometry"])
+        ng.links.new(xf.outputs["Geometry"], out.inputs["Geometry"])
+        obj.modifiers.new("Convert", "NODES").node_group = ng
+        self.context.view_layer.update()
+        return obj
+
     def test_overlapping_bodies_finds_only_intersecting(self):
         cutter = self._box("Cutter", (0, 0, 0))  # [-1,1]^3
         overlap = self._box("Overlap", (1, 1, 1))  # [0,2]^3, interpenetrates
@@ -46,6 +71,22 @@ class TestBooleanTargets(BgsTestCase):
 
         hits = overlapping_bodies(cutter, [overlap, far], depsgraph)
         self.assertEqual(hits, [overlap])
+
+    def test_gn_solid_cutter_overlaps_multiple_bodies(self):
+        # The real case: the cutter is a Curves object whose modifier OUTPUTS the
+        # solid (an extruded sketch). to_mesh() gives nothing for it, so detection
+        # must evaluate the GN geometry -- and it must find EVERY overlapping body,
+        # not just one (the "only detects one target" bug).
+        # The bodies poke transversally through the rod's side faces (half 0.5,
+        # so they cross rather than sit flush -- BVHTree.overlap needs a crossing).
+        cutter = self._gn_solid("Rod", (0.0, 0.0, 0.0))  # [-1,1]^3
+        b1 = self._box("B1", (1, 0, 0), half=0.5)  # crosses +X face
+        b2 = self._box("B2", (0, 1, 0), half=0.5)  # crosses +Y face
+        far = self._box("Far", (0, 0, 6), half=0.5)  # disjoint
+        depsgraph = self.context.evaluated_depsgraph_get()
+
+        hits = overlapping_bodies(cutter, [b1, b2, far], depsgraph)
+        self.assertEqual(set(hits), {b1, b2}, "must find both overlapping bodies")
 
     def test_overlap_ignores_a_profile_with_no_solid(self):
         # A flat profile (no faces) can't participate: no BVH, no overlap.

--- a/testing/test_migrate_modifiers.py
+++ b/testing/test_migrate_modifiers.py
@@ -6,7 +6,7 @@ modifiers become the addon's node tools with mapped parameters, and that
 unsupported modifiers are skipped and recorded.
 """
 
-from ..operators.modifiers import View3D_OT_node_boolean, get_modifier_input
+from ..operators.modifiers import boolean_input_ids, get_modifier_input
 from ..utilities.migrate import _migrate_modifiers
 from .utils import Sketch2dTestCase
 
@@ -61,7 +61,7 @@ class TestMigrateModifiers(Sketch2dTestCase):
             for m in self._sketch_mods()
             if m.node_group.name == "CAD Sketcher Boolean"
         )
-        ids = View3D_OT_node_boolean._input_ids(mod.node_group)
+        ids = boolean_input_ids(mod.node_group)
         self.assertEqual(get_modifier_input(mod, ids["Cutter"]), cutter)
         self.assertEqual(int(get_modifier_input(mod, ids["Operation"])), 1)  # Union
 

--- a/testing/test_migration.py
+++ b/testing/test_migration.py
@@ -131,7 +131,7 @@ class TestMigration(unittest.TestCase):
         # remap boolean cutters onto the migrated sketches, and delete the old
         # meshes so the geometry is not duplicated.
         from ..model.sketch_ref import is_sketch_object
-        from ..operators.modifiers import View3D_OT_node_boolean, get_modifier_input
+        from ..operators.modifiers import boolean_input_ids, get_modifier_input
 
         _open("CAD_Sketcher_Part.blend")
         sketches = list(get_sketches(bpy.context))
@@ -146,7 +146,7 @@ class TestMigration(unittest.TestCase):
                     extrudes += 1
                 elif name == "CAD Sketcher Boolean":
                     booleans += 1
-                    ids = View3D_OT_node_boolean._input_ids(m.node_group)
+                    ids = boolean_input_ids(m.node_group)
                     cutter = get_modifier_input(m, ids["Cutter"])
                     # The cutter is another migrated sketch, not an old mesh.
                     self.assertTrue(

--- a/utilities/boolean_targets.py
+++ b/utilities/boolean_targets.py
@@ -1,0 +1,158 @@
+"""Auto-detect boolean targets and a default operation for extrude/revolve.
+
+When a sketch is extruded/revolved into a solid, the "boolean directly from the
+tool" flow needs to know *which* bodies to cut/join and *whether* to cut or join.
+Two signals drive it:
+
+- Provenance: a sketch drawn on a mesh face records that body on its workplane
+  (``face_anchor``). It is the primary, unambiguous target -- push/pull into the
+  solid you sketched on.
+- Spatial overlap: the extruded solid is tested against candidate bodies so it
+  also cuts/joins everything it actually passes through (multiple targets).
+
+The operation (Difference/Union) is only a default here; the caller exposes it so
+the user can override it.
+"""
+
+import bpy
+from mathutils import Vector
+from mathutils.bvhtree import BVHTree
+
+from .face_anchor import KEY_SOURCE
+
+# Object types a boolean can operate on: a mesh, or a sketch/curve whose modifier
+# produces a solid mesh (read through Object Info in the boolean group).
+_BODY_TYPES = {"MESH", "CURVE", "CURVES"}
+
+
+def sketch_source_body(sketch):
+    """The body a face-anchored sketch was drawn on, or None.
+
+    Reads the workplane empty's ``slvs_wp_source`` (stamped by face_anchor when a
+    workplane is created from a mesh face). Free/base-plane sketches have none.
+    """
+    wp = getattr(sketch, "workplane_object", None)
+    if wp is None:
+        target = getattr(sketch, "target_object", None)
+        wp = target.parent if target is not None else None
+    if wp is None:
+        return None
+    source = wp.get(KEY_SOURCE)
+    return source if isinstance(source, bpy.types.Object) else None
+
+
+def _world_geometry(obj, depsgraph):
+    """Return ``(bvh, aabb_min, aabb_max)`` in world space, or None if no solid.
+
+    Built from the *evaluated* mesh, so it reflects the object's modifiers (a
+    sketch's fill, its extrude/revolve). Returns None when the object yields no
+    faces (e.g. a flat, unextruded profile), which can't participate in a boolean.
+    """
+    ev = obj.evaluated_get(depsgraph)
+    try:
+        mesh = ev.to_mesh()
+    except Exception:
+        return None
+    if mesh is None or len(mesh.polygons) == 0:
+        if mesh is not None:
+            ev.to_mesh_clear()
+        return None
+
+    mw = obj.matrix_world
+    verts = [mw @ v.co for v in mesh.vertices]
+    polys = [tuple(p.vertices) for p in mesh.polygons]
+    ev.to_mesh_clear()
+
+    lo = Vector(
+        (min(v.x for v in verts), min(v.y for v in verts), min(v.z for v in verts))
+    )
+    hi = Vector(
+        (max(v.x for v in verts), max(v.y for v in verts), max(v.z for v in verts))
+    )
+    return BVHTree.FromPolygons(verts, polys), lo, hi
+
+
+def _aabb_overlap(a, b):
+    """Whether two world-space AABBs (each ``(min, max)``) intersect."""
+    (a_lo, a_hi), (b_lo, b_hi) = a, b
+    return all(a_lo[i] <= b_hi[i] and b_lo[i] <= a_hi[i] for i in range(3))
+
+
+def overlapping_bodies(cutter, candidates, depsgraph):
+    """Subset of ``candidates`` whose solid geometry actually overlaps ``cutter``.
+
+    An AABB pre-filter (cheap, no BVH) gates the exact ``BVHTree.overlap`` test, so
+    the expensive check only runs on plausibly-touching bodies. Order preserved.
+    """
+    cutter_geo = _world_geometry(cutter, depsgraph)
+    if cutter_geo is None:
+        return []
+    cutter_bvh, cutter_lo, cutter_hi = cutter_geo
+
+    hits = []
+    for obj in candidates:
+        geo = _world_geometry(obj, depsgraph)
+        if geo is None:
+            continue
+        bvh, lo, hi = geo
+        if not _aabb_overlap((cutter_lo, cutter_hi), (lo, hi)):
+            continue
+        if cutter_bvh.overlap(bvh):
+            hits.append(obj)
+    return hits
+
+
+def candidate_bodies(context, cutter):
+    """Visible boolean-capable objects that are safe targets for ``cutter``.
+
+    Excludes the cutter itself, non-solid types, hidden objects, and anything that
+    would close a boolean dependency cycle (the cutter already depends on it).
+    """
+    from ..operators.modifiers import creates_boolean_cycle
+
+    result = []
+    for obj in context.view_layer.objects:
+        if obj == cutter or obj.type not in _BODY_TYPES:
+            continue
+        if not obj.visible_get():
+            continue
+        if creates_boolean_cycle(obj, cutter):
+            continue
+        result.append(obj)
+    return result
+
+
+def detect_targets(context, cutter, sketch, depsgraph=None):
+    """Ordered bodies to boolean ``cutter`` into: source body first, then overlaps.
+
+    The provenance source body (if any) leads and is included whether or not the
+    overlap test catches it; the remaining overlapping bodies follow. Deduplicated,
+    order stable.
+    """
+    if depsgraph is None:
+        depsgraph = context.evaluated_depsgraph_get()
+
+    candidates = candidate_bodies(context, cutter)
+    overlaps = overlapping_bodies(cutter, candidates, depsgraph)
+
+    ordered = []
+    source = sketch_source_body(sketch) if sketch is not None else None
+    if source is not None and source in candidates:
+        ordered.append(source)
+    for obj in overlaps:
+        if obj not in ordered:
+            ordered.append(obj)
+    return ordered
+
+
+def default_operation(offset, has_source_body):
+    """Guess Difference vs Union for the auto-detected targets.
+
+    Push/pull semantics: extruding *outward* from the face you sketched on adds
+    material (Union); extruding *into* the solid removes it (Difference). Without a
+    source body to orient against, default to Difference (the common "cut with this
+    shape"). Always a guess -- the caller lets the user override it.
+    """
+    if has_source_body and offset > 0.0:
+        return "Union"
+    return "Difference"

--- a/utilities/boolean_targets.py
+++ b/utilities/boolean_targets.py
@@ -41,35 +41,52 @@ def sketch_source_body(sketch):
     return source if isinstance(source, bpy.types.Object) else None
 
 
-def _world_geometry(obj, depsgraph):
-    """Return ``(bvh, aabb_min, aabb_max)`` in world space, or None if no solid.
+def _world_geometry_map(depsgraph, wanted):
+    """Map each object in ``wanted`` to ``(bvh, aabb_min, aabb_max)`` in world space.
 
-    Built from the *evaluated* mesh, so it reflects the object's modifiers (a
-    sketch's fill, its extrude/revolve). Returns None when the object yields no
-    faces (e.g. a flat, unextruded profile), which can't participate in a boolean.
+    Reads the *evaluated* geometry from depsgraph instances in a single pass. This
+    is what makes it work for a sketch: its extrude/revolve modifier OUTPUTS a mesh
+    from a Curves object, and that mesh surfaces as a depsgraph instance rather
+    than on the evaluated object (``to_mesh``/``new_from_object`` raise "does not
+    have geometry data" there). Objects yielding no faces (a flat, unextruded
+    profile) are simply absent from the map.
     """
-    ev = obj.evaluated_get(depsgraph)
-    try:
-        mesh = ev.to_mesh()
-    except Exception:
-        return None
-    if mesh is None or len(mesh.polygons) == 0:
-        if mesh is not None:
-            ev.to_mesh_clear()
-        return None
+    wanted = set(wanted)
+    accum = {}  # origin object -> ([world verts], [poly index tuples])
+    for inst in depsgraph.object_instances:
+        ob = inst.object
+        origin = (
+            inst.parent.original
+            if inst.is_instance and inst.parent is not None
+            else ob.original
+        )
+        if origin not in wanted:
+            continue
+        try:
+            mesh = ob.to_mesh()
+        except Exception:
+            mesh = None
+        if mesh is None or len(mesh.polygons) == 0:
+            if mesh is not None:
+                ob.to_mesh_clear()
+            continue
+        mw = inst.matrix_world
+        verts, polys = accum.setdefault(origin, ([], []))
+        base = len(verts)
+        verts.extend(mw @ v.co for v in mesh.vertices)
+        polys.extend(tuple(base + i for i in p.vertices) for p in mesh.polygons)
+        ob.to_mesh_clear()
 
-    mw = obj.matrix_world
-    verts = [mw @ v.co for v in mesh.vertices]
-    polys = [tuple(p.vertices) for p in mesh.polygons]
-    ev.to_mesh_clear()
-
-    lo = Vector(
-        (min(v.x for v in verts), min(v.y for v in verts), min(v.z for v in verts))
-    )
-    hi = Vector(
-        (max(v.x for v in verts), max(v.y for v in verts), max(v.z for v in verts))
-    )
-    return BVHTree.FromPolygons(verts, polys), lo, hi
+    result = {}
+    for obj, (verts, polys) in accum.items():
+        lo = Vector(
+            (min(v.x for v in verts), min(v.y for v in verts), min(v.z for v in verts))
+        )
+        hi = Vector(
+            (max(v.x for v in verts), max(v.y for v in verts), max(v.z for v in verts))
+        )
+        result[obj] = (BVHTree.FromPolygons(verts, polys), lo, hi)
+    return result
 
 
 def _aabb_overlap(a, b):
@@ -84,17 +101,18 @@ def overlapping_bodies(cutter, candidates, depsgraph):
     An AABB pre-filter (cheap, no BVH) gates the exact ``BVHTree.overlap`` test, so
     the expensive check only runs on plausibly-touching bodies. Order preserved.
     """
-    cutter_geo = _world_geometry(cutter, depsgraph)
+    geo = _world_geometry_map(depsgraph, [cutter, *candidates])
+    cutter_geo = geo.get(cutter)
     if cutter_geo is None:
         return []
     cutter_bvh, cutter_lo, cutter_hi = cutter_geo
 
     hits = []
     for obj in candidates:
-        geo = _world_geometry(obj, depsgraph)
-        if geo is None:
+        og = geo.get(obj)
+        if og is None:
             continue
-        bvh, lo, hi = geo
+        bvh, lo, hi = og
         if not _aabb_overlap((cutter_lo, cutter_hi), (lo, hi)):
             continue
         if cutter_bvh.overlap(bvh):

--- a/utilities/migrate.py
+++ b/utilities/migrate.py
@@ -294,7 +294,7 @@ def _translate_boolean(mod, old_mesh, obj, cutter_map=None):
     if cutter_map is not None:
         cutter = cutter_map.get(cutter, cutter)
     from ..operators.modifiers import (
-        View3D_OT_node_boolean,
+        boolean_input_ids,
         set_boolean_operation,
         set_modifier_input,
     )
@@ -303,7 +303,7 @@ def _translate_boolean(mod, old_mesh, obj, cutter_map=None):
     ng = build_boolean_node_group()
     m = obj.modifiers.new(f"CAD_Sketcher Boolean {cutter.name}", "NODES")
     m.node_group = ng
-    ids = View3D_OT_node_boolean._input_ids(ng)
+    ids = boolean_input_ids(ng)
     set_modifier_input(m, ids["Cutter"], cutter)
     op = {"DIFFERENCE": "Difference", "UNION": "Union", "INTERSECT": "Intersect"}[
         mod.operation


### PR DESCRIPTION
Extruding or revolving a sketch into a solid and then booleaning it into a body used to be two separate tool invocations. This lets the Extrude and Revolve tools boolean their result directly, auto-detecting the target bodies and a default operation, both editable in the redo panel.

## Behavior

- Extrude/revolve a sketch, and on release the solid is booleaned into the body you sketched on and into everything it overlaps (multiple targets).
- The operation (Difference / Union / Intersect / None) is auto-guessed but overridable in the redo panel.
- The detected targets are listed in the redo panel with a checkbox each; unchecking one removes its boolean.

## How it works

Three pieces:

- Reusable boolean core. ``apply_boolean(body, cutter, operation, ...)`` plus ``creates_boolean_cycle`` / ``boolean_cutters`` / ``boolean_input_ids`` are module functions in ``operators/modifiers.py``; the standalone Boolean tool and ``migrate.py`` now delegate to them (no behavior change).
- Auto-detection (``utilities/boolean_targets.py``). ``sketch_source_body`` reads the body a face-anchored sketch was drawn on (the workplane's ``slvs_wp_source``); ``overlapping_bodies`` runs an AABB pre-filter then ``BVHTree.overlap`` on the evaluated solids; ``detect_targets`` orders source first then overlaps, excluding the cutter, hidden objects and cycle-forming bodies; ``default_operation`` applies a push/pull heuristic (out of the sketched face adds material, into it removes).
- Tool wiring. A shared ``BooleanFromToolMixin`` gives Extrude and Revolve an ``operation`` enum, a ``boolean_targets`` collection and a ``boolean_detected`` flag. ``fini`` detects once, seeds the default operation, and applies/removes the per-target booleans; ``draw_settings`` renders the operation and the target toggle list. A boolean lives on the body's modifier stack (not the sketch's), so this chains a second modifier rather than baking it into the extrude/revolve group.

## Design notes

- The cutter (the extruded/revolved sketch) is switched to wireframe when it cuts something, matching the standalone Boolean tool.
- Detection runs once per operation, in ``init`` the state is reset so a fresh invoke redetects while the redo panel preserves the user's edits.
- ``None`` is offered so the tools can stay a plain solid.

## Tests

New ``testing/test_boolean_targets.py`` covers overlap detection (only intersecting bodies, ignores flat profiles), reading the workplane anchor, the mode heuristic, and an end-to-end detect then apply. Existing boolean/node/migration/revolve tests still pass (the refactor is a no-op).

## Not yet verified in the GUI

The interactive apply-on-release flow and, in particular, whether the redo-panel target-list collection renders its toggles and preserves exclusions across redo re-runs inside the stateful-operator framework. Reviewers should try: extrude a sketch overlapping a body, check the redo panel for the operation and target list, toggle a target off, flip the operation.
