### PR TITLE
Re-editable object pointers (redo-panel eyedropper)

### DIFF
--- a/draw_handler.py
+++ b/draw_handler.py
@@ -148,10 +148,12 @@ def draw_hover_element():
 
     context = bpy.context
 
-    # Only while a hover tool is active; otherwise clear stale hover so the
-    # highlight doesn't linger after switching tools.
+    # While a hover tool is active, or any pick is in progress (the redo-panel
+    # eyedropper re-pick publishes hover_types without switching tools).
+    # Otherwise clear stale hover so the highlight doesn't linger after switching.
     tool = context.workspace.tools.from_space_view3d_mode(context.mode)
-    if tool is None or tool.widget != GizmoGroups.ObjectHover.value:
+    tool_active = tool is not None and tool.widget == GizmoGroups.ObjectHover.value
+    if not tool_active and global_data.hover_types is None:
         global_data.hover_element = None
         return
 

--- a/gizmos/object_hover.py
+++ b/gizmos/object_hover.py
@@ -126,6 +126,12 @@ class VIEW3D_GGT_slvs_object_hover(GizmoGroup):
 
     @classmethod
     def poll(cls, context):
+        # Stay active during any pick, even when the workspace tool isn't ours:
+        # the redo-panel eyedropper re-pick publishes hover_types without
+        # switching tools, and hover highlight should still work for it. When no
+        # pick is running, fall back to the tool check (which unlinks us).
+        if global_data.hover_types is not None:
+            return True
         return context_mode_check(context, cls.bl_idname)
 
     def setup(self, context):

--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -323,11 +323,24 @@ class NodeOperator(Operator3d):
     # Message shown when the resolved target fails is_valid_target().
     invalid_target_msg = "Invalid target object"
 
-    # Persisted target so the redo panel (which re-runs execute() on a fresh
-    # instance, losing the transient pointer state) can re-resolve the object
-    # and edit the existing modifier instead of failing. Not SKIP_SAVE: it must
-    # survive redo; main() overwrites it every run so a stale value is harmless.
+    # Expose the redo-panel eyedropper (framework edit-state re-entry) so a
+    # finished node op can be re-pointed at a different object/cutter. Object
+    # pointers need none of the entity stable-id machinery -- re-apply just
+    # relocates the modifier (see _prepare_edit / main).
+    editable = True
+
+    # Persisted target so the redo panel (a fresh instance) can re-resolve the
+    # object and edit the existing modifier: the pointer props rebuild
+    # ``self.object`` on the edit path, and this is a plain fallback for value
+    # tweaks. Not SKIP_SAVE; main() overwrites it every run.
     target_name: StringProperty(options={"HIDDEN"})
+
+    # What this op's modifier was applied to before an eyedropper re-point (the
+    # object + the modifier name). Stamped by _prepare_edit so main() can drop
+    # that now-stale modifier and move it to the re-picked target instead of
+    # leaving an orphan. SKIP_SAVE: only meaningful during the edit re-pick.
+    previous_target: StringProperty(options={"HIDDEN", "SKIP_SAVE"})
+    previous_modifier: StringProperty(options={"HIDDEN", "SKIP_SAVE"})
 
     @classmethod
     def poll(cls, context):
@@ -342,12 +355,68 @@ class NodeOperator(Operator3d):
         # for non-entity pointers (it breaks the redo panel and redo_states).
         return None
 
-    def resolved_object(self):
-        """The object to operate on: the live pointer, else the persisted name.
+    def _prepare_pick_ui(self, context):
+        # The object-hover gizmo drives the pick highlight, but it's unlinked
+        # while a non-sketcher tool (e.g. Select) is active. Link it so the
+        # eyedropper re-pick shows hover highlight.
+        from ..declarations import GizmoGroups
 
-        On the interactive path the base Object state resolves ``self.object``;
-        on the redo path that pointer is gone, so fall back to ``target_name``.
-        """
+        context.window_manager.gizmo_group_type_ensure(GizmoGroups.ObjectHover.value)
+
+        # Re-picking a mesh element (e.g. the revolve axis edge) needs the base
+        # geometry, but the tool's modifier shows the *result* -- the profile's
+        # own edges are hidden and not ray-castable. Temporarily disable it so
+        # those edges are visible and pickable; restored in _finish_pick_ui.
+        self._hidden_modifier = None
+        state = self.get_states()[self.edit_state]
+        ob = self.resolved_object()
+        if Object not in state.types and ob is not None:  # a mesh-element pointer
+            mod = ob.modifiers.get(self._modifier_name())
+            if mod is not None and mod.show_viewport:
+                mod.show_viewport = False
+                self._hidden_modifier = (ob.name, mod.name)
+                ob.update_tag()
+                context.view_layer.update()  # force the viewport to drop the result now
+
+    def _maintain_pick_ui(self, context):
+        # The redo-panel re-run (execute of the previous op) reverts the modifier
+        # we hid in _prepare_pick_ui. Re-hide it so the base geometry stays
+        # visible/pickable for the whole re-pick.
+        hidden = getattr(self, "_hidden_modifier", None)
+        if not hidden:
+            return
+        ob = bpy.data.objects.get(hidden[0])
+        mod = ob.modifiers.get(hidden[1]) if ob else None
+        if mod is not None and mod.show_viewport:
+            mod.show_viewport = False
+            ob.update_tag()
+            context.view_layer.update()
+
+    def _finish_pick_ui(self, context):
+        hidden = getattr(self, "_hidden_modifier", None)
+        if not hidden:
+            return
+        ob = bpy.data.objects.get(hidden[0])
+        mod = ob.modifiers.get(hidden[1]) if ob else None
+        if mod is not None:
+            mod.show_viewport = True
+            ob.update_tag()
+        self._hidden_modifier = None
+
+    def _update_pick_hover(self, context, coords):
+        from .. import global_data
+        from ..gizmos.object_hover import detect_hover
+
+        element = detect_hover(context, coords, global_data.hover_types)
+        if element != global_data.hover_element:
+            global_data.hover_element = element
+            if context.area:
+                context.area.tag_redraw()
+
+    def resolved_object(self):
+        """The object to operate on: the live/restored pointer, else the
+        persisted name. The pointer props rebuild ``self.object`` on the redo/edit
+        path; ``target_name`` is a plain fallback."""
         ob = self.object
         if ob is None and self.target_name:
             ob = bpy.data.objects.get(self.target_name)
