### PR TITLE
Remove donation links from the Blender UI

### DIFF
--- a/base/preferences.py
+++ b/base/preferences.py
@@ -234,11 +234,6 @@ class Preferences(AddonPreferences):
 
             list_props_recursiv(self.theme_settings)
 
-        from . import whats_new
-
-        layout.separator()
-        whats_new.draw_donation(layout)
-
 
 classes = (
     SKETCHER_MT_theme_presets,

--- a/base/whats_new.py
+++ b/base/whats_new.py
@@ -22,11 +22,6 @@ from bpy.types import Operator
 logger = logging.getLogger(__name__)
 
 RELEASES_URL = "https://github.com/hlorus/CAD_Sketcher/releases"
-OPENCOLLECTIVE_URL = "https://opencollective.com/cadsketcher/contribute"
-# Individual developer donation links, mirroring the repo's Donations section.
-CONTRIBUTOR_LINKS = (
-    ("hlorus - Lead Dev", "https://github.com/sponsors/hlorus"),
-)
 _DIALOG_WIDTH = 600
 # Blender labels don't wrap; this many characters fit per ~width unit. Tuned to
 # fill most of the dialog with a small margin against proportional-font variance.
@@ -117,21 +112,6 @@ def _prefs():
     return addon.preferences if addon else None
 
 
-def draw_donation(layout):
-    """Soft donation call-to-action, shared by the dialog and the preferences.
-
-    Open Collective fund first, then the individual contributor links (mirrors
-    the repo's Donations section).
-    """
-    box = layout.box()
-    box.label(text="Enjoying CAD Sketcher?", icon="FUND")
-    box.label(text="Please consider supporting its development:")
-    col = box.column(align=True)
-    col.operator("wm.url_open", text="Open Collective").url = OPENCOLLECTIVE_URL
-    for name, url in CONTRIBUTOR_LINKS:
-        col.operator("wm.url_open", text=name).url = url
-
-
 class VIEW3D_OT_slvs_whats_new(Operator):
     """Show what changed in the latest CAD Sketcher update"""
 
@@ -166,9 +146,6 @@ class VIEW3D_OT_slvs_whats_new(Operator):
         prefs = _prefs()
         if prefs is not None:
             row.prop(prefs, "show_whats_new", text="Show on update")
-
-        layout.separator()
-        draw_donation(layout)
 
     def execute(self, context):
         return {"FINISHED"}


### PR DESCRIPTION
Addresses extensions.blender.org review feedback #8: donation links aren't allowed in the add-on UI.

Removes the `draw_donation` box — the **Open Collective** link and the **"hlorus - Lead Dev"** GitHub Sponsors link — from both places it appeared:
- the add-on **Preferences**, and
- the **What's New** dialog.

Also drops the now-unused `OPENCOLLECTIVE_URL` / `CONTRIBUTOR_LINKS` constants and the `whats_new` import in preferences. The What's New dialog itself and its "Full changelog" (GitHub releases) link stay — those aren't donations. Funding info can live on the website per the reviewer.

Verified: 7 What's New tests pass, the dialog operator still registers, and no donation/sponsor/OpenCollective references remain in shipped code. ruff clean.