### PR TITLE
Drop self-referential coincident left behind by merge points

### DIFF
--- a/operators/add_geometric_constraints.py
+++ b/operators/add_geometric_constraints.py
@@ -50,27 +50,50 @@ def merge_points(context, duplicate, target):
         if getattr(c, "curve_id_3", 0) == dup_cid:
             c.curve_id_3 = tgt_cid
 
-    # A constraint that referenced both merged points (e.g. a coincident joining
-    # the two) is now self-referential after the remap. Leaving it behind yields a
-    # redundant/failed constraint, so drop any that collapsed onto a single curve.
-    _remove_self_referential(sketch.constraints)
+    # The remap can leave two kinds of redundant constraint behind, both of which
+    # the solver reports as failed/redundant:
+    #  - self-referential: a coincident joining the two merged points now points
+    #    target->target (a point coincident with itself);
+    #  - duplicate: two points each constrained to the same third entity (another
+    #    point, a line, a circle...) collapse to identical constraints.
+    # Drop them so the merge leaves a clean, solvable sketch.
+    _remove_redundant_constraints(sketch.constraints)
 
     # Remove duplicate
     duplicate.remove()
 
 
-def _remove_self_referential(constraints):
-    """Remove constraints whose two curve references collapsed to the same curve."""
+def _constraint_operands(c):
+    """The non-empty curve references of a constraint, order-insensitive."""
+    ids = (
+        getattr(c, "curve_id_1", ""),
+        getattr(c, "curve_id_2", ""),
+        getattr(c, "curve_id_3", ""),
+    )
+    return frozenset(i for i in ids if i)
+
+
+def _remove_redundant_constraints(constraints):
+    """Drop self-referential and duplicate constraints left by a merge remap.
+
+    Removes one constraint per pass and rescans, so a held reference is never used
+    across a collection mutation (which would invalidate it)."""
     while True:
-        degenerate = None
+        victim = None
+        seen = {}
         for c in constraints.all:
             id1 = getattr(c, "curve_id_1", "")
             if id1 and id1 == getattr(c, "curve_id_2", ""):
-                degenerate = c
+                victim = c  # self-referential
                 break
-        if degenerate is None:
+            key = (c.type, _constraint_operands(c))
+            if key in seen:
+                victim = c  # duplicate of an earlier constraint
+                break
+            seen[key] = c
+        if victim is None:
             return
-        constraints.remove(degenerate)
+        constraints.remove(victim)
 
 
 class VIEW3D_OT_slvs_merge_points(Operator):

--- a/operators/add_geometric_constraints.py
+++ b/operators/add_geometric_constraints.py
@@ -50,14 +50,17 @@ def merge_points(context, duplicate, target):
         if getattr(c, "curve_id_3", 0) == dup_cid:
             c.curve_id_3 = tgt_cid
 
-    # The remap can leave two kinds of redundant constraint behind, both of which
+    # The remap can leave three kinds of redundant constraint behind, all of which
     # the solver reports as failed/redundant:
     #  - self-referential: a coincident joining the two merged points now points
     #    target->target (a point coincident with itself);
     #  - duplicate: two points each constrained to the same third entity (another
-    #    point, a line, a circle...) collapse to identical constraints.
+    #    point, a line, a circle...) collapse to identical constraints;
+    #  - point-on-own-curve: a coincident that put a point onto a curve now targets
+    #    that curve's own endpoint (e.g. merging an on-line point onto the line's
+    #    end), so the point lies on the curve by construction.
     # Drop them so the merge leaves a clean, solvable sketch.
-    _remove_redundant_constraints(sketch.constraints)
+    _remove_redundant_constraints(sketch, sketch.constraints)
 
     # Remove duplicate
     duplicate.remove()
@@ -73,8 +76,35 @@ def _constraint_operands(c):
     return frozenset(i for i in ids if i)
 
 