@@ -411,7 +480,11 @@ class NodeOperator(Operator3d):
                 self.report({"ERROR"}, f'Cannot load asset "{rName}" from library')
                 return False
 
-        bpy.ops.ed.undo_push(message=f'Load Asset "{rName}"')
+        # Don't push undo on the eyedropper re-pick path (edit_state >= 0):
+        # calling ed.undo_push while entering a modal from the redo panel hangs
+        # Blender. init still loads the asset so the re-apply has the group.
+        if self.edit_state < 0:
+            bpy.ops.ed.undo_push(message=f'Load Asset "{rName}"')
         return True
 
     def _modifier_name(self):
@@ -440,6 +513,16 @@ class NodeOperator(Operator3d):
         self.modifier.node_group = nodegroup
         return True
 
+    def _prepare_edit(self, context):
+        """Edit re-pick (framework hook): remember the object + modifier name we
+        are editing away from, so main() drops that modifier if the re-pick lands
+        on a different object -- or changes a per-cutter name. Harmless when a
+        non-target state is edited: main only acts when it actually changes."""
+        ob = self.resolved_object()
+        if ob is not None:
+            self.previous_target = ob.name
+            self.previous_modifier = self._modifier_name()
+
     def main(self, context):
         ob = self.resolved_object()
         if not self.is_valid_target(ob):
@@ -447,10 +530,22 @@ class NodeOperator(Operator3d):
             return False
 
         # Persist the target and keep a resolved reference for this run so
-        # _ensure_modifier / set_props work on both the interactive and redo
-        # paths without going through the (redo-transient) pointer state.
+        # _ensure_modifier / set_props don't re-resolve the pointer repeatedly.
         self.target_name = ob.name
         self._obj = ob
+
+        # Re-pointed via the eyedropper: move the modifier here by dropping it
+        # from the object/name it used to be on (see _prepare_edit).
+        if self.previous_target and (
+            self.previous_target != ob.name
+            or self.previous_modifier != self._modifier_name()
+        ):
+            prev = bpy.data.objects.get(self.previous_target)
+            if prev is not None:
+                old = prev.modifiers.get(self.previous_modifier)
+                if old is not None:
+                    prev.modifiers.remove(old)
+                    prev.update_tag()
 
         if not self._ensure_modifier(context):
             return False
@@ -728,7 +823,8 @@ class View3D_OT_node_revolve(Operator, BooleanFromToolMixin, NodeOperator):
         from ..utilities.revolve_nodes import build_revolve_node_group
 
         build_revolve_node_group()
-        bpy.ops.ed.undo_push(message="Add Revolve")
+        if self.edit_state < 0:  # not on the eyedropper re-pick (see NodeOperator.init)
+            bpy.ops.ed.undo_push(message="Add Revolve")
         self.reset_booleans()
         return True
 
@@ -942,15 +1038,26 @@ class View3D_OT_node_boolean(Operator, NodeOperator):
         from ..utilities.boolean_nodes import build_boolean_node_group
 
         build_boolean_node_group()
-        bpy.ops.ed.undo_push(message="Add Boolean")
+        if self.edit_state < 0:  # not on the eyedropper re-pick (see NodeOperator.init)
+            bpy.ops.ed.undo_push(message="Add Boolean")
         return True
+
+    def _prepare_edit(self, context):
+        # Resolve the current cutter so the base's _prepare_edit can stamp the
+        # per-cutter modifier name it is editing away from (self._cutter is what
+        # _modifier_name reads, and it is otherwise only set in main()).
+        cutter = self._resolve_cutter(context)
+        if cutter is None:
+            return
+        self._cutter = cutter
+        super()._prepare_edit(context)
 
     def _resolve_cutter(self, context: Context):
         """The cutter object: the picked pointer, else the persisted name (redo).
 
-        Mirrors ``resolved_object`` for the body: the ``cutter`` pointer state
-        carries the interactive/prefilled pick, and ``cutter_name`` restores it
-        on the redo path where the pointer is gone.
+        Like the base Object pointer, the ``cutter`` pointer state carries the
+        interactive/prefilled pick and is rebuilt from the persisted pointer
+        props on redo; ``cutter_name`` is a further fallback.
         """
         cutter = getattr(self, "cutter", None)
         if cutter is not None:
@@ -1026,8 +1133,9 @@ class View3D_OT_node_boolean(Operator, NodeOperator):
         return True
 
     def draw_settings(self, context):
+        # The Cutter pointer is drawn (with its eyedropper) by the framework's
+        # per-state row; only the non-pointer options belong here.
         layout = self.layout
-        layout.prop_search(self, "cutter_name", bpy.data, "objects", text="Cutter")
         layout.prop(self, "operation")
         layout.prop(self, "cutter_display")
         layout.prop(self, "self_intersection")

