### PR TITLE
Extrude non-filled sketches into open walls

### DIFF
--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -521,6 +521,11 @@ class View3D_OT_node_extrude(Operator, BooleanFromToolMixin, NodeOperator):
     def init(self, context: Context, event: Event):
         if not super().init(context, event):
             return False
+        # Teach the shipped face-extrude asset to turn a non-filled (wire) profile
+        # into open walls; a no-op on groups already carrying the patch.
+        from ..utilities.extrude_nodes import ensure_extrude_edge_walls
+
+        ensure_extrude_edge_walls(bpy.data.node_groups.get(self.NODEGROUP_NAME))
         self.reset_booleans()
         return True
 

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -348,6 +348,29 @@ class TestNodeTools(BgsTestCase):
         z1 = self._extent(self._eval_mesh(ob), "z")
         self.assertGreater(z1, z0 + 0.5)
 
+    def test_extrude_unfilled_wire_becomes_walls(self):
+        # A non-filled profile converts to a face-less wire; the extrude tool must
+        # extrude its edges into open walls with real thickness instead of doing
+        # nothing (the face-only asset silently produced no geometry before).
+        from ..utilities.extrude_nodes import ensure_extrude_edge_walls
+
+        self.assertTrue(am.load_asset(LIB_NAME, "node_groups", EXTRUDE))
+        ensure_extrude_edge_walls(bpy.data.node_groups.get(EXTRUDE))
+
+        me = bpy.data.meshes.new("wire")
+        me.from_pydata(
+            [(0, 0, 0), (2, 0, 0), (2, 2, 0), (0, 2, 0)],
+            [(0, 1), (1, 2), (2, 3), (3, 0)],
+            [],
+        )
+        me.update()
+        ob = self._link("wire", me)
+        mod = self._add_node_mod(ob, EXTRUDE)
+        set_modifier_input(mod, "Input_2", 1.5)  # Size
+        out = self._eval_mesh(ob)
+        self.assertGreater(len(out.polygons), 0, "no walls created from wire")
+        self.assertAlmostEqual(self._extent(out, "z"), 1.5, delta=0.01)
+
     def test_array_multiplies_geometry(self):
         self.assertTrue(am.load_asset(LIB_NAME, "node_groups", ARRAY))
         ob = self._cube()

