### PR TITLE
Protect sketch origin point from deletion

### DIFF
--- a/model/curve_ref.py
+++ b/model/curve_ref.py
@@ -180,6 +180,11 @@ class CurveRef:
         self._set_attr_value("visible", bool(value))
 
     @property
+    def is_origin(self):
+        """True for the sketch's protected origin point (read-only)."""
+        return bool(self._get_attr_value("is_origin", False))
+
+    @property
     def name(self):
         """User-facing name stored on the curve (falls back to the type)."""
         return self._get_attr_value("name", "") or self._type_label
@@ -409,7 +414,7 @@ class PointRef(CurveRef):
         return mat @ pos
 
     @staticmethod
-    def create(sketch, co, construction=False, fixed=False, name=None):
+    def create(sketch, co, construction=False, fixed=False, name=None, is_origin=False):
         """Create a new point curve and return a PointRef.
 
         Args:
@@ -418,6 +423,7 @@ class PointRef(CurveRef):
             construction: Whether this is a construction point.
             fixed: Whether this point is fixed.
             name: Optional display name; a default is generated when omitted.
+            is_origin: Whether this is the sketch's protected origin point.
 
         Returns:
             PointRef for the new curve.
@@ -443,6 +449,8 @@ class PointRef(CurveRef):
         set_attribute(attrs, "construction", construction, curve_idx)
         set_attribute(attrs, "fixed", fixed, curve_idx)
         set_attribute(attrs, "visible", True, curve_idx)
+        if is_origin:
+            set_attribute(attrs, "is_origin", True, curve_idx)
         set_attribute(attrs, "name",
                       name or default_curve_name(curve_data, SketchCurveType.POINT),
                       curve_idx)

--- a/operators/add_sketch.py
+++ b/operators/add_sketch.py
@@ -45,7 +45,7 @@ def create_sketch_on_workplane(context: Context, wp_empty, operator: Operator):
 
     sketch = Sketch(sketch_obj)
 
-    origin = PointRef.create(sketch, (0.0, 0.0), fixed=True)
+    origin = PointRef.create(sketch, (0.0, 0.0), fixed=True, is_origin=True)
     assert origin is not None, "Failed to create origin point"
 
     activate_sketch(context, sketch_obj, operator)

--- a/operators/context_menu.py
+++ b/operators/context_menu.py
@@ -77,6 +77,8 @@ class View3D_OT_slvs_context_menu(Operator, HighlightElement):
             row = col.row()
             row.alert = True
             if is_entity:
+                # The origin is protected — show Delete grayed out.
+                row.enabled = not getattr(element, "is_origin", False)
                 op = row.operator(Operators.DeleteEntity, text="Delete", icon="X")
                 op.index = element._curve_id
             else:

--- a/operators/delete_entity.py
+++ b/operators/delete_entity.py
@@ -41,6 +41,17 @@ def _get_dependent_curve_ids(sketch, curve_id):
     return deps
 
 
+def _is_origin_curve(sketch, curve_id):
+    """True if curve_id is the sketch's protected origin point."""
+    from ..utilities.curve_data import get_curve_data
+
+    cd, idx, _ = get_curve_data(sketch, curve_id)
+    if cd is None:
+        return False
+    attr = cd.attributes.get("is_origin")
+    return bool(attr.data[idx].value) if attr else False
+
+
 def _get_constraint_indices_for_curve_id(curve_id, context):
     """Find constraints that reference a curve_id."""
     from ..model.sketch_ref import get_active_constraints
@@ -102,6 +113,11 @@ class View3D_OT_slvs_delete_entity(Operator, HighlightElement):
         return {"FINISHED"}
 
     def _delete_curve(self, context, sketch, curve_id):
+        # The sketch origin is a permanent fixture — silently ignore it,
+        # whether selected directly or reached via a cascade.
+        if _is_origin_curve(sketch, curve_id):
+            return
+
         deps = _get_dependent_curve_ids(sketch, curve_id)
         if deps:
             for dep_cid in deps:

--- a/operators/delete_entity.py
+++ b/operators/delete_entity.py
@@ -86,6 +86,10 @@ class View3D_OT_slvs_delete_entity(Operator, HighlightElement):
     @classmethod
     def description(cls, context, properties):
         cls.handle_highlight_hover(context, properties)
+        if properties.index:
+            sketch = get_active_sketch(context)
+            if sketch and _is_origin_curve(sketch, properties.index):
+                return "Cannot delete the sketch origin"
         return cls.__doc__
 
     def execute(self, context: Context):

--- a/testing/test_validate.py
+++ b/testing/test_validate.py
@@ -84,7 +84,9 @@ class TestValidate(Sketch2dTestCase):
 
     def test_removes_degenerate_line(self):
         from ..model.constants import SketchCurveType
-        self.add_point((0.0, 0.0))
+        # A real sketch always carries its protected origin; tag it so self-heal
+        # doesn't fabricate a replacement and skew the count.
+        self.add_point((0.0, 0.0), fixed=True, is_origin=True)
         self.add_point((1.0, 0.0))
         cd = self.sketch.target_object.data
         # Fake a native endpoint-delete: a 1-point curve typed as a LINE.
@@ -100,3 +102,35 @@ class TestValidate(Sketch2dTestCase):
         set_uuid(self.sketch.target_object.data, "curve_id", 1, p1.curve_id)
         self.assertTrue(validate_sketch(self.sketch))   # fixes dup, caches sig
         self.assertFalse(validate_sketch(self.sketch))  # unchanged -> skip