--- a/stateful_operator/integration.py
+++ b/stateful_operator/integration.py
@@ -8,8 +8,13 @@ Add integration with native blender types, following are supported:
 """
 
 
-from .logic import StatefulOperatorLogic
+from typing import Optional
+
+import bpy
+from bpy.types import Context
+
 from .constants import mesh_element_types
+from .logic import StatefulOperatorLogic
 from .utilities.generic import get_pointer_get_set, to_list
 from .utilities.geometry import (
     get_evaluated_obj,
@@ -18,10 +23,94 @@ from .utilities.geometry import (
     get_scale_from_pos,
 )
 
-import bpy
-from bpy.types import Context
 
-from typing import Optional, Any
+class PointerKind:
+    """Handles one family of pointer types for get/set_state_pointer.
+
+    A pointer state stores a picked element's identity in ``_state_data``; the
+    handler that ``handles`` the stored ``type`` knows how to read it back
+    (``resolve``), write it (``store``), and which concrete type names it can
+    rebuild on redo (``type_registry``). Registering handlers (see
+    ``_pointer_handlers``) replaces the old per-type if/elif chains and the
+    call-super-then-fall-through ladder between the native and extension layers.
+    """
+
+    # Base types this handler owns (matched by issubclass).
+    types = ()
+
+    def handles(self, ptype):
+        return isinstance(ptype, type) and issubclass(ptype, self.types)
+
+    def type_registry(self):
+        """Concrete type name -> class, for rebuilding data['type'] on redo."""
+        return {t.__name__: t for t in self.types}
+
+    def resolve(self, op, data, implicit):
+        """Return the pointer value: the implicit id, or the resolved element."""
+        raise NotImplementedError
+
+    def store(self, op, data, values, implicit):
+        """Write the pointer identity from ``values`` into ``data``."""
+        raise NotImplementedError
+
+
+class ObjectPointer(PointerKind):
+    types = (bpy.types.Object,)
+
+    def resolve(self, op, data, implicit):
+        obj_name = data.get("object_name")
+        if not obj_name:
+            return None
+        blender_obj = bpy.data.objects.get(obj_name)
+        if blender_obj is None:
+            return None
+        if implicit:
+            return obj_name
+        return get_evaluated_obj(bpy.context, blender_obj)
+
+    def store(self, op, data, values, implicit):
+        v = values[0] if values else None
+        data["object_name"] = v if (implicit or v is None) else v.name
+        return True
+
+
+class MeshElementPointer(PointerKind):
+    types = mesh_element_types  # (MeshVertex, MeshEdge, MeshPolygon)
+
+    def resolve(self, op, data, implicit):
+        obj_name = data.get("object_name")
+        blender_obj = bpy.data.objects.get(obj_name) if obj_name else None
+        if blender_obj is None:
+            return None
+        index = data.get("mesh_index")
+        if implicit:
+            return obj_name, index
+        obj = get_evaluated_obj(bpy.context, blender_obj)
+        ptype = data["type"]
+        if ptype is bpy.types.MeshVertex:
+            return obj.data.vertices[index]
+        if ptype is bpy.types.MeshPolygon:
+            return obj.data.polygons[index]
+        # MeshEdge
+        edges = getattr(obj.data, "edges", None)
+        if edges is None:
+            # A curve/sketch edge has no mesh edge to return; hand back the
+            # object so the pointer still reads as "set" (the picker resolves
+            # the actual endpoints from the stored index).
+            return obj
+        if index >= len(edges):
+            return None
+        return edges[index]
+
+    def store(self, op, data, values, implicit):
+        v0 = values[0] if values else None
+        v1 = values[1] if values and len(values) > 1 else None
+        data["object_name"] = v0 if (implicit or v0 is None) else v0.name
+        data["mesh_index"] = v1 if (implicit or v1 is None) else v1.index
+        return True
+
+
+_NATIVE_POINTER_KINDS = (ObjectPointer(), MeshElementPointer())
 
 
 class StatefulOperator(StatefulOperatorLogic):
@@ -29,12 +118,13 @@ class StatefulOperator(StatefulOperatorLogic):
 
     @classmethod
     def register_properties(cls):
+        from bpy.props import BoolProperty, IntProperty, StringProperty
+
         states = cls.get_states_definition()
         annotations = cls.__annotations__.copy()
 
         for i, s in enumerate(states):
             pointer_name = s.pointer
-            types = s.types
 
             if not pointer_name:
                 continue
@@ -60,95 +150,68 @@ class StatefulOperator(StatefulOperatorLogic):
                     )
                 )
 
+        # Hidden per-pointer-state persistence props so the redo/execute path
+        # can rebuild the picked pointer on a fresh instance where the transient
+        # _state_data is gone (see logic._store_pointers / _restore_pointers).
+        for i, s in enumerate(states):
+            if not s.pointer:
+                continue
+            annotations.setdefault("ptr%d_kind" % i, StringProperty(options={"HIDDEN"}))
+            annotations.setdefault("ptr%d_existing" % i, BoolProperty(options={"HIDDEN"}))
+            annotations.setdefault("ptr%d_name" % i, StringProperty(options={"HIDDEN"}))
+            annotations.setdefault(
+                "ptr%d_index" % i, IntProperty(default=-1, options={"HIDDEN"})
+            )
+        setattr(cls, "__annotations__", annotations)
+
     def state_property(self, state_index):
         return None
+
+    # -- pointer handlers -----------------------------------------------------
+
+    def _pointer_handlers(self):
+        """The pointer-kind handlers, most specific first. The extension layer
+        appends its entity/curve-ref handlers via super()."""
+        return _NATIVE_POINTER_KINDS
+
+    def _pointer_handler_for(self, ptype):
+        for handler in self._pointer_handlers():
+            if handler.handles(ptype):
+                return handler
+        return None
+
+    def _pointer_type_registry(self):
+        registry = {}
+        for handler in self._pointer_handlers():
+            registry.update(handler.type_registry())
+        return registry
 
     def get_state_pointer(
         self, index: Optional[int] = None, implicit: Optional[bool] = False
     ):
-        # Creates pointer value from its implicitly stored props
+        # Rebuild the pointer value from its implicitly stored identity.
         if index is None:
             index = self.state_index
-
-        state = self.get_states_definition()[index]
-        pointer_name = state.pointer
         data = self._state_data.get(index, {})
-        if "type" not in data.keys():
+        ptype = data.get("type")
+        if not ptype:
             return None
-
-        pointer_type = data["type"]
-        if not pointer_type:
+        handler = self._pointer_handler_for(ptype)
+        if handler is None:
             return None
-
-        if pointer_type in (bpy.types.Object, *mesh_element_types):
-            obj_name = data["object_name"]
-            blender_obj = bpy.data.objects.get(obj_name)
-            if blender_obj is None:
-                return None
-            obj = get_evaluated_obj(bpy.context, blender_obj)
-
-        if pointer_type in mesh_element_types:
-            index = data["mesh_index"]
-
-        if pointer_type == bpy.types.Object:
-            if implicit:
-                return obj_name
-            return obj
-
-        elif pointer_type == bpy.types.MeshVertex:
-            if implicit:
-                return obj_name, index
-            return obj.data.vertices[index]
-
-        elif pointer_type == bpy.types.MeshEdge:
-            if implicit:
-                return obj_name, index
-            edges = getattr(obj.data, "edges", None)
-            if edges is None:
-                # A curve/sketch edge has no mesh edge to return; hand back the
-                # object so the pointer still reads as "set" (the picker resolves
-                # the actual endpoints from the stored index).
-                return obj
-            if index >= len(edges):
-                return None
-            return edges[index]
-
-        elif pointer_type == bpy.types.MeshPolygon:
-            if implicit:
-                return obj_name, index
-            return obj.data.polygons[index]
+        return handler.resolve(self, data, implicit)
 
     def set_state_pointer(self, values, index=None, implicit=False):
-        # handles type specific setters
         if index is None:
             index = self.state_index
-
-        state = self.get_states_definition()[index]
-        pointer_name = state.pointer
         data = self._state_data.get(index, {})
-
-        pointer_type = data.get("type")
-        if pointer_type is None:
+        ptype = data.get("type")
+        if ptype is None:
             return None
-
-        def get_value(index):
-            if values is None:
-                return None
-            return values[index]
-
-        if pointer_type == bpy.types.Object:
-            if implicit:
-                val = get_value(0)
-            else:
-                val = get_value(0).name
-            data["object_name"] = val
-            return True
-
-        elif pointer_type in mesh_element_types:
-            obj_name = get_value(0) if implicit else get_value(0).name
-            data["object_name"] = obj_name
-            data["mesh_index"] = get_value(1) if implicit else get_value(1).index
-            return True
+        handler = self._pointer_handler_for(ptype)
+        if handler is None:
+            return None
+        return handler.store(self, data, values, implicit)
 
     def state_func(self, context: Context, coords):
         pos = get_placement_pos(context, coords)
@@ -191,7 +254,7 @@ class StatefulOperator(StatefulOperatorLogic):
         if not do_object and not do_mesh_elem:
             return
 
-        ob, type, index = get_mesh_element(context, coords, **types)
+        ob, element_type, index = get_mesh_element(context, coords, **types)
 
         # NOTE: scene.ray_cast() cannot pick empties (no geometry).
         # Empties are picked via custom ID buffer or selection prefill.
@@ -203,18 +266,17 @@ class StatefulOperator(StatefulOperatorLogic):
             data["type"] = bpy.types.Object
             return ob.name
 
-        # get_mesh_element returns the Object sentinel when the ray hit an
-        # object but no vertex/edge/face landed within threshold. For a
-        # mesh-element state that's a miss -- return None so callers can fall
-        # back (e.g. the curve-edge pick for a revolve axis).
+        # element_type is None when the ray hit an object but no vertex/edge/face
+        # landed within threshold. For a mesh-element state that's a miss --
+        # return None so callers can fall back (e.g. the curve-edge revolve axis).
         type_map = {
             "VERTEX": bpy.types.MeshVertex,
             "EDGE": bpy.types.MeshEdge,
             "FACE": bpy.types.MeshPolygon,
         }
-        if type not in type_map:
+        if element_type not in type_map:
             return None
-        data["type"] = type_map[type]
+        data["type"] = type_map[element_type]
 
         return ob.name, index
 
@@ -244,9 +306,6 @@ class StatefulOperator(StatefulOperatorLogic):
         # Use the operator-aware state list so per-state ``get_types`` narrowing
         # (e.g. an EQUAL slot restricted once the other slot is picked) applies
         # during selection prefill, exactly as it does for interactive picking.
-        # ``get_states_definition()`` builds states with ``operator=None`` and
-        # therefore skips that narrowing, which would let an incompatible
-        # preselection through.
         state = self.get_states()[index]
         data = self.get_state_data(index)
 
@@ -271,13 +330,20 @@ class StatefulOperator(StatefulOperatorLogic):
 
         # Map CurveRef types to legacy entity types
         from ..model.curve_ref import (
-            CurveRef, PointRef, LineRef, ArcRef, CircleRef,
+            ArcRef,
+            CircleRef,
+            CurveRef,
+            LineRef,
+            PointRef,
         )
         if not isinstance(element, CurveRef):
             return False
 
         from ..model.types import (
-            SlvsPoint2D, SlvsLine2D, SlvsArc, SlvsCircle,
+            SlvsArc,
+            SlvsCircle,
+            SlvsLine2D,
+            SlvsPoint2D,
         )
         _map = {
             PointRef: SlvsPoint2D,
@@ -288,24 +354,80 @@ class StatefulOperator(StatefulOperatorLogic):
         mapped = _map.get(type(element))
         return mapped in types if mapped else False
 
+    # True -> expose an eyedropper next to picked pointer states in the redo
+    # panel that re-enters this op to edit just that state (edit_state re-entry).
+    editable = False
+
+    def _declared_prop_names(self):
+        names = set()
+        for klass in type(self).__mro__:
+            names.update(klass.__dict__.get("__annotations__", {}))
+        return names
+
+    def _pointer_repick_label(self, i):
+        """Label for a picked pointer, read from its persisted props."""
+        kind = getattr(self, "ptr%d_kind" % i, "")
+        name = getattr(self, "ptr%d_name" % i, "")
+        index = getattr(self, "ptr%d_index" % i, -1)
+        if name and index >= 0:
+            return "%s [%d]" % (name, index)
+        if name:
+            return name
+        if index >= 0:
+            return "%s #%d" % (kind or "Element", index)
+        return kind or "-"
+
+    def _state_is_editable(self, i, state):
+        """Whether state ``i`` offers a redo-panel eyedropper to re-pick it.
+        Default: the op's ``editable`` flag applies to every picked pointer.
+        Subclasses can restrict it (e.g. to object pointers only)."""
+        return self.editable
+
+    def _draw_state_row(self, layout, i, state):
+        """Draw one state's redo-panel row: a picked pointer (label + eyedropper
+        to re-pick) or the state's editable property."""
+        # A picked pointer is rendered from its persisted identity (which
+        # survives into the redo panel, unlike the transient _state_data).
+        picked = state.pointer and getattr(self, "ptr%d_existing" % i, False)
+        if picked and getattr(self, "ptr%d_kind" % i, ""):
+            row = layout.row(align=True)
+            row.label(text=self._pointer_repick_label(i))
+            if self._state_is_editable(i, state):
+                # Re-enter THIS op to edit just state i. Use the class bl_idname
+                # (dotted, via the str-Enum .value); the instance form is the RNA
+                # identifier which layout.operator won't accept. Forward the op's
+                # current props so it restores full state, then edits state i.
+                idname = getattr(type(self).bl_idname, "value", type(self).bl_idname)
+                op = row.operator(idname, text="", icon="EYEDROPPER")
+                for name in self._declared_prop_names():
+                    if name == "edit_state" or name.startswith("_"):
+                        continue
+                    try:
+                        val = getattr(self, name)
+                    except (AttributeError, TypeError):
+                        continue
+                    if hasattr(val, "__len__") and not isinstance(val, str):
+                        val = tuple(val)
+                    try:
+                        setattr(op, name, val)
+                    except (AttributeError, TypeError):
+                        pass
+                op.edit_state = i
+            return
+
+        props = self.get_property(index=i)
+        if props:
+            for p in props:
+                layout.prop(self, p, text="")
+
     def draw(self, context):
         layout = self.layout
 
         for i, state in enumerate(self.get_states()):
             if i != 0:
                 layout.separator()
