### PR TITLE
Cleaner sketch→mesh topology: single-segment lines, welded point entities

### DIFF
--- a/model/curve_ref.py
+++ b/model/curve_ref.py
@@ -547,6 +547,11 @@ class LineRef(CurveRef):
 
         set_attribute(attrs, "curve_id", cid, curve_idx)
         set_attribute(attrs, "sketch_type", SketchCurveType.LINE, curve_idx)
+        # A line is a straight two-point Bezier; evaluating it at the Bezier
+        # default resolution (12) tessellates it into 12 collinear segments for no
+        # benefit. Keep it a single segment so the generated mesh matches the
+        # sketch's own vertices (arcs/circles keep their curved resolution).
+        set_attribute(attrs, "resolution", 1, curve_idx)
         set_attribute(attrs, "start_point_id",
                       p1.curve_id if isinstance(p1, CurveRef) else "", curve_idx)
         set_attribute(attrs, "end_point_id",

--- a/testing/test_merge_id.py
+++ b/testing/test_merge_id.py
@@ -62,7 +62,7 @@ class TestMergeIds(Sketch2dTestCase):
         self.assertEqual(len(junctions), 4)
 
     def test_interior_and_center_points_stay_zero(self):
-        """Only segment endpoints carry a weld id; centers/points keep 0."""
+        """Centers and points no segment references keep 0 (never welded)."""
         p0 = self.add_point((0, 0), fixed=True)
         p1 = self.add_point((3, 0))
         p2 = self.add_point((0, 3))
@@ -78,6 +78,34 @@ class TestMergeIds(Sketch2dTestCase):
             if cid == p0.curve_id:
                 pidx = cd.curves[i].points[0].index
                 self.assertEqual(mid.data[pidx].value, 0)
+
+    def test_point_entity_welds_onto_referenced_corner(self):
+        """A point entity a segment references shares that junction's weld id, so
+        it collapses onto the corner instead of leaving a duplicate vertex."""
+        from ..utilities.curve_data import compute_merge_ids
+
+        p0 = self.add_point((0, 0))
+        p1 = self.add_point((1, 0))
+        self.add_line(p0, p1)
+        compute_merge_ids(self.sketch)
+
+        cd = self.sketch.target_object.data
+        ta = cd.attributes.get("sketch_type")
+        mid = cd.attributes.get("merge_id")
+        point_id = endpoint_id = None
+        for i in range(len(cd.curves)):
+            t = ta.data[i].value
+            pts = cd.curves[i].points
+            if t == SketchCurveType.POINT and get_uuid(cd, "curve_id", i) == p0.curve_id:
+                point_id = mid.data[pts[0].index].value
+            elif (
+                t == SketchCurveType.LINE
+                and get_uuid(cd, "start_point_id", i) == p0.curve_id
+            ):
+                endpoint_id = mid.data[pts[0].index].value
+        self.assertIsNotNone(point_id)
+        self.assertGreater(point_id, 0, "a referenced point entity must weld")
+        self.assertEqual(point_id, endpoint_id, "point and corner share the weld id")
 
     def test_uuid_derived_seeds_survive_neighbor_insert_and_remove(self):
         from ..utilities.curve_data import (

--- a/utilities/convert_nodes.py
+++ b/utilities/convert_nodes.py
@@ -33,7 +33,7 @@ GENERATED_ID_VERSION = 2
 
 # Bump whenever the built node tree changes, so groups baked into existing files
 # (or a stale merge-by-distance asset of the same name) are rebuilt on load.
-CONVERT_VERSION = 5
+CONVERT_VERSION = 6
 
 _CHILD_ID_MULTIPLIER = 1_000_003
 _VERTEX_ROLE = 0x13579
@@ -215,14 +215,16 @@ def build_convert_node_group(name: str = CONVERT_NODE_GROUP):
     links.new(delete.outputs["Geometry"], to_mesh.inputs["Curve"])
 
     # 3. Weld by identity: merge vertices sharing merge_id, but only true segment
-    #    endpoints (valence 1 on the disconnected chains) -- tessellated interior
-    #    vertices (valence 2) are excluded, so their interpolated id is harmless.
+    #    endpoints (valence 1) and standalone point entities (valence 0) -- both
+    #    have fewer than two neighbours. Tessellated interior vertices (valence 2)
+    #    are excluded, so their interpolated id is harmless. Welding valence-0
+    #    points lets a point entity collapse onto the coincident segment corner.
     merge_id = nodes.new("GeometryNodeInputNamedAttribute")
     merge_id.data_type = "INT"
     merge_id.inputs["Name"].default_value = "merge_id"
 
     neighbors = nodes.new("GeometryNodeInputMeshVertexNeighbors")
-    is_end, end_a = _int_compare(nodes, links, "EQUAL", 1)
+    is_end, end_a = _int_compare(nodes, links, "LESS_THAN", 2)
     links.new(neighbors.outputs["Vertex Count"], end_a)
 
     # id 0 means "no weld". Exclude it so a not-yet-computed merge_id (e.g. a

--- a/utilities/curve_data.py
+++ b/utilities/curve_data.py
@@ -772,14 +772,19 @@ def compute_merge_ids(sketch):
     # id), so read the raw id tuples and skip the per-curve hex formatting.
     sp_ids = read_uuid_raw_list(cd, "start_point_id")
     ep_ids = read_uuid_raw_list(cd, "end_point_id")
+    # A standalone point entity's own curve_id is the id that segments reference
+    # through start/end_point_id, so it joins the same junction and welds onto the
+    # shared corner instead of sitting as a duplicate vertex.
+    curve_ids = read_uuid_raw_list(cd, "curve_id")
 
     ids = np.zeros(n_points, dtype=np.int32)
     dense = {}
 
     def junction(u):
-        # 1-based so 0 stays the "no weld" default for interior/point/circle.
+        # 1-based so 0 stays the "no weld" default for interior/circle vertices.
         return dense.setdefault(u, len(dense) + 1)
 
+    # First, junctions from the segments' referenced endpoints.
     for i in range(len(cd.curves)):
         t = type_attr.data[i].value
         if t not in (SketchCurveType.LINE, SketchCurveType.ARC):
@@ -792,6 +797,19 @@ def compute_merge_ids(sketch):
             ids[cv.points[0].index] = junction(sp_ids[i])
         if any(ep_ids[i]):
             ids[cv.points[npt - 1].index] = junction(ep_ids[i])
+
+    # Then weld each standalone point entity onto its coincident corner -- but
+    # only when a segment actually references it. A lone point or an arc/circle
+    # center that no segment endpoint uses stays 0 (never welded).
+    for i in range(len(cd.curves)):
+        if type_attr.data[i].value != SketchCurveType.POINT:
+            continue
+        cv = cd.curves[i]
+        if cv.points_length < 1:
+            continue
+        jid = dense.get(curve_ids[i])
+        if jid is not None:
+            ids[cv.points[0].index] = jid
 
     attr = cd.attributes.get("merge_id")
     if attr is None:


### PR DESCRIPTION
Two independent conversion-topology fixes so the generated mesh matches the sketch's own vertices instead of an inflated, duplicated set. Motivated by custom-attribute work (#639) — POINT attributes were being interpolated across needless tessellation and averaged/lost at unwelded corners — but these help all conversion.

## 1. Straight lines are a single segment
Sketch curves are created as BEZIER and inherit Blender's default resolution (12), so `Curve to Mesh` tessellated every straight line into 12 collinear segments. A 4-corner rectangle became **48 wire verts**. Now lines are created with `resolution = 1`; arcs/circles keep their curved resolution. The rectangle converts to **4 verts**.

## 2. Point entities weld onto their corner
The native model stores each entity as its own curve, so a corner shared by a point entity and two lines is 3 coincident vertices. `compute_merge_ids` only tagged segment endpoints, leaving point entities at `merge_id = 0` — never welded, sitting as duplicate/isolated vertices (and, for attributes, their authored value never reached the surface).

Now a point entity whose `curve_id` a segment actually references joins that junction and welds onto the corner; the convert's weld gate is relaxed from valence == 1 to < 2 so the valence-0 point vertex is included. A lone point or an arc/circle center that no segment references still stays `merge_id = 0` (never welded).

## Tests
- `test_point_entity_welds_onto_referenced_corner`: a referenced point entity shares the segment corner's weld id.
- `test_interior_and_center_points_stay_zero` kept (centers/unreferenced points stay 0).
- Full suite: 303 pass, ruff clean.