-def _remove_redundant_constraints(constraints):
-    """Drop self-referential and duplicate constraints left by a merge remap.
+def _point_is_structural_end(sketch, point_id, curve_id):
+    """True if ``point_id`` is a start/end/center point of curve ``curve_id``."""
+    from ..utilities.curve_data import get_curve_data, get_uuid, has_uuid_field
+
+    if not point_id or not curve_id or point_id == curve_id:
+        return False
+    cd, idx, _ = get_curve_data(sketch, curve_id)
+    if cd is None:
+        return False
+    for field in ("start_point_id", "end_point_id", "center_point_id"):
+        if has_uuid_field(cd, field) and get_uuid(cd, field, idx) == point_id:
+            return True
+    return False
+
+
+def _is_redundant_point_on_curve(sketch, c):
+    """A coincident whose point operand is already a structural end of its curve."""
+    if c.type != "COINCIDENT":
+        return False
+    id1 = getattr(c, "curve_id_1", "")
+    id2 = getattr(c, "curve_id_2", "")
+    return _point_is_structural_end(sketch, id1, id2) or _point_is_structural_end(
+        sketch, id2, id1
+    )
+
+
+def _remove_redundant_constraints(sketch, constraints):
+    """Drop self-referential, duplicate and point-on-own-curve constraints left by
+    a merge remap.
 
     Removes one constraint per pass and rescans, so a held reference is never used
     across a collection mutation (which would invalidate it)."""
@@ -85,6 +115,9 @@ def _remove_redundant_constraints(constraints):
             id1 = getattr(c, "curve_id_1", "")
             if id1 and id1 == getattr(c, "curve_id_2", ""):
                 victim = c  # self-referential
+                break
+            if _is_redundant_point_on_curve(sketch, c):
+                victim = c  # point already lies on the curve by construction
                 break
             key = (c.type, _constraint_operands(c))
             if key in seen:

--- a/operators/add_geometric_constraints.py
+++ b/operators/add_geometric_constraints.py
@@ -51,8 +51,27 @@ def merge_points(context, duplicate, target):
         if getattr(c, "curve_id_3", 0) == dup_cid:
             c.curve_id_3 = tgt_cid
 
+    # A constraint that referenced both merged points (e.g. a coincident joining
+    # the two) is now self-referential after the remap. Leaving it behind yields a
+    # redundant/failed constraint, so drop any that collapsed onto a single curve.
+    _remove_self_referential(sketch.constraints)
+
     # Remove duplicate
     duplicate.remove()
+
+
+def _remove_self_referential(constraints):
+    """Remove constraints whose two curve references collapsed to the same curve."""
+    while True:
+        degenerate = None
+        for c in constraints.all:
+            id1 = getattr(c, "curve_id_1", "")
+            if id1 and id1 == getattr(c, "curve_id_2", ""):
+                degenerate = c
+                break
+        if degenerate is None:
+            return
+        constraints.remove(degenerate)
 
 
 class VIEW3D_OT_slvs_merge_points(Operator):

--- a/operators/add_geometric_constraints.py
+++ b/operators/add_geometric_constraints.py
@@ -1,25 +1,24 @@
 import logging
 
-from bpy.types import Operator, Context
 from bpy.props import FloatProperty
+from bpy.types import Context, Operator
 
 from ..curve_solver import solve_system
 from ..declarations import Operators
-from ..stateful_operator.utilities.register import register_stateops_factory
-from .base_constraint import GenericConstraintOp
-from ..utilities.select import deselect_all
-from ..utilities.view import refresh
 from ..drawing import selection
-
 from ..model.coincident import SlvsCoincident
 from ..model.equal import SlvsEqual
-from ..model.vertical import SlvsVertical
 from ..model.horizontal import SlvsHorizontal
+from ..model.midpoint import SlvsMidpoint
 from ..model.parallel import SlvsParallel
 from ..model.perpendicular import SlvsPerpendicular
-from ..model.tangent import SlvsTangent
-from ..model.midpoint import SlvsMidpoint
 from ..model.ratio import SlvsRatio
+from ..model.tangent import SlvsTangent
+from ..model.vertical import SlvsVertical
+from ..stateful_operator.utilities.register import register_stateops_factory
+from ..utilities.select import deselect_all
+from ..utilities.view import refresh
+from .base_constraint import GenericConstraintOp
 
 logger = logging.getLogger(__name__)
 
@@ -87,8 +86,8 @@ class VIEW3D_OT_slvs_merge_points(Operator):
         return bool(get_active_sketch(context))
 
     def execute(self, context: Context):
-        from ..model.sketch_ref import get_active_sketch
         from ..model.curve_ref import curve_ref
+        from ..model.sketch_ref import get_active_sketch
 
         sketch = get_active_sketch(context)
         if not sketch:

--- a/testing/test_merge_selfref.py
+++ b/testing/test_merge_selfref.py
@@ -8,8 +8,8 @@ place it is redundant and the solver flags it as failed (``REDUNDANT_OK``); the
 merge must drop it instead.
 """
 
