### PR TITLE
Add 0.31.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ prepended to that version's GitHub release notes, and it is shown in the in-app
 `## X.Y.Z` section (matching the manifest version) with a short summary — CI
 rejects a stable release that has no matching entry.
 
+## 0.31.0
+This release adds nondestructive Boolean modeling, custom sketch attributes and refines the Extrude, Revolve and Projection tools.
+
+New
+- Nondestructive Boolean modeling: Extrude and Revolve can cut, union or intersect their result into overlapping bodies, with automatic target detection
+- Custom sketch attributes
+- Live Snapping: pick existing curve and mesh elements as references while drawing, they will be implicitly projected and update after future geometry changes
+
+Improved
+- Revolve can now build from a source object, with automatic boolean detection
+- Project Geometry is now a dedicated tool, and can project individual elements and sketch sources
+- Node tools (Extrude, Revolve, Array) return to the Select tool after finishing
+- The tools panel now shows the tools relevant to the current sketch mode
+- Auto-constraints while drawing are validated so they no longer over-constrain the sketch
+- Legacy files are migrated on demand via a button in the Sketcher panel, instead of automatically on file load
+
+Fixed
+- Crash when a boolean cutter referenced itself
+- Extrude of unfilled profiles now builds open walls instead of nothing
+- Revolve of profiles with holes
+- Copy/paste of constraints
+- Merging of coincident self-referencing points
+- Sketch-conversion topology, and node weld on Blender 5.0
+
 ## 0.30.0
 The data model of the extension has been fundamentally reworked for a closer integration
 into Blender, better stability and performance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,17 @@ prepended to that version's GitHub release notes, and it is shown in the in-app
 rejects a stable release that has no matching entry.
 
 ## 0.31.0
-This release adds nondestructive Boolean modeling, custom sketch attributes and refines the Extrude, Revolve and Projection tools.
+This release adds a unified Dimension tool, native 3D sketches, nondestructive Boolean modeling and custom sketch attributes, and refines the Extrude, Revolve and Projection tools.
 
 New
+- Dimension tool: a single tool that adds the right dimensional constraint for what you select — line length, distance, angle, diameter, or edge-to-edge — then drag to place the label or type a value
+- Native 3D sketches: draw points and lines freely in 3D space, anchored to an origin instead of a workplane
 - Nondestructive Boolean modeling: Extrude and Revolve can cut, union or intersect their result into overlapping bodies, with automatic target detection
 - Custom sketch attributes
 - Live Snapping: pick existing curve and mesh elements as references while drawing, they will be implicitly projected and update after future geometry changes
 
 Improved
+- Constraints are shown as an icon grid in the sidebar, split into dimensional and geometric, with theme-aware icons
 - Revolve can now build from a source object, with automatic boolean detection
 - Project Geometry is now a dedicated tool, and can project individual elements and sketch sources
 - Node tools (Extrude, Revolve, Array) return to the Select tool after finishing


### PR DESCRIPTION
Release notes for 0.31.0 (feeds the GitHub release body and the in-app What's New dialog). Required before tagging the final `v0.31.0` — the release CI hard-errors on a stable tag with no matching changelog entry.

Highlights: nondestructive Boolean modeling, custom sketch attributes, live snapping/reference projection, plus Revolve-from-source and the usual fixes.