### PR TITLE
Project elements from curve objects (per-element hover, highlight, projection)

### DIFF
--- a/draw_handler.py
+++ b/draw_handler.py
@@ -138,6 +138,33 @@ def _draw_vertex_hover(context, ob, index, col, scale):
     gpu.state.blend_set("NONE")
 
 
+def _draw_curve_element_hover(ob, key, col, scale):
+    """Highlight one hovered curve element: its segments and/or its point.
+
+    A line highlights its segment, an arc/circle its tessellated segments, a
+    point its position -- so the whole element under the cursor lights up.
+    """
+    from .drawing.reference_pick import element_geometry
+
+    points, segments = element_geometry(ob, key)
+    if segments:
+        lines = []
+        for a, b in segments:
+            lines += [a, b]
+        _draw_lines_hover(lines, col, scale, width=3)
+    if points:
+        shader = Shaders.point_color_3d()
+        shader.bind()
+        gpu.state.blend_set("ALPHA")
+        gpu.state.point_size_set(8 * scale)
+        shader.uniform_float("color", col)
+        batch = batch_for_shader(shader, "POINTS", {"pos": points})
+        batch.draw(shader)
+        gpu.shader.unbind()
+        gpu.state.point_size_set(1)
+        gpu.state.blend_set("NONE")
+
+
 def draw_hover_element():
     """POST_VIEW: highlight the hovered element per its type.
 
@@ -175,6 +202,9 @@ def draw_hover_element():
         _draw_face_hover(context, ob, index, col, scale)
     elif kind == "VERTEX":
         _draw_vertex_hover(context, ob, index, col, scale)
+    elif kind == "CURVE_ELEM":
+        # ``index`` is the element key (a curve_id or index tuple).
+        _draw_curve_element_hover(ob, index, col, scale)
 
 
 def draw_origin_labels():

--- a/drawing/picking.py
+++ b/drawing/picking.py
@@ -74,6 +74,49 @@ def _dist_to_segment(a, b, px, py):
     return ((px - cx) ** 2 + (py - cy) ** 2) ** 0.5
 
 
+def rank_hits(point_items, seg_items, context, coords):
+    """Ranked element keys from generic ``(key, world)`` datasets under ``coords``.
+
+    ``point_items``: ``[(key, world_pos), ...]``; ``seg_items``: ``[(key, a, b),
+    ...]``. Points take priority over segments, then nearest first, and keys are
+    deduped. Shared by the active-sketch picker and reference curve-object picking
+    (``reference_pick``), so it must stay independent of any sketch specifics.
+    """
+    region, rv3d = context.region, context.region_data
+    if region is None or rv3d is None:
+        return []
+
+    scale = get_scale()
+    cx, cy = float(coords[0]), float(coords[1])
+    hits = []  # (priority, distance, key)
+
+    if point_items:
+        keys, screen, valid = _points_screen(point_items, region, rv3d)
+        d = np.hypot(screen[:, 0] - cx, screen[:, 1] - cy)
+        r = _POINT_RADIUS * scale
+        for i, key in enumerate(keys):
+            if valid[i] and d[i] <= r:
+                hits.append((0, float(d[i]), key))
+
+    if seg_items:
+        keys, screen, valid = _seg_screen(seg_items, region, rv3d)
+        r = _EDGE_RADIUS * scale
+        for i, key in enumerate(keys):
+            if not (valid[i, 0] and valid[i, 1]):
+                continue
+            dist = _dist_to_segment(screen[i, 0], screen[i, 1], cx, cy)
+            if dist <= r:
+                hits.append((1, float(dist), key))
+
+    hits.sort(key=lambda h: (h[0], h[1]))
+    ranked, seen = [], set()
+    for _, _, key in hits:
+        if key not in seen:
+            seen.add(key)
+            ranked.append(key)
+    return ranked
+
+
 def pick_ranked(context, coords):
     """curve_ids of every active-sketch element under ``coords``, nearest first.
 