-from .utils import Sketch2dTestCase
 from ..operators.add_geometric_constraints import merge_points
+from .utils import Sketch2dTestCase
 
 
 class TestMergeSelfReferential(Sketch2dTestCase):
@@ -47,9 +47,7 @@ class TestMergeSelfReferential(Sketch2dTestCase):
         p1 = self.add_point((0, 0))
         p2 = self.add_point((0.001, 0))
         other = self.add_point((5, 0))
-        keep = sk.constraints.add_coincident(
-            curve_id_1=p1.curve_id, curve_id_2=other.curve_id
-        )
+        sk.constraints.add_coincident(curve_id_1=p1.curve_id, curve_id_2=other.curve_id)
 
         merge_points(self.context, p1, p2)
 

--- a/testing/test_merge_selfref.py
+++ b/testing/test_merge_selfref.py
@@ -1,0 +1,72 @@
+"""Regression: merging two coincident-constrained points must not leave a
+self-referential coincident constraint behind.
+
+``merge_points`` remaps every constraint's curve references from the duplicate to
+the target. A coincident constraint that joined the two merged points therefore
+collapses to ``curve_id_1 == curve_id_2`` (a point coincident with itself). Left in
+place it is redundant and the solver flags it as failed (``REDUNDANT_OK``); the
+merge must drop it instead.
+"""
+
+from .utils import Sketch2dTestCase
+from ..operators.add_geometric_constraints import merge_points
+
+
+class TestMergeSelfReferential(Sketch2dTestCase):
+    def _coincident(self):
+        return list(self.sketch.constraints.coincident)
+
+    def test_pairwise_merge_drops_joining_coincident(self):
+        sk = self.sketch
+        p1 = self.add_point((0, 0))
+        p2 = self.add_point((0.001, 0))
+        sk.constraints.add_coincident(curve_id_1=p1.curve_id, curve_id_2=p2.curve_id)
+
+        merge_points(self.context, p1, p2)
+
+        self.assertEqual(
+            self._coincident(), [], "joining coincident should be removed by merge"
+        )
+
+    def test_chain_merge_drops_all_collapsed_coincidents(self):
+        sk = self.sketch
+        p1 = self.add_point((0, 0))
+        p2 = self.add_point((0.001, 0))
+        p3 = self.add_point((0.002, 0))
+        sk.constraints.add_coincident(curve_id_1=p1.curve_id, curve_id_2=p2.curve_id)
+        sk.constraints.add_coincident(curve_id_1=p2.curve_id, curve_id_2=p3.curve_id)
+
+        for dup in (p1, p2):
+            merge_points(self.context, dup, p3)
+
+        self.assertEqual(self._coincident(), [])
+
+    def test_unrelated_coincident_is_preserved(self):
+        """A coincident that only touches one merged point is remapped, not dropped."""
+        sk = self.sketch
+        p1 = self.add_point((0, 0))
+        p2 = self.add_point((0.001, 0))
+        other = self.add_point((5, 0))
+        keep = sk.constraints.add_coincident(
+            curve_id_1=p1.curve_id, curve_id_2=other.curve_id
+        )
+
+        merge_points(self.context, p1, p2)
+
+        remaining = self._coincident()
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining[0].curve_id_1, p2.curve_id)
+        self.assertEqual(remaining[0].curve_id_2, other.curve_id)
+
+    def test_solver_reports_no_redundancy_after_merge(self):
+        """The failed/redundant state the bug produced is gone once merged."""
+        sk = self.sketch
+        p1 = self.add_point((0, 0))
+        p2 = self.add_point((0.001, 0), fixed=True)
+        sk.constraints.add_coincident(curve_id_1=p1.curve_id, curve_id_2=p2.curve_id)
+
+        merge_points(self.context, p1, p2)
+        self.solve()
+
+        self.assertNotEqual(sk.solver_state, "REDUNDANT_OK")
+        self.assertFalse(any(c.failed for c in self._coincident()))