-
             layout.label(text=state.name)
-
-            state_data = self._state_data.get(i, {})
-            is_existing = state_data.get("is_existing_entity", False)
-            props = self.get_property(index=i)
-
-            if state.pointer and is_existing:
-                layout.label(text=str(getattr(self, state.pointer)))
-            elif props:
-                for p in props:
-                    layout.prop(self, p, text="")
+            self._draw_state_row(layout, i, state)
 
         if hasattr(self, "draw_settings"):
             self.draw_settings(context)

--- a/stateful_operator/logic.py
+++ b/stateful_operator/logic.py
@@ -35,6 +35,9 @@ class StatefulOperatorLogic(_StateMachineMixin):
     state_index: IntProperty(options={"HIDDEN", "SKIP_SAVE"})
     wait_for_input: BoolProperty(options={"HIDDEN", "SKIP_SAVE"}, default=True)
     continuous_draw: BoolProperty(name="Continuous Draw", default=False)
+    # >= 0 -> re-enter to edit just that state: restore the persisted input, let
+    # the user re-pick that one state, then re-apply idempotently. -1 = normal.
+    edit_state: IntProperty(default=-1, options={"HIDDEN", "SKIP_SAVE"})
 
     executed = False
     # Tool id to activate once the operator succeeds (see _end). Lets a one-off