+
+    def _origin_flags(self):
+        cd = self.sketch.target_object.data
+        attr = cd.attributes.get("is_origin")
+        return [bool(attr.data[i].value) for i in range(len(cd.curves))]
+
+    def test_restores_deleted_origin(self):
+        origin = self.add_point((0.0, 0.0), fixed=True, is_origin=True)
+        self.add_point((1.0, 0.0))
+        # Simulate a native Edit-Mode delete of the origin point.
+        remove_native_curve_by_id(self.sketch, origin.curve_id)
+        reset_cache()
+
+        self.assertTrue(validate_sketch(self.sketch))
+        cd = self.sketch.target_object.data
+        flags = self._origin_flags()
+        self.assertEqual(sum(flags), 1)  # exactly one origin restored
+        idx = flags.index(True)
+        pos = cd.points[cd.curves[idx].points[0].index].position
+        self.assertAlmostEqual(pos[0], 0.0)
+        self.assertAlmostEqual(pos[1], 0.0)
+
+    def test_adopts_untagged_origin_point(self):
+        # Migration: a pre-tag sketch has a fixed point at (0, 0) but no flag.
+        self.add_point((0.0, 0.0), fixed=True)
+        self.add_point((1.0, 0.0))
+        reset_cache()
+
+        self.assertTrue(validate_sketch(self.sketch))
+        # Adopted in place — no fabricated duplicate.
+        self.assertEqual(len(self.sketch.target_object.data.curves), 2)
+        self.assertEqual(self._origin_flags(), [True, False])

--- a/utilities/curve_data.py
+++ b/utilities/curve_data.py
@@ -278,6 +278,8 @@ def ensure_standard_attributes(curve_data):
     ensure_attribute(attributes, "construction", "BOOLEAN", "CURVE")
     ensure_attribute(attributes, "fixed", "BOOLEAN", "CURVE")
     ensure_attribute(attributes, "visible", "BOOLEAN", "CURVE")
+    # Marks the sketch's protected origin point (undeletable, auto-restored).
+    ensure_attribute(attributes, "is_origin", "BOOLEAN", "CURVE")
     # Per-point weld identity for the Blender 5.2 "Merge Points" fill path:
     # segment endpoints sharing a junction get the same id (see compute_merge_ids).
     ensure_attribute(attributes, "merge_id", "INT", "POINT")

--- a/utilities/validate.py
+++ b/utilities/validate.py
@@ -36,6 +36,9 @@ logger = logging.getLogger(__name__)
 # Start/end points closer than this (sketch units) make an arc zero-sweep.
 _DEGEN_ARC_EPS = 1e-4
 
+# The origin point sits exactly at the workplane's local (0, 0).
+_ORIGIN_EPS = 1e-6
+
 # object.name -> signature of the last validated state
 _validated = {}
 
@@ -125,6 +128,49 @@ def _remove_orphan_points(sketch, candidate_ids):
             remove_native_curve_by_id(sketch, cid)
 
 
+def _ensure_origin(sketch, cd):
+    """Guarantee the sketch keeps its protected origin point.
+
+    A native Edit-Mode delete can remove the origin like any other point.
+    Restore it by adopting an existing fixed point at local (0, 0) — which also
+    migrates sketches created before origins were tagged — or minting a fresh
+    one when none is present. Returns True if the data was changed.
+    """
+    type_attr = cd.attributes.get("sketch_type")
+    if type_attr is None:
+        return False
+
+    origin_attr = cd.attributes.get("is_origin")
+    if origin_attr is None:
+        ensure_standard_attributes(cd)
+        origin_attr = cd.attributes.get("is_origin")
+        if origin_attr is None:
+            return False
+
+    # Already flagged — nothing to do.
+    for i in range(len(cd.curves)):
+        if origin_attr.data[i].value:
+            return False
+
+    # Migration/restore: adopt a pre-existing fixed point at local (0, 0).
+    fixed_attr = cd.attributes.get("fixed")
+    for i in range(len(cd.curves)):
+        if type_attr.data[i].value != SketchCurveType.POINT:
+            continue
+        pos = cd.points[cd.curves[i].points[0].index].position
+        at_origin = math.hypot(pos[0], pos[1]) < _ORIGIN_EPS
+        is_fixed = fixed_attr is None or fixed_attr.data[i].value
+        if at_origin and is_fixed:
+            origin_attr.data[i].value = True
+            return True
+
+    # None to adopt — recreate the origin from scratch.
+    from ..model.curve_ref import PointRef
+
+    PointRef.create(sketch, (0.0, 0.0), fixed=True, is_origin=True)
+    return True
+
+
 def validate_sketch(sketch):
     """Repair invariants on one sketch's curve data.
 
@@ -167,6 +213,10 @@ def validate_sketch(sketch):
                 name_attr.data[i].value = default_curve_name(cd, ctype).encode()
             changed = True
         seen.add(cid)
+
+    # 2b. Guarantee the protected origin point survives a native delete.
+    if _ensure_origin(sketch, cd):
+        changed = True
 
     # 3. Remove segments left degenerate by a native edit — e.g. a line whose
     #    endpoint was deleted in Edit Mode, leaving a 1-point "line".


### PR DESCRIPTION
The sketch origin point could be deleted like any other point. Tag it with an `is_origin` attribute, ignore it in the delete operator (grayed out in the context menu), and restore it via self-heal if removed in Edit Mode.