### PR TITLE
Build convert node group on Blender <5.2 with a distance weld

### DIFF
--- a/utilities/convert_nodes.py
+++ b/utilities/convert_nodes.py
@@ -43,6 +43,14 @@ def _is_identity_group(ng) -> bool:
     return any(n.bl_idname == "GeometryNodeMergePoints" for n in ng.nodes)
 
 
+def _identity_weld_available() -> bool:
+    """Whether the Merge Points node (identity weld) exists (Blender 5.2+).
+
+    Older Blender has no identity weld, so the converter falls back to merging
+    coincident endpoints by distance (see build_convert_node_group)."""
+    return bpy.app.version >= (5, 2, 0)
+
+
 def normalize_attribute_definitions(attribute_definitions):
     """Return stable POINT/CURVE specs used by the shared conversion bridge."""
     specs = []
@@ -335,10 +343,21 @@ def build_convert_node_group(
     links.new(is_end.outputs["Result"], weld.inputs[0])
     links.new(nonzero.outputs["Result"], weld.inputs[1])
 
-    merge = nodes.new("GeometryNodeMergePoints")
-    links.new(wire_mesh, merge.inputs["Geometry"])
-    links.new(merge_id.outputs["Attribute"], merge.inputs["Merge ID"])
-    links.new(weld.outputs["Boolean"], merge.inputs["Selection"])
+    if _identity_weld_available():
+        merge = nodes.new("GeometryNodeMergePoints")
+        links.new(wire_mesh, merge.inputs["Geometry"])
+        links.new(merge_id.outputs["Attribute"], merge.inputs["Merge ID"])
+        links.new(weld.outputs["Boolean"], merge.inputs["Selection"])
+    else:
+        # Blender < 5.2 has no identity weld (Merge Points). Merge the same
+        # selected endpoints by a tiny distance instead: it only collapses points
+        # that already share a position, so it matches the identity weld for the
+        # coincident sketch endpoints in practice. Both nodes output "Geometry",
+        # so the downstream fill/non-fill wiring below is identical.
+        merge = nodes.new("GeometryNodeMergeByDistance")
+        links.new(wire_mesh, merge.inputs["Geometry"])
+        links.new(weld.outputs["Boolean"], merge.inputs["Selection"])
+        merge.inputs["Distance"].default_value = 1e-6
 
     # The welded wire mesh carries POINT values on its vertices and per-segment
     # values on its edges; it feeds the non-fill path directly and is the source

--- a/utilities/curve_data.py
+++ b/utilities/curve_data.py
@@ -474,20 +474,15 @@ def _ensure_convert_modifier(ob):
 
 
 def _get_convert_node_group():
-    """The convert node group: identity-weld build on Blender 5.2+, else the
-    shipped merge-by-distance asset (which is all older Blender can express)."""
-    if bpy.app.version >= (5, 2, 0):
-        from .convert_nodes import build_convert_node_group
+    """The convert node group, built programmatically for every Blender version.
 
-        return build_convert_node_group()
+    The build is identical apart from the weld: Blender 5.2+ welds sketch
+    endpoints by identity (Merge Points), older Blender merges coincident
+    endpoints by distance (all it can express). Building both keeps the two
+    paths in lockstep instead of shipping a separate, drift-prone asset."""
+    from .convert_nodes import build_convert_node_group
 
-    from .. import global_data
-    from ..assets_manager import load_asset
-    from .convert_nodes import ensure_generated_id_nodes
-
-    load_asset(global_data.LIB_NAME, "node_groups", "CAD Sketcher Convert")
-    group = bpy.data.node_groups.get("CAD Sketcher Convert")
-    return ensure_generated_id_nodes(group) if group else None
+    return build_convert_node_group()
 
 
 def ensure_sketch_curve_object(sketch):
@@ -830,9 +825,7 @@ def compute_generated_id_seeds(sketch):
 
     attrs = cd.attributes
     curve_attr = ensure_attribute(attrs, SOURCE_CURVE_ID_ATTR, "INT", "CURVE")
-    endpoint_attr = ensure_attribute(
-        attrs, SOURCE_ENDPOINT_ID_ATTR, "INT", "POINT"
-    )
+    endpoint_attr = ensure_attribute(attrs, SOURCE_ENDPOINT_ID_ATTR, "INT", "POINT")
     type_attr = attrs.get("sketch_type")
     if not curve_attr or not endpoint_attr or not type_attr:
         return False
@@ -846,15 +839,17 @@ def compute_generated_id_seeds(sketch):
     endpoint_seeds = np.zeros(len(cd.points), dtype=np.int32)
 
     for index, curve in enumerate(cd.curves):
-        if type_attr.data[index].value not in (
-            SketchCurveType.LINE,
-            SketchCurveType.ARC,
-        ) or curve.points_length < 2:
+        if (
+            type_attr.data[index].value
+            not in (
+                SketchCurveType.LINE,
+                SketchCurveType.ARC,
+            )
+            or curve.points_length < 2
+        ):
             continue
         if any(start_ids[index]):
-            endpoint_seeds[curve.points[0].index] = _stable_source_id(
-                start_ids[index]
-            )
+            endpoint_seeds[curve.points[0].index] = _stable_source_id(start_ids[index])
         if any(end_ids[index]):
             endpoint_seeds[curve.points[curve.points_length - 1].index] = (
                 _stable_source_id(end_ids[index])


### PR DESCRIPTION
The `test-extension (blender 5.0)` CI job fails with `RuntimeError: Node type GeometryNodeMergePoints undefined` (and a downstream `KeyError: 'id'`). `GeometryNodeMergePoints` (identity weld) only exists on Blender 5.2+, but `blender_version_min` is `5.0.0`.

## Cause

`_get_convert_node_group` routed by version: 5.2+ built the group programmatically (Merge Points), while <5.2 loaded the `CAD Sketcher Convert` group from the shipped `resources/assets.blend` and attached the id tail. Two problems surfaced on 5.0:

- `test_segment_values_survive_weld_and_fill` calls `build_convert_node_group()` directly, which unconditionally created `GeometryNodeMergePoints`, so it errored on 5.0.
- The shipped asset had drifted out of sync with the current stable-id work, so the routed 5.0 path produced no `id` store (`KeyError: 'id'` in `test_active_conversion_path_emits_stable_ids`).

## Fix

Build the group programmatically on every Blender version and swap only the weld node, so the two paths stay in lockstep with no hand-exported asset to drift:

- 5.2+: `GeometryNodeMergePoints` (identity weld by `merge_id`), unchanged.
- <5.2: `GeometryNodeMergeByDistance` over the same endpoint selection with a tiny distance. It only collapses points that already share a position, so it matches the identity weld for coincident sketch endpoints (all older Blender can express). Both nodes output `Geometry`, so the fill / non-fill wiring downstream is identical.

`_get_convert_node_group` now always calls `build_convert_node_group()`; the asset-load branch is gone.

## Verification

- Full suite passes on Blender 5.2 (unchanged 5.2 path).
- Forcing the <5.2 branch on 5.2 (patching the version helper) builds a `MergeByDistance` group that carries the `id` (POINT) and face (FACE) stores, and both previously-failing tests pass under it.
- Real Blender 5.0 node availability is left to CI; `MergePoints` was the only 5.2-only node in the build, the rest predate 5.2.

The now-unused shipped `CAD Sketcher Convert` asset and `ensure_generated_id_nodes` can be removed in a follow-up.
