### PR TITLE
Fill converted sketches with n-gons, not interior triangulation

### DIFF
--- a/testing/test_convert_nodes.py
+++ b/testing/test_convert_nodes.py
@@ -252,3 +252,70 @@ class TestConvertNodeGroup(TestCase):
             self.assertEqual(ng.get("cad_convert_version"), CONVERT_VERSION)
         finally:
             bpy.data.node_groups.remove(ng)
+
+    def _fill(self, loops):
+        """Evaluate the convert group with Fill on over closed wire ``loops``
+        (lists of (x, y) points) and return the filled mesh's bmesh."""
+        import bmesh
+
+        from ..operators.modifiers import set_modifier_input
+        from ..utilities.convert_nodes import build_convert_node_group
+
+        bm = bmesh.new()
+        for loop in loops:
+            vs = [bm.verts.new((x, y, 0.0)) for x, y in loop]
+            for k in range(len(vs)):
+                bm.edges.new((vs[k], vs[(k + 1) % len(vs)]))
+        me = bpy.data.meshes.new("wire")
+        bm.to_mesh(me)
+        bm.free()
+        ob = bpy.data.objects.new("wire", me)
+        bpy.context.scene.collection.objects.link(ob)
+
+        ng = build_convert_node_group("test_convert_fill")
+        mod = ob.modifiers.new("convert", "NODES")
+        mod.node_group = ng
+        ids = {s.name: s.identifier for s in ng.interface.items_tree
+               if s.in_out == "INPUT"}
+        set_modifier_input(mod, ids["Fill"], True)
+
+        dg = bpy.context.evaluated_depsgraph_get()
+        out = bmesh.new()
+        out.from_mesh(ob.evaluated_get(dg).to_mesh())
+        bpy.data.objects.remove(ob, do_unlink=True)
+        bpy.data.node_groups.remove(ng)
+        return out
+
+    def test_fill_is_ngon_not_triangulated(self):
+        # The fill should carry only the outline plus one face per region -- no
+        # interior triangulation. A simple square fills to a single quad with no
+        # interior edges.
+        bm = self._fill([[(-1, -1), (1, -1), (1, 1), (-1, 1)]])
+        try:
+            self.assertEqual(len(bm.faces), 1, "square should fill to one face")
+            self.assertEqual(
+                [len(f.verts) for f in bm.faces], [4], "face should be a quad"
+            )
+            interior = sum(1 for e in bm.edges if len(e.link_faces) == 2)
+            self.assertEqual(interior, 0, "no interior triangulation edges")
+        finally:
+            bm.free()
+
+    def test_holed_fill_has_no_triangulation(self):
+        # A region with a hole cannot be a single mesh face, so it splits into
+        # the fewest n-gons -- but still no triangles: every face has more than
+        # three sides.
+        bm = self._fill(
+            [
+                [(-1, -1), (1, -1), (1, 1), (-1, 1)],
+                [(-0.5, -0.5), (0.5, -0.5), (0.5, 0.5), (-0.5, 0.5)],
+            ]
+        )
+        try:
+            self.assertGreater(len(bm.faces), 0)
+            self.assertTrue(
+                all(len(f.verts) > 3 for f in bm.faces),
+                "holed fill must be n-gons, never triangulated",
+            )
+        finally:
+            bm.free()

--- a/utilities/convert_nodes.py
+++ b/utilities/convert_nodes.py
@@ -33,7 +33,7 @@ GENERATED_ID_VERSION = 2
 
 # Bump whenever the built node tree changes, so groups baked into existing files
 # (or a stale merge-by-distance asset of the same name) are rebuilt on load.
-CONVERT_VERSION = 5
+CONVERT_VERSION = 6
 
 _CHILD_ID_MULTIPLIER = 1_000_003
 _VERTEX_ROLE = 0x13579
@@ -244,6 +244,15 @@ def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
     links.new(merge.outputs["Geometry"], to_curve.inputs["Mesh"])
 
     fill_curve = nodes.new("GeometryNodeFillCurve")
+    # Fill with n-gons, not the default triangle fan: the filled sketch should
+    # carry only its outline plus a single face per region, with no interior
+    # triangulation edges. A region with a hole can't be one mesh face, so it
+    # splits into the fewest n-gons rather than triangulating. Blender 5.x
+    # exposes the mode as a "Mode" input socket (older trees, as a property).
+    if "Mode" in fill_curve.inputs:
+        fill_curve.inputs["Mode"].default_value = "N-gons"
+    else:  # pragma: no cover - pre-5.x fallback
+        fill_curve.mode = "NGONS"
     links.new(to_curve.outputs["Curve"], fill_curve.inputs["Curve"])
 
     switch = nodes.new("GeometryNodeSwitch")


### PR DESCRIPTION
## What

The CAD Sketcher Convert modifier's **Fill** now produces the sketch outline plus a single face per region using **n-gon** fill, instead of the default triangle fan. The converted mesh carries only its outline and fill — no interior triangulation edges.

Measured on the convert group output:

| filled sketch | before (triangles) | after (n-gons) |
|---|---|---|
| square | 2 triangles, 1 interior edge | **1 quad, 0 interior edges** |
| square with a hole | 8 triangles | **2 n-gons** (minimal split — a mesh face can't be multiply-connected), no triangles |

## Why

A filled sketch should read as the shape it is — one clean face for a simple outline — not a triangulated fan with visible diagonals. Interior triangulation is invisible to consumers that re-derive the boundary (revolve/extrude), unhelpful for display, and was the root of the original #634 revolve regression (swept interior edges). A region with a hole still can't be a single mesh face, so it splits into the fewest n-gons rather than triangulating.

## Notes

- `Fill Curve`'s mode is set via its `Mode` input socket on Blender 5.x (the addon's min version is 5.0), with a node-property fallback for older trees.
- Convert group version bumped 5 → 6 so groups baked into existing files rebuild in place on load.
- Independent of #641 (the revolve holed-profile fix); they touch different files and compose cleanly.

## Tests

Added to `test_convert_nodes.py`:
- filled square → exactly one quad face, zero interior edges (no triangulation)
- filled holed profile → all faces are n-gons (never triangulated)

All existing convert / nodes / boolean / revolve suites pass (60 tests).