@@ -294,15 +297,20 @@ class StatefulOperatorLogic(_StateMachineMixin):
 
     def invoke(self, context: Context, event: Event):
         global_data.stateful_op_running = True
-        entered_modal = False
         self._state_data.clear()
-        global_data.hover_types = self.get_states()[0].types
         self._numeric = NumericInput()
+
+        if self.edit_state >= 0:
+            return self._invoke_edit(context, event)
+
+        entered_modal = False
+        global_data.hover_types = self.get_states()[0].types
         self._state_snapshot = self.create_snapshot(context)
         try:
             if hasattr(self, "init"):
                 if not self.init(context, event):
                     return self._end(context, False)
+            self._capture_baseline(context)
 
             retval = {"RUNNING_MODAL"}
             go_modal = True
@@ -337,16 +345,148 @@ class StatefulOperatorLogic(_StateMachineMixin):
             if not entered_modal and global_data.stateful_op_running:
                 global_data.stateful_op_running = False
 
+    # -------------------------------------------------------------------------
+    # Edit-state re-entry (re-pick one state of a finished op, idempotently)
+    # -------------------------------------------------------------------------
+
+    def _invoke_edit(self, context: Context, event: Event):
+        """Re-enter to edit a single state: restore the persisted input, then let
+        the user re-pick just ``edit_state``. Invoked top-level from the redo
+        panel, so the re-applied op becomes the adjustable last operation."""
+        if hasattr(self, "init"):
+            # Load assets etc.; entity ops also set _active_sketch here.
+            if not self.init(context, event):
+                return self._end_edit(context, False)
+        # Rebuild every state from the forwarded/persisted props, then clear the
+        # one being edited so the user picks it fresh. No snapshot -- idempotent
+        # apply (_run_main) replaces this op's own output.
+        self._state_snapshot = None
+        self._restore_pointers()
+        # Let subclasses snapshot pre-re-pick state (the target being edited away
+        # from) before the user changes it -- e.g. node ops relocating a modifier.
+        self._prepare_edit(context)
+        i = self.edit_state
+        self.get_state_data(i).pop("type", None)
+        self.set_state(context, i)
+        global_data.hover_types = self.get_states()[i].types
+        # Make the op's hover/preselection UI available for the re-pick even
+        # though the workspace tool that normally owns it isn't active.
+        self._prepare_pick_ui(context)
+        context.window.cursor_modal_set("EYEDROPPER")
+        self.set_status_text(context)
+        # A modal invoked from a redo-panel button can stall waiting for its first
+        # event (the button-click context delivers none until the mouse moves).
+        # A modal timer keeps it ticking so it becomes responsive immediately.
+        self._edit_timer = context.window_manager.event_timer_add(
+            0.05, window=context.window
+        )
+        context.window_manager.modal_handler_add(self)
+        return {"RUNNING_MODAL"}
+
+    def _modal_edit(self, context: Context, event: Event):
+        # Clicking the eyedropper button in the redo panel makes Blender also
+        # re-run the previous operator's execute()/_end() (an implicit undo +
+        # re-apply). That nulls the shared global_data.hover_types this edit modal
+        # set, and reverts any state _prepare_pick_ui changed (e.g. a hidden
+        # modifier). Re-assert both every event so the pick keeps working.
+        global_data.hover_types = self.get_states()[self.edit_state].types
+        self._maintain_pick_ui(context)
+        if event.type in {"RIGHTMOUSE", "ESC"} and event.value == "PRESS":
+            return self._end_edit(context, False)
+        if event.type == "TIMER":
+            return {"RUNNING_MODAL"}  # just keeps the modal responsive
+        if event.type == "LEFTMOUSE" and event.value == "PRESS":
+            coords = Vector((event.mouse_region_x, event.mouse_region_y))
+            is_picked, values = self._pick_hovered(context, coords, self.state, False)
+            if not is_picked:
+                return {"RUNNING_MODAL"}  # missed a target -- keep waiting
+            self.state_data["is_existing_entity"] = True
+            self.set_state_pointer(values, implicit=True)
+            self._store_pointers()
+            ok = self._reapply(context)
+            if context.area:
+                context.area.tag_redraw()
+            return self._end_edit(context, ok)
+        if event.type == "MOUSEMOVE":
+            # Gizmos don't run their hover test while a modal operator is active,
+            # so drive the hover highlight ourselves for the re-pick.
+            coords = Vector((event.mouse_region_x, event.mouse_region_y))
+            self._update_pick_hover(context, coords)
+        return self._handle_pass_through(context, event)
+
+    def _end_edit(self, context: Context, ok: bool):
+        timer = getattr(self, "_edit_timer", None)
+        if timer is not None:
+            context.window_manager.event_timer_remove(timer)
+            self._edit_timer = None
+        self._finish_pick_ui(context)
+        context.window.cursor_modal_restore()
+        context.workspace.status_text_set(None)
+        global_data.hover_types = None
+        global_data.hover_element = None
+        global_data.stateful_op_running = False
+        return {"FINISHED"} if ok else {"CANCELLED"}
+
     def execute(self, context: Context):
         global_data.stateful_op_running = True
         try:
             self._numeric = NumericInput()