--- a/testing/test_merge_selfref.py
+++ b/testing/test_merge_selfref.py
@@ -1,11 +1,15 @@
-"""Regression: merging two coincident-constrained points must not leave a
-self-referential coincident constraint behind.
+"""Regression: merging points must not leave redundant coincident constraints.
 
 ``merge_points`` remaps every constraint's curve references from the duplicate to
-the target. A coincident constraint that joined the two merged points therefore
-collapses to ``curve_id_1 == curve_id_2`` (a point coincident with itself). Left in
-place it is redundant and the solver flags it as failed (``REDUNDANT_OK``); the
-merge must drop it instead.
+the target. That can leave two kinds of redundant constraint the solver reports as
+failed (``REDUNDANT_OK``):
+
+* self-referential -- a coincident joining the two merged points collapses to
+  ``curve_id_1 == curve_id_2`` (a point coincident with itself);
+* duplicate -- two points each constrained to the same third entity (a point, a
+  line, a circle...) collapse to identical constraints.
+
+The merge must drop both.
 """
 
 from ..operators.add_geometric_constraints import merge_points
@@ -55,6 +59,39 @@ class TestMergeSelfReferential(Sketch2dTestCase):
         self.assertEqual(len(remaining), 1)
         self.assertEqual(remaining[0].curve_id_1, p2.curve_id)
         self.assertEqual(remaining[0].curve_id_2, other.curve_id)
+
+    def test_points_on_same_line_dedupe(self):
+        """Two points constrained onto the same line collapse to one coincident."""
+        sk = self.sketch
+        a = self.add_point((0, 0))
+        b = self.add_point((5, 0))
+        line = self.add_line(a, b)
+        p1 = self.add_point((1, 0.01))
+        p2 = self.add_point((2, -0.01))
+        sk.constraints.add_coincident(curve_id_1=p1.curve_id, curve_id_2=line.curve_id)
+        sk.constraints.add_coincident(curve_id_1=p2.curve_id, curve_id_2=line.curve_id)
+
+        merge_points(self.context, p1, p2)
+        self.solve()
+
+        remaining = self._coincident()
+        self.assertEqual(len(remaining), 1, "duplicate point-on-line not deduped")
+        self.assertNotEqual(sk.solver_state, "REDUNDANT_OK")
+        self.assertFalse(any(c.failed for c in remaining))
+
+    def test_points_on_same_hub_point_dedupe(self):
+        """Two points constrained onto the same third point collapse to one."""
+        sk = self.sketch
+        hub = self.add_point((0, 0))
+        p1 = self.add_point((0.01, 0))
+        p2 = self.add_point((-0.01, 0))
+        sk.constraints.add_coincident(curve_id_1=p1.curve_id, curve_id_2=hub.curve_id)
+        sk.constraints.add_coincident(curve_id_1=p2.curve_id, curve_id_2=hub.curve_id)
+
+        merge_points(self.context, p1, p2)
+        self.solve()
+
+        self.assertEqual(len(self._coincident()), 1)
 
     def test_solver_reports_no_redundancy_after_merge(self):
         """The failed/redundant state the bug produced is gone once merged."""

--- a/testing/test_merge_selfref.py
+++ b/testing/test_merge_selfref.py
@@ -93,6 +93,60 @@ class TestMergeSelfReferential(Sketch2dTestCase):
 
         self.assertEqual(len(self._coincident()), 1)
 
+    def test_merge_online_point_onto_line_endpoint(self):
+        """Merging a point that's coincident on a line onto that line's endpoint
+        leaves the point structurally on the curve -- the coincident is redundant."""
+        sk = self.sketch
+        a = self.add_point((0, 0))
+        b = self.add_point((5, 0))  # line's end endpoint
+        line = self.add_line(a, b)
+        online = self.add_point((2, 0.02))
+        sk.constraints.add_coincident(
+            curve_id_1=online.curve_id, curve_id_2=line.curve_id
+        )
+
+        merge_points(self.context, online, b)  # keep the endpoint
+        self.solve()
+
+        self.assertEqual(self._coincident(), [], "point-on-own-curve not removed")
+        self.assertNotEqual(sk.solver_state, "REDUNDANT_OK")
+
+    def test_merge_line_endpoint_onto_online_point(self):
+        """Same redundancy in the other merge direction (endpoint is the duplicate)."""
+        sk = self.sketch
+        a = self.add_point((0, 0))
+        b = self.add_point((5, 0))
+        line = self.add_line(a, b)
+        online = self.add_point((2, 0.02))
+        sk.constraints.add_coincident(
+            curve_id_1=online.curve_id, curve_id_2=line.curve_id
+        )
+
+        merge_points(self.context, b, online)  # keep the on-line point
+        self.solve()
+
+        self.assertEqual(self._coincident(), [])
+        self.assertNotEqual(sk.solver_state, "REDUNDANT_OK")
+
+    def test_interior_point_on_line_is_preserved(self):
+        """A point coincident on a line but NOT one of its endpoints stays."""
+        sk = self.sketch
+        a = self.add_point((0, 0))
+        b = self.add_point((5, 0))
+        line = self.add_line(a, b)
+        p1 = self.add_point((2, 0.02))
+        p2 = self.add_point((3, -0.02))
+        sk.constraints.add_coincident(curve_id_1=p1.curve_id, curve_id_2=line.curve_id)
+        sk.constraints.add_coincident(curve_id_1=p2.curve_id, curve_id_2=line.curve_id)
+
+        # Merge two interior on-line points: result is one interior coincident.
+        merge_points(self.context, p1, p2)
+        self.solve()
+
+        remaining = self._coincident()
+        self.assertEqual(len(remaining), 1, "interior point-on-line must survive")
+        self.assertEqual(remaining[0].curve_id_2, line.curve_id)
+
     def test_solver_reports_no_redundancy_after_merge(self):
         """The failed/redundant state the bug produced is gone once merged."""
         sk = self.sketch


### PR DESCRIPTION
## Problem

Merging two points that were joined by a coincident constraint leaves a broken constraint behind. `merge_points()` remaps every constraint's curve references from the duplicate to the target, so a coincident constraint linking the two merged points collapses to `curve_id_1 == curve_id_2` — a point constrained coincident with itself.

That self-referential constraint stays in the sketch. On its own it is trivially satisfiable, but as soon as the target point is otherwise constrained (fixed, or an endpoint of constrained geometry — the normal case) it becomes redundant and the solver reports `REDUNDANT_OK`, flagging the constraint as failed.

This is easy to hit: select three points that form a coincident chain and run Merge Points, and two failed self-coincident constraints are left over.

## Fix

After the remap, drop any constraint whose two curve references collapsed onto the same curve. This mirrors the existing collapsed-line cleanup in the merge operator. Constraints that only touch one of the merged points are still remapped and preserved.

## Tests

Adds `testing/test_merge_selfref.py`:
- pairwise merge removes the joining coincident
- chained-coincident merge removes all collapsed constraints
- an unrelated coincident is remapped, not dropped
- solver no longer reports redundancy after the merge

All pass; related suites (`test_merge_id`, `test_fill_coincident`, `test_constraint_ops`, `test_trim`) still green.
