### PR TITLE
Run entity-data versioning in the migrate operator, not on load

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -18,7 +18,6 @@ _builtin_handlers = {}
 # from event_system import add_builtin_handler
 #
 # add_builtin_handler("save_pre", write_addon_version)
-# add_builtin_handler("version_update", do_versioning)
 
 
 def add_builtin_handler(event: str, callback):
@@ -173,9 +172,11 @@ def on_undo_redo(scene, *args):
 
 
 def _setup_builtin_handlers():
-    from .versioning import do_versioning, write_addon_version
+    from .versioning import write_addon_version
 
-    add_builtin_handler("version_update", do_versioning)
+    # NOTE: entity-data versioning (do_versioning) is NOT a handler -- it runs
+    # inside the manual slvs_migrate_legacy operator, right before the legacy
+    # sketches are converted to curves, so nothing versions data on file load.
     add_builtin_handler("save_pre", write_addon_version)
     add_builtin_handler("load_post", on_load_post)
     add_builtin_handler("depsgraph_update_post", on_depsgraph_update)

--- a/operators/migrate.py
+++ b/operators/migrate.py
@@ -20,9 +20,13 @@ class VIEW3D_OT_slvs_migrate_legacy(Operator):
 
     def execute(self, context: Context):
         from ..utilities.migrate import migrate_scene, scene_needs_migration
+        from ..versioning import do_versioning
 
         migrated = scene_needs_migration(context)
         if migrated:
+            # Patch old entity data forward to the current schema first, then
+            # convert it to curves (do_versioning used to run on file load).
+            do_versioning()
             summary = migrate_scene(context)
             self.report(
                 {"INFO"},

--- a/testing/test_migration.py
+++ b/testing/test_migration.py
@@ -13,16 +13,19 @@ import bpy
 
 from ..model.sketch_ref import get_sketches
 from ..utilities.migrate import migrate_scene, scene_needs_migration
+from ..versioning import do_versioning
 
 FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
 DIM_TYPES = {"DISTANCE", "DIAMETER", "ANGLE", "RATIO"}
 
 
 def _open(name):
-    # Migration is manual now (no load handler); run it explicitly on open, the
-    # way the slvs_migrate_legacy operator does.
+    # Migration is manual now (no load/version handlers); run it explicitly on
+    # open exactly the way the slvs_migrate_legacy operator does: patch the
+    # legacy entity data forward, then convert it to curves.
     bpy.ops.wm.open_mainfile(filepath=os.path.join(FIXTURES, name))
     if scene_needs_migration(bpy.context):
+        do_versioning()
         migrate_scene(bpy.context)
 
 

--- a/versioning.py
+++ b/versioning.py
@@ -1,5 +1,7 @@
-import bpy
 import logging
+
+import bpy
+
 from . import get_addon_version_tuple
 
 logger = logging.getLogger(__name__)
@@ -37,20 +39,17 @@ def recalc_pointers(scene):
         logger.debug("Update entity indices:" + msg)
 
 
-def do_versioning(self):
+def do_versioning():
+    """Patch legacy entity data forward to the current schema.
+
+    Run by the slvs_migrate_legacy operator just before legacy sketches are
+    converted to curves (it is no longer a version_update handler). No-op for
+    scenes without a stored ``sketcher.version`` or already at the current one.
+    """
 
     logger.debug("Check versioning")
 
-    # Current blender version
-    current_version = bpy.context.preferences.version
-    # blender version this file was saved with
-    file_version = bpy.data.version
-    # Current addon version
     current_addon_version = get_addon_version_tuple()
-    # "Blender Version: ", current_version,
-    # "\nFile Blender Version: ", file_version,
-    # "\nAddon Version: ", current_addon_version,
-    # "\nFile Addon Version", file_addon_version,
 
     # NOTE: Versioning is done per scene
 
@@ -104,8 +103,8 @@ def do_versioning(self):
         if version < (0, 27, 4):
             # update distance constraints on only a line
             # to distance constraints on the endpoints of that line.
-            from .model.line_2d import SlvsLine2D
             from .model.distance import SlvsDistance
+            from .model.line_2d import SlvsLine2D
             from .model.point_2d import SlvsPoint2D
             from .model.sketch import SlvsSketch
 


### PR DESCRIPTION
Follow-up to #657, completing feedback #6: remove the last automatic on-load versioning work.

`do_versioning` was a `version_update` handler that patched legacy entity/constraint schema forward on **every file load**. It's distinct from `migrate_scene` (entity→curve conversion) — it fixes up the *old entity data in place* (origin elements, angle-constraint reference flags, distance-on-line → distance-on-endpoints, constraint UIDs). But it only ever matters for old entity-based files, which are exactly what the manual `slvs_migrate_legacy` operator handles.

- Call `do_versioning()` inside the operator, right before `migrate_scene`, and drop the `version_update` handler.
- `do_versioning` is now a plain arg-less function (was a handler callback); cleaned up its unused `current_version`/`file_version` debug locals and import order that this surfaced.
- `test_migration.py` mirrors the operator (version-patch, then convert).

Net: **nothing versions or migrates data automatically on file load** — the general user's load path is fully clean.

Verified on a real install: 8 migration tests pass (including reference-dimension and full CAD-part fixtures), the operator runs the do_versioning→migrate→revolve path, and our `version_update` handler is gone (only Blender's built-in `do_versions` remains). ruff clean.