-            self.redo_states(context)
-            ok = self.main(context)
+            ok = self._reapply(context)
             return self._end(context, ok, skip_undo=True)
         finally:
             if global_data.stateful_op_running:
                 global_data.stateful_op_running = False
+
+    def _run_main(self, context: Context):
+        """Invoke ``main``; a hook for subclasses to make apply idempotent
+        (e.g. entity ops that own + replace their created output)."""
+        return self.main(context)
+
+    def _reapply(self, context: Context):
+        """Rebuild everything from persisted state and run main -- the shared
+        execute / redo-panel / edit-re-pick path. Default: redo_states + main.
+        Subclasses that own their output (Operator2d) remove it first so their
+        stable-id recreation doesn't collide with the still-present old copy."""
+        self.redo_states(context)
+        return self._run_main(context)
+
+    def _prepare_edit(self, context: Context):
+        """Hook: called in the edit re-pick invoke, after the persisted state is
+        restored but before the user re-picks edit_state. Lets a subclass capture
+        what it is editing away from (default no-op)."""
+        pass
+
+    def _prepare_pick_ui(self, context: Context):
+        """Hook: called when the edit re-pick modal starts. Lets a subclass make
+        its hover/preselection UI available even though the workspace tool that
+        owns it isn't active (e.g. ensure a gizmo group is linked, or reveal
+        geometry a modifier is hiding). Default no-op."""
+        pass
+
+    def _finish_pick_ui(self, context: Context):
+        """Hook: called when the edit re-pick modal ends. Undo whatever
+        ``_prepare_pick_ui`` set up. Default no-op."""
+        pass
+
+    def _update_pick_hover(self, context: Context, coords):
+        """Hook: called on mouse-move during the edit re-pick to refresh the
+        hover highlight (gizmos don't run their hover test during a modal).
+        Default no-op."""
+        pass
+
+    def _maintain_pick_ui(self, context: Context):
+        """Hook: called on every edit-modal event to re-assert whatever
+        ``_prepare_pick_ui`` set up, since a redo-panel re-run can revert it.
+        Default no-op."""
+        pass
+
+    def _capture_baseline(self, context: Context):
+        """Hook: record the state before the op runs (for output ownership)."""
+        pass
+
+    def _record_committed_output(self, context: Context):
+        """Hook: after a successful commit, record what the op created."""
+        pass
 
     def _handle_pass_through(self, context: Context, event: Event):
         if event.type in {"MIDDLEMOUSE", "WHEELUPMOUSE", "WHEELDOWNMOUSE", "MOUSEMOVE"}:
@@ -354,6 +494,9 @@ class StatefulOperatorLogic(_StateMachineMixin):
         return {"RUNNING_MODAL"}
 
     def modal(self, context: Context, event: Event):
+        if self.edit_state >= 0:
+            return self._modal_edit(context, event)
+
         state = self.state
         event_triggered = self.check_event(event)
         coords = Vector((event.mouse_region_x, event.mouse_region_y))
@@ -542,23 +685,135 @@ class StatefulOperatorLogic(_StateMachineMixin):
             raise NotImplementedError(
                 "StatefulOperators need to have a main method defined!"
             )