--- a/utilities/extrude_nodes.py
+++ b/utilities/extrude_nodes.py
@@ -1,0 +1,109 @@
+"""Edge-extrude fallback for the shipped ``CAD Sketcher Extrude`` asset.
+
+The asset extrudes faces (a filled profile becomes a capped solid). A non-filled
+sketch converts to a bare wire mesh -- edges, no faces -- so the face extrude has
+nothing to act on and the tool silently produces no geometry.
+
+``ensure_extrude_edge_walls`` patches the loaded group in place (idempotent,
+version-gated, mirroring ``convert_nodes.ensure_generated_id_nodes``): when the
+input carries no faces it extrudes the boundary edges along local +Z by ``Size``
+into open walls, honouring the ``Mirror Extrude`` toggle. Filled input is
+untouched -- it still flows through the original face-extrude path.
+"""
+
+import bpy
+
+EXTRUDE_NODE_GROUP = "CAD Sketcher Extrude"
+# Bump when the patched sub-graph changes so groups baked into saved files upgrade.
+EXTRUDE_EDGE_WALLS_VERSION = 1
+
+
+def _group_input(nodes):
+    return next((n for n in nodes if n.bl_idname == "NodeGroupInput"), None)
+
+
+def _group_output(nodes):
+    return next((n for n in nodes if n.bl_idname == "NodeGroupOutput"), None)
+
+
+def ensure_extrude_edge_walls(node_group):
+    """Add the face-less wall path to the extrude group once, and return it."""
+    if node_group is None:
+        return node_group
+    if node_group.get("cad_extrude_edge_walls_version") == EXTRUDE_EDGE_WALLS_VERSION:
+        return node_group
+
+    nodes, links = node_group.nodes, node_group.links
+    gi = _group_input(nodes)
+    go = _group_output(nodes)
+    if gi is None or go is None:
+        return node_group
+    geo_out = go.inputs.get("Geometry")
+    if geo_out is None or not geo_out.links:
+        return node_group
+
+    # The face-extrude result currently wired to the output; keep it for filled
+    # input (the branch we fall back to when the profile has faces).
+    faces_result = geo_out.links[0].from_socket
+
+    geometry = gi.outputs["Geometry"]
+    size = gi.outputs["Size"]
+    mirror = gi.outputs["Mirror Extrude"]
+
+    # No faces on the input? Then it's a wire profile to turn into walls.
+    domain = nodes.new("GeometryNodeAttributeDomainSize")
+    domain.component = "MESH"
+    links.new(geometry, domain.inputs["Geometry"])
+    no_faces = nodes.new("FunctionNodeCompare")
+    no_faces.data_type = "INT"
+    no_faces.operation = "EQUAL"
+    a, b = (s for s in no_faces.inputs if s.enabled and s.type == "INT")
+    b.default_value = 0
+    links.new(domain.outputs["Face Count"], a)
+
+    def edge_walls(sign):
+        # Wire wire edges have no usable normal, so the extrude Offset must be an
+        # explicit vector -- a constant socket default is ignored and the edges
+        # would extrude flat. Drive local Z from Size so walls rise perpendicular
+        # to the sketch plane (matching the face path's normal-up direction).
+        combine = nodes.new("ShaderNodeCombineXYZ")
+        if sign < 0:
+            negate = nodes.new("ShaderNodeMath")
+            negate.operation = "MULTIPLY"
+            negate.inputs[1].default_value = -1.0
+            links.new(size, negate.inputs[0])
+            links.new(negate.outputs["Value"], combine.inputs["Z"])
+        else:
+            links.new(size, combine.inputs["Z"])
+
+        extrude = nodes.new("GeometryNodeExtrudeMesh")
+        extrude.mode = "EDGES"
+        links.new(geometry, extrude.inputs["Mesh"])
+        links.new(combine.outputs["Vector"], extrude.inputs["Offset"])
+        return extrude.outputs["Mesh"]
+
+    up = edge_walls(1.0)
+    # Mirror: also extrude down and weld the shared source loop, so the walls span
+    # -Size..+Size instead of 0..+Size.
+    down = edge_walls(-1.0)
+    join = nodes.new("GeometryNodeJoinGeometry")
+    links.new(up, join.inputs["Geometry"])
+    links.new(down, join.inputs["Geometry"])
+    weld = nodes.new("GeometryNodeMergeByDistance")
+    links.new(join.outputs["Geometry"], weld.inputs["Geometry"])
+
+    mirror_switch = nodes.new("GeometryNodeSwitch")
+    mirror_switch.input_type = "GEOMETRY"
+    links.new(mirror, mirror_switch.inputs["Switch"])
+    links.new(up, mirror_switch.inputs["False"])
+    links.new(weld.outputs["Geometry"], mirror_switch.inputs["True"])
+
+    final = nodes.new("GeometryNodeSwitch")
+    final.input_type = "GEOMETRY"
+    links.new(no_faces.outputs["Result"], final.inputs["Switch"])
+    links.new(faces_result, final.inputs["False"])
+    links.new(mirror_switch.outputs["Output"], final.inputs["True"])
+    links.new(final.outputs["Output"], geo_out)
+
+    node_group["cad_extrude_edge_walls_version"] = EXTRUDE_EDGE_WALLS_VERSION
+    return node_group

--- a/utilities/migrate.py
+++ b/utilities/migrate.py
@@ -275,6 +275,9 @@ def _translate_solidify(mod, old_mesh, obj):
     ng = _load_node_group("CAD Sketcher Extrude")
     if ng is None:
         return False
+    from .extrude_nodes import ensure_extrude_edge_walls
+
+    ensure_extrude_edge_walls(ng)
     m = obj.modifiers.new("CAD_Sketcher Extrude", "NODES")
     m.node_group = ng
     set_modifier_input(m, "Input_2", float(mod.thickness))  # Size


### PR DESCRIPTION
Extruding a non-filled sketch did nothing: the profile converts to a face-less wire mesh, and the shipped *CAD Sketcher Extrude* asset is faces-only, so there was nothing to extrude. (Before the recent convert change the non-fill branch emitted an actual Curve, surfacing as the modifier error `Input geometry has unsupported type: Curve`; it now fails silently instead.)

**Fix:** a version-gated patch (`utilities/extrude_nodes.py`, mirroring `ensure_generated_id_nodes`) augments the loaded extrude group with an edge path. When the input carries no faces it extrudes the boundary edges along local +Z by `Size` into open walls (honouring the `Mirror Extrude` toggle); filled input is untouched and still becomes a capped solid. Applied on both the operator and migration paths.

Verified on a rectangle profile:
- filled → capped solid, `z=Size` (unchanged)
- non-filled → open walls, `z=Size`
- non-filled + mirror → walls spanning ±Size

Adds `test_extrude_unfilled_wire_becomes_walls`. Full suite: 332 passing.

Note: asymmetry override isn't yet applied to the wall path (falls back to symmetric); can follow up if wanted.