### PR TITLE
Remove run-as-main segment from shipped code

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -96,7 +96,7 @@ jobs:
         run: |
           version="${TAG_NAME#v}"
           notes="${{ github.workspace }}/notes.md"
-          if python3 changelog.py "$version" CHANGELOG.md > "$notes"; then
+          if PYTHONPATH=. python3 scripts/changelog_notes.py "$version" CHANGELOG.md > "$notes"; then
             echo "Prepending CHANGELOG.md entry for $version."
           else
             : > "$notes"

--- a/changelog.py
+++ b/changelog.py
@@ -2,16 +2,17 @@
 
 Shared, on purpose, by two consumers:
 
-- the release workflow, run directly as ``python changelog.py <version> [path]``,
-  which prepends the matching section to the auto-generated GitHub release notes;
-- the add-on's in-app "What's new" dialog, which imports :func:`extract_section`.
+- the add-on's in-app "What's new" dialog, which imports :func:`extract_section`;
+- the release workflow, via ``scripts/changelog_notes.py`` (excluded from the
+  built extension), which imports the same function to prepend the matching
+  section to the auto-generated GitHub release notes.
 
-Kept dependency-free (standard library only) so the workflow can execute it
-without installing anything and the add-on can import it at runtime.
+Kept dependency-free (standard library only) so it can be imported at runtime
+without installing anything. This module is import-only — it has no
+run-as-main entry point (extensions may not ship standalone-runnable files).
 """
 
 import re
-import sys
 
 # Matches "## 0.3.0", "## [0.3.0]", "## v0.3.0", optionally followed by a date.
 _HEADING = re.compile(r"^##\s+\[?v?([0-9]+\.[0-9]+\.[0-9]+)\]?")
@@ -52,20 +53,3 @@ def latest_version(text: str) -> str:
         if m:
             return m.group(1)
     return ""
-
-
-if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        sys.stderr.write("usage: changelog.py <version> [changelog_path]\n")
-        raise SystemExit(2)
-
-    version = sys.argv[1]
-    path = sys.argv[2] if len(sys.argv) > 2 else "CHANGELOG.md"
-    with open(path, encoding="utf-8") as f:
-        section = extract_section(version, f.read())
-
-    if not section:
-        sys.stderr.write(f"No CHANGELOG entry for version '{version}' in {path}\n")
-        raise SystemExit(1)
-
-    sys.stdout.write(section + "\n")

--- a/scripts/changelog_notes.py
+++ b/scripts/changelog_notes.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Print the CHANGELOG.md section for a version (release-workflow helper).
+
+Lives under scripts/ (excluded from the built extension) so the shipped
+``changelog`` module stays a pure importable library with no run-as-main
+segment. Run from the repository root with it on the path, e.g.:
+
+    PYTHONPATH=. python3 scripts/changelog_notes.py <version> [changelog_path]
+
+Exits 1 when there is no matching section (so the caller can distinguish a
+missing entry from a successful extraction).
+"""
+
+import sys
+
+from changelog import extract_section
+
+if len(sys.argv) < 2:
+    sys.stderr.write("usage: changelog_notes.py <version> [changelog_path]\n")
+    raise SystemExit(2)
+
+version = sys.argv[1]
+path = sys.argv[2] if len(sys.argv) > 2 else "CHANGELOG.md"
+with open(path, encoding="utf-8") as f:
+    section = extract_section(version, f.read())
+
+if not section:
+    sys.stderr.write(f"No CHANGELOG entry for version '{version}' in {path}\n")
+    raise SystemExit(1)
+
+sys.stdout.write(section + "\n")


### PR DESCRIPTION
Addresses extensions.blender.org review feedback #5: extensions may not ship files with a `if __name__ == "__main__":` run-as-main segment.

Only one shipped file had one: `changelog.py`. It's imported at runtime by the What's New dialog (`base/whats_new.py` uses `extract_section`), so it can't just be dropped — instead it's now import-only, and its CLI (used by the release workflow to extract release notes) moves to `scripts/changelog_notes.py`, which is excluded from the built package.

The other `__main__` guards in the repo live under `scripts/` and `testing/`, both excluded from the build, so they don't ship.

Verified: the built package contains no `__main__` guard and does not include `changelog_notes.py`; the new wrapper reproduces the old CLI exactly (prints the section + exit 0 for a present version, stderr + exit 1 for a missing one); ruff clean.