-        retval = self.main(context)
+        # Capture the picked pointers so a later redo (fresh instance) can
+        # rebuild them; this runs on every live update, keeping it current.
+        self._store_pointers()
+        retval = self._run_main(context)
         self.executed = True
         return retval
 
+    # -------------------------------------------------------------------------
+    # Pointer persistence (survives the redo/execute path)
+    # -------------------------------------------------------------------------
+    #
+    # Each pointer state's identity is stored in hidden, per-state real
+    # properties (registered by register_properties): ``ptr{i}_kind`` (the
+    # picked type's __name__), ``ptr{i}_existing`` (is_existing_entity), and the
+    # implicit value split into a string slot ``ptr{i}_name`` + int slot
+    # ``ptr{i}_index``. Blender persists these across the redo/execute path (a
+    # fresh instance), where the transient _state_data is gone.
+
+    def _pointer_type_registry(self):
+        """Map a pointer type's ``__name__`` back to the class, for redo restore.
+
+        Base is empty; the integration layer adds native Blender types and the
+        extension layer adds its entity/curve-ref types.
+        """
+        return {}
+
+    @staticmethod
+    def _pack_pointer_vals(vals):
+        """Split implicit pointer values into a (name, index) pair for storage.
+
+        Implicit values are at most one string id (object name / curve_id) and
+        one int (mesh element index / entity index); -1 marks "no int".
+        """
+        name, index = "", -1
+        for v in vals:
+            if isinstance(v, bool):
+                continue
+            if isinstance(v, str):
+                name = v
+            elif isinstance(v, int):
+                index = v
+        return name, index
+
+    @staticmethod
+    def _unpack_pointer_vals(name, index):
+        """Rebuild the implicit value list from the stored (name, index) slots.
+
+        The filled slots imply the shape: name+index -> mesh element [name,
+        index]; name only -> object / curve-ref [name]; index only -> entity
+        [index]. Returns None when neither slot is set.
+        """
+        if name and index >= 0:
+            return [name, index]
+        if name:
+            return [name]
+        if index >= 0:
+            return [index]
+        return None
+
+    def _store_pointers(self):
+        """Write each resolved pointer state's identity to its hidden props."""
+        for i, state in enumerate(self.get_states()):
+            if not state.pointer:
+                continue
+            data = self._state_data.get(i)
+            kind, existing, name, index = "", False, "", -1
+            if data and data.get("type"):
+                kind = data["type"].__name__
+                existing = bool(data.get("is_existing_entity", False))
+                name, index = self._pack_pointer_vals(
+                    to_list(self.get_state_pointer(index=i, implicit=True))
+                )
+            # Guarded: duplicate-registration phantoms lack the RNA properties.
+            try:
+                setattr(self, "ptr%d_kind" % i, kind)
+                setattr(self, "ptr%d_existing" % i, existing)
+                setattr(self, "ptr%d_name" % i, name)
+                setattr(self, "ptr%d_index" % i, index)
+            except AttributeError:
+                pass
+
+    def _restore_pointers(self):
+        """Rebuild pointer state data from the hidden props (redo/execute path).
+
+        Only for the fresh-instance execute/redo/edit path (``_state_snapshot is
+        None``). During the interactive modal a snapshot is held and _state_data
+        is resolved live every frame; restoring there would re-inject the last
+        *picked* identity (kind + is_existing_entity) and clobber a subsequent
+        free placement -- e.g. hover a point then move to empty and the endpoint
+        stays stuck on the point. The per-state ``data.get("type")`` guard below
+        is not enough on its own: pick_element nulls ``type`` when hovering empty,
+        which re-opens the door for the stale restore.
+        """
+        if self._state_snapshot is not None:
+            return
+        registry = self._pointer_type_registry()
+        for i, state in enumerate(self.get_states()):
+            if not state.pointer:
+                continue
+            data = self.get_state_data(i)
+            if data.get("type"):
+                continue
+            kind = getattr(self, "ptr%d_kind" % i, "")
+            if not kind:
+                continue
+            ptype = registry.get(kind)
+            if ptype is None:
+                continue
+            data["type"] = ptype
+            data["is_existing_entity"] = bool(getattr(self, "ptr%d_existing" % i, False))
+            vals = self._unpack_pointer_vals(
+                getattr(self, "ptr%d_name" % i, ""),
+                getattr(self, "ptr%d_index" % i, -1),
+            )
+            if vals is not None:
+                self.set_state_pointer(vals, index=i, implicit=True)
+
     def redo_states(self, context: Context):
         """Recreate non-persistent elements for states up to the current one."""
+        # The redo/execute path runs on a fresh instance with empty _state_data;
+        # rebuild the picked pointers from the persisted identity first.
+        self._restore_pointers()
+
         for i, state in enumerate(self.get_states()):
             if i > self.state_index:
                 # TODO: don't depend on active state; ideally going back is possible
                 break
             if state.pointer:
                 data = self._state_data.get(i, {})
-                # The redo/execute path runs on a fresh operator instance, so
-                # the transient per-state data may be gone. Treat a missing
-                # entry as "existing" (nothing to recreate) rather than crash;
-                # operators that need to re-resolve a pointer on redo persist it
-                # in a real property instead (see NodeOperator.target_name).
                 is_existing_entity = data.get("is_existing_entity", True)
                 props = self.get_property(index=i)
                 if props and not is_existing_entity:
@@ -597,6 +852,10 @@ class StatefulOperatorLogic(_StateMachineMixin):
             else:
                 bpy.ops.ed.undo_push(message="Cancelled: " + self.bl_label)
                 bpy.ops.ed.undo()
+        elif succeede:
+            # Record what this commit created (modal path; the execute/edit path
+            # records in _run_main). Enables idempotent re-apply on re-pick.
+            self._record_committed_output(context)
 
         self._state_snapshot = None
         return {"FINISHED"} if succeede else {"CANCELLED"}