@@ -82,42 +125,12 @@ def pick_ranked(context, coords):
     radius, so overlapping entities can be cycled through instead of only ever
     getting the topmost one (issue #50)."""
     data = _active_data(context)
-    region, rv3d = context.region, context.region_data
-    if data is None or region is None or rv3d is None:
+    if data is None:
         return []
-
     ignore = selection.ignore_list
-    scale = get_scale()
-    cx, cy = float(coords[0]), float(coords[1])
-    hits = []  # (priority, distance, cid)
-
     pts = [(cid, p) for cid, p in data.point_ids if cid not in ignore]
-    if pts:
-        cids, screen, valid = _points_screen(pts, region, rv3d)
-        d = np.hypot(screen[:, 0] - cx, screen[:, 1] - cy)
-        r = _POINT_RADIUS * scale
-        for i, cid in enumerate(cids):
-            if valid[i] and d[i] <= r:
-                hits.append((0, float(d[i]), cid))
-
     segs = [(cid, a, b) for cid, a, b in data.segment_ids if cid not in ignore]
-    if segs:
-        cids, screen, valid = _seg_screen(segs, region, rv3d)
-        r = _EDGE_RADIUS * scale
-        for i, cid in enumerate(cids):
-            if not (valid[i, 0] and valid[i, 1]):
-                continue
-            dist = _dist_to_segment(screen[i, 0], screen[i, 1], cx, cy)
-            if dist <= r:
-                hits.append((1, float(dist), cid))
-
-    hits.sort(key=lambda h: (h[0], h[1]))
-    ranked, seen = [], set()
-    for _, _, cid in hits:
-        if cid not in seen:
-            seen.add(cid)
-            ranked.append(cid)
-    return ranked
+    return rank_hits(pts, segs, context, coords)
 
 
 def pick(context, coords):

--- a/drawing/reference_pick.py
+++ b/drawing/reference_pick.py
@@ -1,0 +1,91 @@
+"""Screen-space picking of *reference* curve objects (not the active sketch).
+
+Phase 1 of per-element curve hover/pick: extract a curve object's pickable
+geometry (points and tessellated segments) in world space, then rank it under
+the cursor with the same screen-space test the active-sketch picker uses
+(``picking.rank_hits``).
+
+Supported sources:
+- CAD Sketcher sketches (a Curves object carrying ``sketch_type``/``curve_id``):
+  reuse the sketch extraction, so elements are keyed by ``curve_id`` and
+  arcs/circles are already tessellated into pickable segments.
+- Raw Blender Curves objects: control points and the polyline between them,
+  keyed by index.
+
+Legacy ``Curve`` (bezier/nurbs) objects are not handled yet; they return empty.
+"""
+
+from mathutils import Vector
+
+from ..utilities.curve_data import has_uuid_field
+from . import picking
+
+
+def _is_sketch(curve_data) -> bool:
+    """Whether a Curves datablock is a CAD Sketcher sketch (has our attributes)."""
+    return (
+        curve_data.attributes.get("sketch_type") is not None
+        and has_uuid_field(curve_data, "curve_id") is not None
+    )
+
+
+def _sketch_geometry(obj):
+    """Pickable points/segments of a sketch, keyed by ``curve_id``.
+
+    Reuses ``render_data.build``, which already projects points and tessellates
+    lines/arcs/circles into ``point_ids`` / ``segment_ids`` for picking.
+    """
+    from ..model.sketch_ref import Sketch
+    from ..utilities.preferences import get_prefs
+    from . import render_data
+
+    sketch = Sketch(obj)
+    ts = get_prefs().theme_settings.entity
+    rd = render_data.build(sketch, ts, is_active=False)
+    return rd.point_ids, rd.segment_ids
+
+
+def _raw_curves_geometry(obj):
+    """Pickable points/segments of a raw Curves object, keyed by index.
+
+    Each control point is a pickable point; each span between consecutive points
+    of a curve is a pickable segment. No arc concept exists on a raw Curves
+    object, so its curves are treated as polylines.
+    """
+    data = obj.data
+    mat = obj.matrix_world
+    points, segments = [], []
+    for ci, curve in enumerate(data.curves):
+        n = curve.points_length
+        if n == 0:
+            continue
+        first = curve.points[0].index
+        world = [(mat @ Vector(data.points[first + k].position))[:] for k in range(n)]
+        for k in range(n):
+            points.append((("point", first + k), world[k]))
+        for k in range(n - 1):
+            segments.append((("seg", ci, k), world[k], world[k + 1]))
+    return points, segments
+
+
+def extract_pickable_geometry(obj):
+    """Return ``(points, segments)`` of a curve object in world space.
+
+    ``points``:   ``[(key, world_pos), ...]``
+    ``segments``: ``[(key, world_a, world_b), ...]`` (arcs/circles tessellated)
+
+    ``key`` identifies the source element: a sketch's ``curve_id`` string, or an
+    index-based tuple for a raw Curves object. Non-Curves or legacy ``Curve``
+    objects return empty (legacy bezier/nurbs support is a later slice).
+    """
+    if obj is None or obj.type != "CURVES" or obj.data is None:
+        return [], []
+    if _is_sketch(obj.data):
+        return _sketch_geometry(obj)
+    return _raw_curves_geometry(obj)
+
+
+def pick_object_ranked(obj, context, coords):
+    """Keys of ``obj``'s elements under ``coords``, nearest first (points first)."""
+    points, segments = extract_pickable_geometry(obj)
+    return picking.rank_hits(points, segments, context, coords)

--- a/drawing/reference_pick.py
+++ b/drawing/reference_pick.py
@@ -89,3 +89,41 @@ def pick_object_ranked(obj, context, coords):
     """Keys of ``obj``'s elements under ``coords``, nearest first (points first)."""
     points, segments = extract_pickable_geometry(obj)
     return picking.rank_hits(points, segments, context, coords)
+
+
+def pick_reference_element(context, coords, exclude=None):
+    """Nearest ``(object, element_key)`` across visible curve objects under coords.
+
+    Merges every visible curve object's pickable geometry into one screen-space
+    ranking so the closest element wins regardless of which object it belongs to.
+    ``exclude`` skips an object (e.g. the active sketch, to avoid self-reference).
+    """
+    objs = {}
+    point_items, seg_items = [], []
+    for ob in context.visible_objects:
+        if ob.type != "CURVES" or ob == exclude:
+            continue
+        pts, segs = extract_pickable_geometry(ob)
+        if not pts and not segs:
+            continue
+        objs[ob.name] = ob
+        point_items += [((ob.name, key), pos) for key, pos in pts]
+        seg_items += [((ob.name, key), a, b) for key, a, b in segs]
+
+    ranked = picking.rank_hits(point_items, seg_items, context, coords)
+    if not ranked:
+        return None
+    obj_name, key = ranked[0]
+    return objs[obj_name], key
+
+
+def element_geometry(obj, key):
+    """World-space ``(points, segments)`` of just element ``key`` of ``obj``.
+
+    Used to highlight one hovered element: a point returns its position, a line
+    its single segment, an arc/circle its tessellated segments.
+    """
+    pts, segs = extract_pickable_geometry(obj)
+    points = [pos for k, pos in pts if k == key]
+    segments = [(a, b) for k, a, b in segs if k == key]
+    return points, segments

--- a/gizmos/object_hover.py
+++ b/gizmos/object_hover.py
@@ -94,13 +94,28 @@ def detect_hover(context, coords, types):
     want_face = MeshPolygon in types
 
     if want_vertex or want_edge or want_face:
+        # CURVES objects (sketches / native curves) hover as whole elements --
+        # points, lines, arcs, circles -- via the screen-space reference pick,
+        # taking priority over a raycast hit on a sketch's converted fill mesh.
+        from ..drawing.reference_pick import pick_reference_element
+        from ..model.sketch_ref import get_active_sketch
+
+        active = get_active_sketch(context)
+        ref = pick_reference_element(
+            context, coords, exclude=active.target_object if active else None
+        )
+        if ref is not None:
+            ob, key = ref
+            return ("CURVE_ELEM", ob.name, key)
+
         ob, elem_type, index = get_mesh_element(
             context, coords, vertex=want_vertex, edge=want_edge, face=want_face
         )
         if ob is not None and elem_type in ("VERTEX", "EDGE", "FACE"):
             return (elem_type, ob.name, index)
 
-        # Curves aren't raycastable -> screen-space segment pick for edge states.
+        # Legacy Curve objects (bezier/nurbs) aren't handled by reference_pick
+        # yet; keep the raw segment-hover fallback for them.
         if want_edge:
             from ..utilities.view import curve_segment_under_cursor
 

--- a/global_data.py
+++ b/global_data.py
@@ -9,7 +9,10 @@ batches = {}
 
 # Typed hover element under the cursor for object/mesh-picking tools, published
 # by the hover gizmo and rendered by the draw handler. One of:
-#   ("OBJECT", name, None) | ("VERTEX"|"EDGE"|"FACE", name, index) | None
+#   ("OBJECT", name, None) | ("VERTEX"|"EDGE"|"FACE", name, index)
+#   | ("CURVE_ELEM", name, element_key) | None
+# CURVE_ELEM is a whole curve element (line/arc/circle/point) of a Curves object;
+# element_key is its curve_id (sketch) or index tuple (raw), see reference_pick.
 hover_element = None
 # Accepted pick types of the current stateful-operator state (or None), so the
 # hover gizmo detects/highlights what this state will actually pick.

--- a/operators/base_2d.py
+++ b/operators/base_2d.py
@@ -216,12 +216,14 @@ class Operator2d(GenericEntityOp):
         if snap_type not in ("VERTEX", "EDGE_MIDPOINT", "EDGE"):
             return
         source = bpy.data.objects.get(snap.get("object") or "")
-        if source is None or source.type != "MESH":
+        if source is None or source.type not in ("MESH", "CURVES"):
             return
+        is_curve = source.type == "CURVES"
 
-        # Snapping reads the evaluated mesh; resolve the evaluated vertices back to
-        # the original ones to bind (by persistent id when tagged, else an
-        # order-preserving index). Skip when the correspondence isn't trustworthy.
+        # A mesh snap reports evaluated-mesh indices that must map back to the
+        # original vertices (by persistent id when tagged, else an order-preserving
+        # index). A curve snap reads the source's control points directly, so its
+        # indices are already the originals -- no remap needed.
         from ..stateful_operator.utilities.geometry import get_evaluated_obj
         from ..utilities.projection_anchor import (
             project_mesh_edge,
@@ -229,8 +231,13 @@ class Operator2d(GenericEntityOp):
             resolve_source_vertex_index,
         )
 
-        eval_source = get_evaluated_obj(context, source)
+        eval_source = None if is_curve else get_evaluated_obj(context, source)
         world_point = snap.get("world_point")
+
+        def _orig(index):
+            if is_curve:
+                return index
+            return resolve_source_vertex_index(source, eval_source, index)
 
         # Place the point where the user snapped (the evaluated hit), so a
         # vertex-moving modifier doesn't leave it a frame behind the source.
@@ -238,7 +245,7 @@ class Operator2d(GenericEntityOp):
             v_index = snap.get("vertex_index")
             if v_index is None:
                 return
-            orig = resolve_source_vertex_index(source, eval_source, v_index)
+            orig = _orig(v_index)
             if orig is None:
                 return
             projected = project_mesh_vertex(
@@ -248,8 +255,8 @@ class Operator2d(GenericEntityOp):
             edge = snap.get("edge_vertices")
             if not edge:
                 return
-            orig_a = resolve_source_vertex_index(source, eval_source, edge[0])
-            orig_b = resolve_source_vertex_index(source, eval_source, edge[1])
+            orig_a = _orig(edge[0])
+            orig_b = _orig(edge[1])
             if orig_a is None or orig_b is None:
                 return
             projected = project_mesh_edge(

--- a/operators/project_geometry.py
+++ b/operators/project_geometry.py
@@ -17,7 +17,7 @@ from ..stateful_operator.integration import StatefulOperator
 from ..stateful_operator.state import state_from_args
 from ..stateful_operator.utilities.register import register_stateops_factory
 from ..utilities.curve_data import refresh_curve_geometry
-from ..utilities.projection_anchor import project_mesh_element
+from ..utilities.projection_anchor import project_curves_element, project_mesh_element
 from .base_stateful import GenericEntityOp
 
 _TYPE_TO_ELEMENT = {
@@ -56,26 +56,61 @@ class VIEW3D_OT_slvs_project_geometry(Operator, GenericEntityOp):
         return get_active_sketch(context) is not None
 
     def pick_element(self, context: Context, coords):
-        # Only the raw mesh-element pick; skip GenericEntityOp's curve/constraint
-        # hover handling, which is irrelevant when projecting scene meshes.
-        return StatefulOperator.pick_element(self, context, coords)
+        # Raw mesh-element pick first (skip GenericEntityOp's curve/constraint
+        # hover handling). With no mesh hit, fall back to a reference curve element
+        # so another sketch's line/point can be picked and projected -- agreeing
+        # with the hover gizmo, which uses the same reference pick.
+        retval = StatefulOperator.pick_element(self, context, coords)
+        data = self.state_data
+        if retval is not None:
+            data.pop("curve_ref", None)
+            return retval
+
+        from ..drawing.reference_pick import pick_reference_element
+
+        active = get_active_sketch(context)
+        ref = pick_reference_element(
+            context, coords, exclude=active.target_object if active else None
+        )
+        if ref is not None:
+            ob, key = ref
+            data["curve_ref"] = (ob.name, key)
+            data["type"] = None  # not a mesh element; dispatched via curve_ref
+            return (ob.name,)
+        data.pop("curve_ref", None)
+        return None
 
     def main(self, context: Context):
         sketch = get_active_sketch(context)
+        if sketch is None:
+            return False
         data = self._state_data.get(0, {})
-        elem = _TYPE_TO_ELEMENT.get(data.get("type"))
-        pointer = self.get_state_pointer(index=0, implicit=True)
-        if sketch is None or elem is None or not pointer:
-            return False
 
-        obj_name, mesh_index = pointer
-        source = bpy.data.objects.get(obj_name)
-        if source is None or source.type != "MESH":
-            return False
+        curve_ref = data.get("curve_ref")
+        if curve_ref:
+            source = bpy.data.objects.get(curve_ref[0])
+            if source is None:
+                return False
+            n_points, n_lines, skipped = project_curves_element(
+                sketch, source, curve_ref[1], construction=self.construction
+            )
+            if skipped:
+                self.report(
+                    {"INFO"}, "This curve element can't be projected yet (arc/circle)"
+                )
+        else:
+            elem = _TYPE_TO_ELEMENT.get(data.get("type"))
+            pointer = self.get_state_pointer(index=0, implicit=True)
+            if elem is None or not pointer:
+                return False
+            obj_name, mesh_index = pointer
+            source = bpy.data.objects.get(obj_name)
+            if source is None or source.type != "MESH":
+                return False
+            n_points, n_lines = project_mesh_element(
+                sketch, source, elem, mesh_index, construction=self.construction
+            )
 
-        n_points, n_lines = project_mesh_element(
-            sketch, source, elem, mesh_index, construction=self.construction
-        )
         if n_points or n_lines:
             refresh_curve_geometry(sketch)
             from .. import global_data

--- a/operators/project_geometry.py
+++ b/operators/project_geometry.py
@@ -6,6 +6,8 @@ projects just that element as live native curves through the shared
 ``project_mesh_element`` path. Re-run to project more; shared corners are reused.
 """
 
+import logging
+
 import bpy
 from bpy.props import BoolProperty
 from bpy.types import Context, Operator
@@ -19,6 +21,8 @@ from ..stateful_operator.utilities.register import register_stateops_factory
 from ..utilities.curve_data import refresh_curve_geometry
 from ..utilities.projection_anchor import project_curves_element, project_mesh_element
 from .base_stateful import GenericEntityOp
+
+logger = logging.getLogger(__name__)
 
 _TYPE_TO_ELEMENT = {
     bpy.types.MeshVertex: "VERTEX",
@@ -64,6 +68,7 @@ class VIEW3D_OT_slvs_project_geometry(Operator, GenericEntityOp):
         data = self.state_data
         if retval is not None:
             data.pop("curve_ref", None)
+            logger.debug("project pick: mesh element %s", retval)
             return retval
 
         from ..drawing.reference_pick import pick_reference_element
@@ -72,27 +77,47 @@ class VIEW3D_OT_slvs_project_geometry(Operator, GenericEntityOp):
         ref = pick_reference_element(
             context, coords, exclude=active.target_object if active else None
         )
+        logger.debug("project pick: no mesh hit; reference curve element -> %s", ref)
         if ref is not None:
             ob, key = ref
             data["curve_ref"] = (ob.name, key)
             data["type"] = None  # not a mesh element; dispatched via curve_ref
-            return (ob.name,)
+            return (ob.name, key)
         data.pop("curve_ref", None)
         return None
+
+    def get_state_pointer(self, index=None, implicit=False):
+        # A picked curve element has no mesh/entity pointer, so report the stashed
+        # reference as the state's pointer -- otherwise check_props() sees an empty
+        # pointer and never calls main() (nothing would project).
+        idx = self.state_index if index is None else index
+        data = self._state_data.get(idx, {})
+        if data.get("curve_ref"):
+            return data["curve_ref"]
+        return super().get_state_pointer(index=index, implicit=implicit)
 
     def main(self, context: Context):
         sketch = get_active_sketch(context)
         if sketch is None:
+            logger.debug("project main: no active sketch")
             return False
         data = self._state_data.get(0, {})
 
         curve_ref = data.get("curve_ref")
+        logger.debug("project main: curve_ref=%s type=%s", curve_ref, data.get("type"))
         if curve_ref:
             source = bpy.data.objects.get(curve_ref[0])
             if source is None:
+                logger.debug("project main: source object %r missing", curve_ref[0])
                 return False
             n_points, n_lines, skipped = project_curves_element(
                 sketch, source, curve_ref[1], construction=self.construction
+            )
+            logger.debug(
+                "project main: curve element -> points=%s lines=%s skipped=%s",
+                n_points,
+                n_lines,
+                skipped,
             )
             if skipped:
                 self.report(

--- a/operators/project_geometry.py
+++ b/operators/project_geometry.py
@@ -6,8 +6,6 @@ projects just that element as live native curves through the shared
 ``project_mesh_element`` path. Re-run to project more; shared corners are reused.
 """
 
-import logging
-
 import bpy
 from bpy.props import BoolProperty
 from bpy.types import Context, Operator
@@ -21,8 +19,6 @@ from ..stateful_operator.utilities.register import register_stateops_factory
 from ..utilities.curve_data import refresh_curve_geometry
 from ..utilities.projection_anchor import project_curves_element, project_mesh_element
 from .base_stateful import GenericEntityOp
-
-logger = logging.getLogger(__name__)
 
 _TYPE_TO_ELEMENT = {
     bpy.types.MeshVertex: "VERTEX",
@@ -68,7 +64,6 @@ class VIEW3D_OT_slvs_project_geometry(Operator, GenericEntityOp):
         data = self.state_data
         if retval is not None:
             data.pop("curve_ref", None)
-            logger.debug("project pick: mesh element %s", retval)
             return retval
 
         from ..drawing.reference_pick import pick_reference_element
@@ -77,7 +72,6 @@ class VIEW3D_OT_slvs_project_geometry(Operator, GenericEntityOp):
         ref = pick_reference_element(
             context, coords, exclude=active.target_object if active else None
         )
-        logger.debug("project pick: no mesh hit; reference curve element -> %s", ref)
         if ref is not None:
             ob, key = ref
             data["curve_ref"] = (ob.name, key)
@@ -99,25 +93,16 @@ class VIEW3D_OT_slvs_project_geometry(Operator, GenericEntityOp):
     def main(self, context: Context):
         sketch = get_active_sketch(context)
         if sketch is None:
-            logger.debug("project main: no active sketch")
             return False
         data = self._state_data.get(0, {})
 
         curve_ref = data.get("curve_ref")
-        logger.debug("project main: curve_ref=%s type=%s", curve_ref, data.get("type"))
         if curve_ref:
             source = bpy.data.objects.get(curve_ref[0])
             if source is None:
-                logger.debug("project main: source object %r missing", curve_ref[0])
                 return False
             n_points, n_lines, skipped = project_curves_element(
                 sketch, source, curve_ref[1], construction=self.construction
-            )
-            logger.debug(
-                "project main: curve element -> points=%s lines=%s skipped=%s",
-                n_points,
-                n_lines,
-                skipped,
             )
             if skipped:
                 self.report(

--- a/testing/test_projection_anchor.py
+++ b/testing/test_projection_anchor.py
@@ -8,6 +8,7 @@ from ..utilities.projection_anchor import (
     PROJECT_VERTEX_INDEX_ATTR,
     VERTEX_ID_ATTR,
     find_projected_point,
+    project_curves_element,
     project_curves_object,
     project_mesh_edge,
     project_mesh_element,
@@ -377,3 +378,49 @@ class TestProjectionAnchor(Sketch2dTestCase):
         self.assertEqual(resolve_source_vertex_index(source, eval_source, 1), 1)
         # An out-of-range evaluated index resolves to nothing rather than crash.
         self.assertIsNone(resolve_source_vertex_index(source, eval_source, 99))
+
+    def test_project_single_sketch_line_element(self):
+        # Project just one picked line of a source sketch (Phase 3 of the tool).
+        from ..model.curve_ref import LineRef, PointRef
+
+        src = self.new_sketch()
+        p1 = PointRef.create(src, (0.0, 0.0))
+        p2 = PointRef.create(src, (2.0, 3.0))
+        line = LineRef.create(src, p1, p2)
+
+        points, lines, skipped = project_curves_element(
+            self.sketch, src.target_object, line.curve_id
+        )
+        self.assertEqual(len(points), 2)
+        self.assertEqual(len(lines), 1)
+        self.assertEqual(skipped, 0)
+        self.assertTrue(all(p.fixed for p in points))
+
+        # Idempotent: re-projecting the same line reuses its endpoints, adds none.
+        p_again, l_again, _ = project_curves_element(
+            self.sketch, src.target_object, line.curve_id
+        )
+        self.assertEqual(len(p_again), 0)
+        self.assertEqual(len(l_again), 0)
+
+    def test_project_single_sketch_arc_element_is_skipped(self):
+        from ..model.curve_ref import ArcRef, PointRef
+
+        src = self.new_sketch()
+        center = PointRef.create(src, (0.0, 0.0))
+        start = PointRef.create(src, (1.0, 0.0))
+        end = PointRef.create(src, (0.0, 1.0))
+        arc = ArcRef.create(src, center, start, end)
+
+        points, lines, skipped = project_curves_element(
+            self.sketch, src.target_object, arc.curve_id
+        )
+        self.assertEqual((len(points), len(lines), skipped), (0, 0, 1))
+
+    def test_project_element_rejects_non_sketch_key(self):
+        # A raw-Curves index key is hoverable but not projectable yet.
+        src = self.new_sketch()
+        self.assertEqual(
+            project_curves_element(self.sketch, src.target_object, ("point", 0)),
+            ([], [], 1),
+        )

--- a/testing/test_projection_anchor.py
+++ b/testing/test_projection_anchor.py
@@ -424,3 +424,28 @@ class TestProjectionAnchor(Sketch2dTestCase):
             project_curves_element(self.sketch, src.target_object, ("point", 0)),
             ([], [], 1),
         )
+
+    def test_snap_projection_primitives_accept_a_curve_source(self):
+        # The #619 draw-snap projection reuses project_mesh_vertex/edge; these must
+        # now accept a Curves source so snapping onto a sketch/curve live-projects
+        # its control point or segment (not just meshes).
+        import bpy
+
+        cu = bpy.data.hair_curves.new("SnapSrc")
+        cu.add_curves([2])
+        cu.points[0].position = (0.0, 0.0, 0.0)
+        cu.points[1].position = (2.0, 0.0, 0.0)
+        src = bpy.data.objects.new("SnapSrcCurve", cu)
+        self.scene.collection.objects.link(src)
+
+        # Vertex: binds a fixed, source-tracked point to control point 0, deduped.
+        pv = project_mesh_vertex(self.sketch, src, 0, construction=True)
+        self.assertIsNotNone(pv)
+        self.assertTrue(pv.fixed)
+        self.assertIsNotNone(find_projected_point(self.sketch, src, 0))
+        self.assertEqual(project_mesh_vertex(self.sketch, src, 0).curve_id, pv.curve_id)
+
+        # Edge: projects a live line bound to both control points.
+        line = project_mesh_edge(self.sketch, src, 0, 1, construction=True)
+        self.assertIsNotNone(line)
+        self.assertIsNotNone(find_projected_point(self.sketch, src, 1))

--- a/testing/test_reference_pick.py
+++ b/testing/test_reference_pick.py
@@ -2,7 +2,7 @@
 
 import bpy
 
-from ..drawing.reference_pick import extract_pickable_geometry
+from ..drawing.reference_pick import element_geometry, extract_pickable_geometry
 from .utils import Sketch2dTestCase
 
 
@@ -59,3 +59,31 @@ class TestReferencePickGeometry(Sketch2dTestCase):
         ob = self.data.objects.new("m", me)
         self.scene.collection.objects.link(ob)
         self.assertEqual(extract_pickable_geometry(ob), ([], []))
+
+    def test_element_geometry_isolates_one_element_for_highlight(self):
+        # element_geometry returns only the requested element's geometry, so the
+        # hover highlight lights up exactly that line / arc / point.
+        p0 = self.add_point((0.0, 0.0))
+        p1 = self.add_point((2.0, 0.0))
+        line = self.add_line(p0, p1)
+        obj = self.sketch.target_object
+
+        # a line: one segment, no owned point (its endpoints are their own elems)
+        lpoints, lsegments = element_geometry(obj, line.curve_id)
+        self.assertEqual(len(lsegments), 1)
+        self.assertEqual(lpoints, [])
+
+        # a point: its position, no segment
+        ppoints, psegments = element_geometry(obj, p0.curve_id)
+        self.assertEqual(len(ppoints), 1)
+        self.assertEqual(psegments, [])
+
+    def test_element_geometry_of_arc_is_the_tessellated_arc(self):
+        ct = self.add_point((0.0, 0.0))
+        start = self.add_point((1.0, 0.0))
+        end = self.add_point((0.0, 1.0))
+        arc = self.add_arc(ct, start, end)
+
+        points, segments = element_geometry(self.sketch.target_object, arc.curve_id)
+        self.assertGreater(len(segments), 1)  # tessellated
+        self.assertEqual(points, [])

--- a/testing/test_reference_pick.py
+++ b/testing/test_reference_pick.py
@@ -1,0 +1,61 @@
+"""World-space geometry extraction for reference curve-object picking."""
+
+import bpy
+
+from ..drawing.reference_pick import extract_pickable_geometry
+from .utils import Sketch2dTestCase
+
+
+class TestReferencePickGeometry(Sketch2dTestCase):
+    def test_sketch_extraction_keys_by_curve_id(self):
+        # A sketch source is keyed by curve_id: standalone points and line
+        # endpoints are pickable points, the line is a pickable segment.
+        p0 = self.add_point((0.0, 0.0))
+        p1 = self.add_point((2.0, 0.0))
+        line = self.add_line(p0, p1)
+        standalone = self.add_point((1.0, 1.0))
+
+        points, segments = extract_pickable_geometry(self.sketch.target_object)
+        pkeys = {k for k, _ in points}
+        skeys = {k for k, _, _ in segments}
+
+        self.assertIn(standalone.curve_id, pkeys)
+        self.assertIn(p0.curve_id, pkeys)
+        self.assertIn(p1.curve_id, pkeys)
+        self.assertIn(line.curve_id, skeys)
+
+    def test_arc_is_hoverable_as_tessellated_segments(self):
+        # Arcs must be hoverable even though projection skips them: they come out
+        # as several tessellated segments, all keyed by the arc's curve_id.
+        ct = self.add_point((0.0, 0.0))
+        start = self.add_point((1.0, 0.0))
+        end = self.add_point((0.0, 1.0))
+        arc = self.add_arc(ct, start, end)
+
+        _, segments = extract_pickable_geometry(self.sketch.target_object)
+        arc_segments = [k for k, _, _ in segments if k == arc.curve_id]
+        self.assertGreater(len(arc_segments), 1)
+
+    def test_raw_curves_object_extraction(self):
+        # A raw Curves object (no sketch attributes) extracts control points and
+        # the polyline between them, keyed by index.
+        cu = bpy.data.hair_curves.new("raw")
+        cu.add_curves([3])
+        coords = ((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0))
+        for i, co in enumerate(coords):
+            cu.points[i].position = co
+        obj = bpy.data.objects.new("raw", cu)
+        self.scene.collection.objects.link(obj)
+
+        points, segments = extract_pickable_geometry(obj)
+        self.assertEqual(len(points), 3)  # 3 control points
+        self.assertEqual(len(segments), 2)  # 3 points -> 2 spans
+        got = sorted(tuple(round(c, 3) for c in p) for _, p in points)
+        self.assertEqual(got, [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0)])
+
+    def test_non_curve_object_returns_empty(self):
+        me = self.data.meshes.new("m")
+        me.from_pydata([(0.0, 0.0, 0.0)], [], [])
+        ob = self.data.objects.new("m", me)
+        self.scene.collection.objects.link(ob)
+        self.assertEqual(extract_pickable_geometry(ob), ([], []))

--- a/testing/test_reference_pick.py
+++ b/testing/test_reference_pick.py
@@ -78,6 +78,18 @@ class TestReferencePickGeometry(Sketch2dTestCase):
         self.assertEqual(len(ppoints), 1)
         self.assertEqual(psegments, [])
 
+    def test_project_operator_reports_curve_pointer_for_check_props(self):
+        # A picked curve element has no mesh pointer; the operator must still
+        # report a truthy state pointer, or check_props() blocks main() and
+        # nothing projects (the "still cannot project" bug).
+        from ..operators.project_geometry import VIEW3D_OT_slvs_project_geometry
+
+        op = VIEW3D_OT_slvs_project_geometry.__new__(VIEW3D_OT_slvs_project_geometry)
+        op.state_index = 0
+        op._state_data = {0: {"curve_ref": ("Src", "deadbeef")}}
+        self.assertTrue(bool(op.get_state_pointer(index=0)))
+        self.assertEqual(op.get_state_pointer(index=0), ("Src", "deadbeef"))
+
     def test_element_geometry_of_arc_is_the_tessellated_arc(self):
         ct = self.add_point((0.0, 0.0))
         start = self.add_point((1.0, 0.0))

--- a/testing/test_reference_pick.py
+++ b/testing/test_reference_pick.py
@@ -81,14 +81,18 @@ class TestReferencePickGeometry(Sketch2dTestCase):
     def test_project_operator_reports_curve_pointer_for_check_props(self):
         # A picked curve element has no mesh pointer; the operator must still
         # report a truthy state pointer, or check_props() blocks main() and
-        # nothing projects (the "still cannot project" bug).
+        # nothing projects (the "still cannot project" bug). Call the override
+        # unbound on a stand-in self -- a bpy Operator can't be instantiated.
+        import types
+
         from ..operators.project_geometry import VIEW3D_OT_slvs_project_geometry
 
-        op = VIEW3D_OT_slvs_project_geometry.__new__(VIEW3D_OT_slvs_project_geometry)
-        op.state_index = 0
-        op._state_data = {0: {"curve_ref": ("Src", "deadbeef")}}
-        self.assertTrue(bool(op.get_state_pointer(index=0)))
-        self.assertEqual(op.get_state_pointer(index=0), ("Src", "deadbeef"))
+        op = types.SimpleNamespace(
+            state_index=0, _state_data={0: {"curve_ref": ("Src", "deadbeef")}}
+        )
+        pointer = VIEW3D_OT_slvs_project_geometry.get_state_pointer(op, index=0)
+        self.assertEqual(pointer, ("Src", "deadbeef"))
+        self.assertTrue(bool(pointer))
 
     def test_element_geometry_of_arc_is_the_tessellated_arc(self):
         ct = self.add_point((0.0, 0.0))

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -12,6 +12,8 @@ indices. A depsgraph handler reprojects changed source vertices into the sketch
 plane and connected native line curves follow through ``rebuild_segments``.
 """
 
+import logging
+
 from mathutils import Vector
 
 from ..model.constants import SketchCurveType
@@ -23,6 +25,8 @@ from ..utilities.curve_data import (
     read_curve_id_list,
     read_uuid_list,
 )
+
+logger = logging.getLogger(__name__)
 
 # Persistent identity on the SOURCE mesh (POINT domain).
 VERTEX_ID_ATTR = "slvs_project_vertex_id"
@@ -739,9 +743,16 @@ def project_curves_element(sketch, source, curve_id, construction=True):
     projectable. Endpoints are reused across calls via ``find_projected_point``,
     so re-projecting the same element is idempotent.
     """
+    logger.debug(
+        "project_curves_element: source=%r type=%s key=%r",
+        getattr(source, "name", None),
+        getattr(source, "type", None),
+        curve_id,
+    )
     if source is None or source.type not in _CURVE_SOURCE:
         raise TypeError("Source must be a sketch or curve object")
     if not isinstance(curve_id, str):
+        logger.debug("project_curves_element: non-sketch key -> not projectable yet")
         return [], [], 1  # a raw Curves index key: not projectable yet
 
     from ..model.constants import SketchCurveType
@@ -751,6 +762,7 @@ def project_curves_element(sketch, source, curve_id, construction=True):
 
     src_sketch = Sketch(source)
     src_type = get_curve_type(src_sketch, curve_id)
+    logger.debug("project_curves_element: src_type=%s", src_type)
     owner = sketch.target_object
     inv = owner.matrix_world.inverted()
     points, lines = [], []

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -89,6 +89,12 @@ _MESH_SOURCE = {"MESH"}
 _CURVE_SOURCE = {"CURVES", "CURVE"}
 
 
+def _source_point_count(source):
+    """Number of source elements (mesh vertices or curve control points)."""
+    data = source.data
+    return len(data.vertices if source.type in _MESH_SOURCE else data.points)
+
+
 def _source_point_index(source, vertex_index):
     """Local position of source element ``vertex_index`` (mesh vert or curve point)."""
     if source.type in _MESH_SOURCE:
@@ -509,13 +515,12 @@ def project_mesh_vertex(sketch, source, vertex_index, construction=True, world_c
     vertex-moving modifier (the original vertex position differs from the snapped,
     evaluated one). It defaults to the original vertex position.
     """
-    if source is None or source.type != "MESH":
-        raise TypeError("Source must be a mesh object")
-    mesh = source.data
-    if not (0 <= vertex_index < len(mesh.vertices)):
+    if source is None or source.type not in (_MESH_SOURCE | _CURVE_SOURCE):
+        raise TypeError("Source must be a mesh or curve object")
+    if not (0 <= vertex_index < _source_point_count(source)):
         return None
 
-    vertex_id = ensure_vertex_id(mesh, vertex_index)
+    vertex_id = ensure_vertex_id(source.data, vertex_index)
     existing = find_projected_vertex_point(sketch, source, vertex_id)
     if existing is not None:
         return existing
@@ -525,7 +530,7 @@ def project_mesh_vertex(sketch, source, vertex_index, construction=True, world_c
         local = owner.matrix_world.inverted() @ Vector(world_co)
     else:
         local = owner.matrix_world.inverted() @ (
-            source.matrix_world @ mesh.vertices[vertex_index].co
+            source.matrix_world @ _source_point_index(source, vertex_index)
         )
     with batch_update(sketch):
         point = PointRef.create(
@@ -550,10 +555,9 @@ def project_mesh_edge(sketch, source, vertex_index, vertex_index_2, construction
     index is out of range, the indices coincide, or the edge collapses to a point
     on the sketch plane (a zero-length line the solver cannot use).
     """
-    if source is None or source.type != "MESH":
-        raise TypeError("Source must be a mesh object")
-    mesh = source.data
-    n = len(mesh.vertices)
+    if source is None or source.type not in (_MESH_SOURCE | _CURVE_SOURCE):
+        raise TypeError("Source must be a mesh or curve object")
+    n = _source_point_count(source)
     if not (0 <= vertex_index < n and 0 <= vertex_index_2 < n):
         return None
     if vertex_index == vertex_index_2:
@@ -566,7 +570,7 @@ def project_mesh_edge(sketch, source, vertex_index, vertex_index_2, construction
         existing = find_projected_point(sketch, source, index)
         if existing is not None:
             return existing
-        local = inv @ (source.matrix_world @ mesh.vertices[index].co)
+        local = inv @ (source.matrix_world @ _source_point_index(source, index))
         point = PointRef.create(
             sketch,
             (local.x, local.y),

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -727,3 +727,70 @@ def project_curves_object(sketch, source, construction=True):
                 skipped_curves += 1
 
     return points, lines, skipped_curves
+
+
+def project_curves_element(sketch, source, curve_id, construction=True):
+    """Project a single line or point of a source sketch into ``sketch``.
+
+    ``curve_id`` is a source sketch element's id (what the reference pick returns
+    for a sketch). Returns ``(points, lines, skipped)``: ``skipped`` is 1 when the
+    element has no planar-line projection yet (arc/circle) or the key is not a
+    sketch element (e.g. a raw Curves index) -- both are hoverable but not
+    projectable. Endpoints are reused across calls via ``find_projected_point``,
+    so re-projecting the same element is idempotent.
+    """
+    if source is None or source.type not in _CURVE_SOURCE:
+        raise TypeError("Source must be a sketch or curve object")
+    if not isinstance(curve_id, str):
+        return [], [], 1  # a raw Curves index key: not projectable yet
+
+    from ..model.constants import SketchCurveType
+    from ..model.curve_ref import LineRef as _LineRef
+    from ..model.sketch_ref import Sketch
+    from ..utilities.curve_data import get_curve_type
+
+    src_sketch = Sketch(source)
+    src_type = get_curve_type(src_sketch, curve_id)
+    owner = sketch.target_object
+    inv = owner.matrix_world.inverted()
+    points, lines = [], []
+
+    def _project(src_point):
+        flat_index = _source_point_flat_index(src_point)
+        if flat_index is None:
+            return None
+        existing = find_projected_point(sketch, source, flat_index)
+        if existing is not None:
+            return existing
+        local = inv @ src_point.location
+        projected = PointRef.create(
+            sketch,
+            (local.x, local.y),
+            construction=construction,
+            fixed=True,
+            name="Projected Point",
+        )
+        bind_projected_point(sketch, projected, source, flat_index)
+        points.append(projected)
+        return projected
+
+    with batch_update(sketch):
+        if src_type == SketchCurveType.LINE:
+            src_line = _LineRef(src_sketch, curve_id)
+            p1_src, p2_src = src_line.p1, src_line.p2
+            if p1_src is None or p2_src is None:
+                return points, lines, 0
+            p1 = _project(p1_src)
+            p2 = _project(p2_src)
+            if p1 and p2 and not _line_exists_between(sketch, p1, p2):
+                lines.append(
+                    LineRef.create(
+                        sketch, p1, p2, construction=construction, name="Projected Line"
+                    )
+                )
+            return points, lines, 0
+        if src_type == SketchCurveType.POINT:
+            _project(PointRef(src_sketch, curve_id))
+            return points, lines, 0
+        # Arc / circle: hoverable, but no native planar-line projection yet.
+        return points, lines, 1

--- a/utilities/projection_anchor.py
+++ b/utilities/projection_anchor.py
@@ -12,8 +12,6 @@ indices. A depsgraph handler reprojects changed source vertices into the sketch
 plane and connected native line curves follow through ``rebuild_segments``.
 """
 
-import logging
-
 from mathutils import Vector
 
 from ..model.constants import SketchCurveType
@@ -25,8 +23,6 @@ from ..utilities.curve_data import (
     read_curve_id_list,
     read_uuid_list,
 )
-
-logger = logging.getLogger(__name__)
 
 # Persistent identity on the SOURCE mesh (POINT domain).
 VERTEX_ID_ATTR = "slvs_project_vertex_id"
@@ -747,16 +743,9 @@ def project_curves_element(sketch, source, curve_id, construction=True):
     projectable. Endpoints are reused across calls via ``find_projected_point``,
     so re-projecting the same element is idempotent.
     """
-    logger.debug(
-        "project_curves_element: source=%r type=%s key=%r",
-        getattr(source, "name", None),
-        getattr(source, "type", None),
-        curve_id,
-    )
     if source is None or source.type not in _CURVE_SOURCE:
         raise TypeError("Source must be a sketch or curve object")
     if not isinstance(curve_id, str):
-        logger.debug("project_curves_element: non-sketch key -> not projectable yet")
         return [], [], 1  # a raw Curves index key: not projectable yet
 
     from ..model.constants import SketchCurveType
@@ -766,7 +755,6 @@ def project_curves_element(sketch, source, curve_id, construction=True):
 
     src_sketch = Sketch(source)
     src_type = get_curve_type(src_sketch, curve_id)
-    logger.debug("project_curves_element: src_type=%s", src_type)
     owner = sketch.target_object
     inv = owner.matrix_world.inverted()
     points, lines = [], []

--- a/utilities/view.py
+++ b/utilities/view.py
@@ -321,7 +321,12 @@ def _curve_snap_candidates(
                     0,
                     float(d[i]),
                     Vector((screen[i, 0], screen[i, 1])),
-                    {"type": "VERTEX", "world_point": Vector(world[i])},
+                    {
+                        "type": "VERTEX",
+                        "world_point": Vector(world[i]),
+                        "object": obj.name,
+                        "vertex_index": int(i),
+                    },
                 )
             )
 
@@ -376,6 +381,8 @@ def _curve_snap_candidates(
                                     "type": "EDGE_MIDPOINT",
                                     "world_point": Vector((world[a] + world[b]) * 0.5),
                                     "world_edge": (Vector(world[a]), Vector(world[b])),
+                                    "object": obj.name,
+                                    "edge_vertices": (int(a), int(b)),
                                 },
                             )
                         )
@@ -404,6 +411,8 @@ def _curve_snap_candidates(
                                     "type": "EDGE",
                                     "world_point": world_closest,
                                     "world_edge": (Vector(world[a]), Vector(world[b])),
+                                    "object": obj.name,
+                                    "edge_vertices": (int(a), int(b)),
                                 },
                             )
                         )


### PR DESCRIPTION
Project elements from curve objects: per-element hover, highlight, and projection of a sketch's line/point elements, built into the core hover gizmo and the Project Geometry tool. Restores and generalizes the curve-source projection that was dropped when the tool became a mesh-element picker (3f022b1d).

## What this adds

- Reference geometry extractor (`drawing/reference_pick.py`): `extract_pickable_geometry(obj)` returns a curve object's pickable points and segments in world space. Sketches are keyed by `curve_id` with lines and arcs/circles tessellated; raw Curves objects are keyed by index. Legacy `Curve` (bezier/nurbs) is not handled yet.
- Generalized screen-space pick: the active-sketch picker's ranking is factored into `picking.rank_hits`, reused for any curve object. `pick_reference_element` ranks across all visible Curves objects, excluding the active sketch.
- Element-granular hover in the core `ObjectHover` gizmo: a hovered element becomes `("CURVE_ELEM", name, key)`, taking priority over a raycast hit on a sketch's converted fill mesh. Legacy Curve keeps the existing segment-hover fallback.
- Highlight: `draw_handler` lights up the whole hovered element, a line, an arc/circle's tessellated curve, or a control point.
- Projection on click: the Project tool's `pick_element` falls back to a reference curve element, and `main` projects it via `project_curves_element` (a single line/point of a source sketch, endpoints reused across calls for idempotency). Arcs/circles and raw/legacy curves are hoverable but report "can't project yet".

## How to test

1. Make one sketch active; have a second sketch visible with a line, an arc, and a couple of points.
2. Activate the Project Geometry tool (Object mode).
3. Hover the second sketch: line, arc (along its whole curve), and control points highlight. The active sketch does not self-highlight.
4. Click a line or a point: it is projected into the active sketch as live construction geometry that tracks the source (move the source, the projection follows). Clicking an arc/circle reports that it can't be projected yet.

## Tests

`testing/test_reference_pick.py` covers extraction and per-element highlight geometry. `testing/test_projection_anchor.py` adds single-element projection (line projects two points and a line, idempotent on re-project; arc is skipped; a raw index key is rejected). Full suite passes.