--- a/testing/test_nodes.py
+++ b/testing/test_nodes.py
@@ -281,6 +281,76 @@ class TestNodeTools(BgsTestCase):
         n = len([m for m in ob.modifiers if m.name == "CAD_Sketcher Revolve"])
         self.assertEqual(n, 1)
 
+    def test_repoint_moves_modifier_to_the_new_object(self):
+        # Re-pointing the object with the eyedropper stamps previous_target/
+        # previous_modifier for what it edited away from; re-apply then MOVES the
+        # modifier to the new object instead of orphaning it on the old one.
+        import math
+
+        a, b = self._cube(), self._cube()
+        a.name, b.name = "TargetA", "TargetB"
+        common = dict(
+            axis_origin=(0.0, 0.0, 0.0),
+            axis_direction=(0.0, 0.0, 1.0),
+            angle=math.pi,
+            angular_resolution=math.radians(30),
+            flip=False,
+        )
+        self.assertEqual(
+            bpy.ops.view3d.slvs_node_revolve(
+                "EXEC_DEFAULT", target_name="TargetA", **common
+            ),
+            {"FINISHED"},
+        )
+        self.assertIsNotNone(a.modifiers.get("CAD_Sketcher Revolve"))
+
+        self.assertEqual(
+            bpy.ops.view3d.slvs_node_revolve(
+                "EXEC_DEFAULT",
+                target_name="TargetB",
+                previous_target="TargetA",
+                previous_modifier="CAD_Sketcher Revolve",
+                **common,
+            ),
+            {"FINISHED"},
+        )
+        self.assertIsNone(
+            a.modifiers.get("CAD_Sketcher Revolve"), "old target kept its modifier"
+        )
+        self.assertIsNotNone(
+            b.modifiers.get("CAD_Sketcher Revolve"), "new target missing modifier"
+        )
+
+    def test_boolean_repoint_cutter_removes_old_modifier(self):
+        # A boolean modifier is named per cutter, so re-pointing the cutter changes
+        # the name; the old-named modifier must be removed, not left beside the new.
+        body, c, d = self._cube(), self._cube(), self._cube()
+        body.name, c.name, d.name = "Body", "CutC", "CutD"
+
+        self.assertEqual(
+            bpy.ops.view3d.slvs_node_boolean(
+                "EXEC_DEFAULT", target_name="Body", cutter_name="CutC"
+            ),
+            {"FINISHED"},
+        )
+        self.assertIsNotNone(body.modifiers.get("CAD_Sketcher Boolean CutC"))
+
+        self.assertEqual(
+            bpy.ops.view3d.slvs_node_boolean(
+                "EXEC_DEFAULT",
+                target_name="Body",
+                cutter_name="CutD",
+                previous_target="Body",
+                previous_modifier="CAD_Sketcher Boolean CutC",
+            ),
+            {"FINISHED"},
+        )
+        names = [
+            m.name for m in body.modifiers
+            if m.name.startswith("CAD_Sketcher Boolean")
+        ]
+        self.assertEqual(names, ["CAD_Sketcher Boolean CutD"], f"got {names}")
+
     def test_revolve_readback_seeds_props_from_modifier(self):
         # Re-invoking on an object that already has the modifier should start
         # from its current values, not the defaults. read_props pulls the angle


### PR DESCRIPTION
Makes the node tools' **object pointers re-editable** in the redo panel via an **eyedropper**, by porting the object-pointer slice of the `feature/stateops-reeditable` framework work — **without** the sketch-entity `curve_id`/stable-id machinery (objects have native Blender identity, so re-apply just relocates a modifier).

Supersedes the earlier `prop_search` attempt, which fought the framework: the pointer's real store is the transient `_state_data`, so a name-string field was both shadowed by the read-only `self.object` and drawn as a duplicate row. The eyedropper edits the pointer *through* the framework, so it's one row and it actually works.

## What was ported (framework)

- **`integration.py`** — pointer-kind handlers (`ObjectPointer`/`MeshElementPointer`), hidden per-state persistence props (`ptr{i}_kind/_existing/_name/_index`), and a `draw()` that renders each picked pointer as a row with an eyedropper (gated by a new `editable` flag).
- **`logic.py`** — edit-state re-entry: `edit_state`, `_invoke_edit`/`_modal_edit`/`_end_edit`, `_store_pointers`/`_restore_pointers`, and `execute → _reapply` (base `_reapply` = `redo_states + main`, i.e. identical to today for everything else).

## What was deliberately excluded

- The entity `curve_id`/`constraint_uid` **stable-id reuse** system and `Operator2d`'s idempotent `_reapply` (`base_2d.py`, `curve_data.py`) — untouched.
- `editable` stays **False** for sketch/entity ops, so they behave exactly as before (they'd need the stable-ids to be safely re-editable). Only `NodeOperator` sets `editable = True`.
- `base_stateful.py` is unchanged — its existing entity `get_state_pointer` override still resolves entity pointers on top of the new kind-based resolver.

## Node tools (`modifiers.py`)

- `editable = True`; the eyedropper appears on the object row (and the boolean's cutter row).
- `applied_object`/`applied_modifier` track where the modifier lives; on re-apply `_relocate_stale_modifier()` **moves** the modifier to the re-picked object (or, for the per-cutter Boolean name, removes the old-named one). The boolean's manual cutter `prop_search` is gone — the framework draws it now.

## Tests

- `test_repoint_moves_modifier_to_the_new_object` — revolve target A→B moves the modifier.
- `test_boolean_repoint_cutter_removes_old_modifier` — cutter C→D leaves only `Boolean CutD`.

Full suite green in a clean isolated install (301 tests, 2 expected failures) — sketch/entity tools unaffected by the framework change.

> Note: the relocate logic is unit-tested via `execute`; the eyedropper's modal re-pick itself needs a quick manual check in the GUI.
