### PR TITLE
Constraint tools as an icon grid

### DIFF
--- a/base/preferences.py
+++ b/base/preferences.py
@@ -84,6 +84,11 @@ class Preferences(AddonPreferences):
         description="Hide entity-based drawing (shows only native curve overlay)",
         default=False,
     )
+    constraint_grid_view: BoolProperty(
+        name="Constraint Grid View",
+        description="Show the constraint tools as a compact icon grid instead of a list",
+        default=True,
+    )
 
     decimal_precision: IntProperty(
         name="Decimal Precision",

--- a/declarations.py
+++ b/declarations.py
@@ -131,10 +131,13 @@ class WorkSpaceTools(str, Enum):
     Revolve = "sketcher.slvs_node_revolve"
 
 
-ConstraintOperators = (
+DimensionalConstraintOperators = (
     Operators.AddDistance,
     Operators.AddDiameter,
     Operators.AddAngle,
+)
+
+GeometricConstraintOperators = (
     Operators.AddCoincident,
     Operators.AddEqual,
     Operators.AddVertical,
@@ -146,3 +149,5 @@ ConstraintOperators = (
     Operators.AddRatio,
     Operators.AddSymmetry,
 )
+
+ConstraintOperators = DimensionalConstraintOperators + GeometricConstraintOperators

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -24,8 +24,12 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
         prefs = preferences.get_prefs()
         header = layout.row(align=True)
         header.label(text="Constraints:")
-        header.prop(
-            prefs, "constraint_grid_view", text="", icon="MESH_GRID", toggle=True
+        # Right-aligned so the toggle stays a normal-size square button (not
+        # stretched to fill the row like the scaled constraint icons below).
+        toggle = header.row()
+        toggle.alignment = "RIGHT"
+        toggle.prop(
+            prefs, "constraint_grid_view", text="", icon="IMGDISPLAY", toggle=True
         )
 
         if prefs.constraint_grid_view:
@@ -49,7 +53,10 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
             _icon_grid(declarations.GeometricConstraintOperators)
         else:
             col = layout.column(align=True)
-            for op in declarations.ConstraintOperators:
+            for op in declarations.DimensionalConstraintOperators:
+                col.operator(op, icon_value=icon_manager.get_constraint_icon(op))
+            col.separator()
+            for op in declarations.GeometricConstraintOperators:
                 col.operator(op, icon_value=icon_manager.get_constraint_icon(op))
 
         layout.separator()

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -26,13 +26,14 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
         header = layout.row(align=True)
         header.label(text="Constraints:")
         # Right-aligned so the toggle stays a normal-size button (not stretched to
-        # fill the row). The icon reflects the current view; emboss=False drops the
-        # button box (otherwise the active toggle shows a persistent grey fill).
+        # fill the row). The icon shows the view it switches *to* (list icon while
+        # the grid is active); emboss=False drops the button box (otherwise the
+        # active toggle shows a persistent grey fill).
         toggle = header.row()
         toggle.alignment = "RIGHT"
         toggle.prop(
             prefs, "constraint_grid_view", text="",
-            icon="IMGDISPLAY" if prefs.constraint_grid_view else "LONGDISPLAY",
+            icon="LONGDISPLAY" if prefs.constraint_grid_view else "IMGDISPLAY",
             toggle=True, emboss=False,
         )
 

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -1,7 +1,7 @@
 from bpy.types import Context
 
 from ...model.sketch_ref import get_active_sketch
-from .. import declarations, icon_manager
+from .. import declarations, icon_manager, preferences
 from . import VIEW3D_PT_sketcher_base
 
 
@@ -21,24 +21,36 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
         layout.operator(declarations.Operators.MergePoints)
         layout.operator(declarations.Operators.ProjectGeometry, icon="MOD_SHRINKWRAP")
 
-        # Icon-only buttons; the constraint name still shows in the tooltip.
-        # Dimensional constraints (value-based) go in their own grid, kept separate
-        # from the geometric ones. Both use the same column count and scale so the
-        # buttons are identically sized.
-        def _icon_grid(operators):
-            grid = layout.grid_flow(
-                row_major=True, columns=5, even_columns=True, even_rows=True, align=True
-            )
-            grid.scale_x = 1.2
-            grid.scale_y = 1.2
-            for op in operators:
-                grid.operator(
-                    op, text="", icon_value=icon_manager.get_constraint_icon(op)
-                )
+        prefs = preferences.get_prefs()
+        header = layout.row(align=True)
+        header.label(text="Constraints:")
+        header.prop(
+            prefs, "constraint_grid_view", text="", icon="MESH_GRID", toggle=True
+        )
 
-        layout.label(text="Constraints:")
-        _icon_grid(declarations.DimensionalConstraintOperators)
-        _icon_grid(declarations.GeometricConstraintOperators)
+        if prefs.constraint_grid_view:
+            # Icon-only buttons; the constraint name still shows in the tooltip.
+            # Dimensional constraints (value-based) go in their own grid, kept
+            # separate from the geometric ones. Both use the same column count and
+            # scale so the buttons are identically sized.
+            def _icon_grid(operators):
+                grid = layout.grid_flow(
+                    row_major=True, columns=5, even_columns=True,
+                    even_rows=True, align=True,
+                )
+                grid.scale_x = 1.2
+                grid.scale_y = 1.2
+                for op in operators:
+                    grid.operator(
+                        op, text="", icon_value=icon_manager.get_constraint_icon(op)
+                    )
+
+            _icon_grid(declarations.DimensionalConstraintOperators)
+            _icon_grid(declarations.GeometricConstraintOperators)
+        else:
+            col = layout.column(align=True)
+            for op in declarations.ConstraintOperators:
+                col.operator(op, icon_value=icon_manager.get_constraint_icon(op))
 
         layout.separator()
 

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -12,7 +12,7 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
 
     bl_label = "Tools"
     bl_idname = declarations.Panels.SketcherTools
-    bl_options = {"DEFAULT_CLOSED"}
+    bl_options = set()  # expanded by default
 
     def _draw_sketch_tools(self, context: Context):
         """Tools that only make sense while editing a sketch."""
@@ -22,22 +22,23 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
         layout.operator(declarations.Operators.ProjectGeometry, icon="MOD_SHRINKWRAP")
 
         # Icon-only buttons; the constraint name still shows in the tooltip.
-        # Dimensional constraints (value-based) get their own row, kept separate
-        # from the geometric ones below.
-        layout.label(text="Constraints:")
-        row = layout.row(align=True)
-        row.scale_x = 1.2
-        row.scale_y = 1.2
-        for op in declarations.DimensionalConstraintOperators:
-            row.operator(op, text="", icon_value=icon_manager.get_constraint_icon(op))
+        # Dimensional constraints (value-based) go in their own grid, kept separate
+        # from the geometric ones. Both use the same column count and scale so the
+        # buttons are identically sized.
+        def _icon_grid(operators):
+            grid = layout.grid_flow(
+                row_major=True, columns=5, even_columns=True, even_rows=True, align=True
+            )
+            grid.scale_x = 1.2
+            grid.scale_y = 1.2
+            for op in operators:
+                grid.operator(
+                    op, text="", icon_value=icon_manager.get_constraint_icon(op)
+                )
 
-        grid = layout.grid_flow(
-            row_major=True, columns=5, even_columns=True, even_rows=True, align=True
-        )
-        grid.scale_x = 1.2
-        grid.scale_y = 1.2
-        for op in declarations.GeometricConstraintOperators:
-            grid.operator(op, text="", icon_value=icon_manager.get_constraint_icon(op))
+        layout.label(text="Constraints:")
+        _icon_grid(declarations.DimensionalConstraintOperators)
+        _icon_grid(declarations.GeometricConstraintOperators)
 
         layout.separator()
 

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -25,16 +25,20 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
         prefs = preferences.get_prefs()
         header = layout.row(align=True)
         header.label(text="Constraints:")
-        # Right-aligned so the toggle stays a normal-size button (not stretched to
-        # fill the row). The icon shows the view it switches *to* (list icon while
-        # the grid is active); emboss=False drops the button box (otherwise the
-        # active toggle shows a persistent grey fill).
+        # Right-aligned, box-less icon that shows the view it switches *to* (list
+        # icon while the grid is active). Use an operator rather than a prop toggle:
+        # an emboss=False toggle would tint the icon by its on/off state (white vs
+        # black), whereas an operator icon always follows the theme.
         toggle = header.row()
         toggle.alignment = "RIGHT"
-        toggle.prop(
-            prefs, "constraint_grid_view", text="",
+        op = toggle.operator(
+            "wm.context_toggle", text="",
             icon="LONGDISPLAY" if prefs.constraint_grid_view else "IMGDISPLAY",
-            toggle=True, emboss=False,
+            emboss=False,
+        )
+        op.data_path = (
+            f'preferences.addons["{preferences.get_name()}"]'
+            ".preferences.constraint_grid_view"
         )
 
         if prefs.constraint_grid_view:

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -24,12 +24,15 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
         prefs = preferences.get_prefs()
         header = layout.row(align=True)
         header.label(text="Constraints:")
-        # Right-aligned so the toggle stays a normal-size square button (not
-        # stretched to fill the row like the scaled constraint icons below).
+        # Right-aligned so the toggle stays a normal-size button (not stretched to
+        # fill the row). The icon reflects the current view; emboss=False drops the
+        # button box (otherwise the active toggle shows a persistent grey fill).
         toggle = header.row()
         toggle.alignment = "RIGHT"
         toggle.prop(
-            prefs, "constraint_grid_view", text="", icon="IMGDISPLAY", toggle=True
+            prefs, "constraint_grid_view", text="",
+            icon="IMGDISPLAY" if prefs.constraint_grid_view else "LONGDISPLAY",
+            toggle=True, emboss=False,
         )
 
         if prefs.constraint_grid_view:

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -21,15 +21,22 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
         layout.operator(declarations.Operators.MergePoints)
         layout.operator(declarations.Operators.ProjectGeometry, icon="MOD_SHRINKWRAP")
 
+        # Icon-only buttons; the constraint name still shows in the tooltip.
+        # Dimensional constraints (value-based) get their own row, kept separate
+        # from the geometric ones below.
         layout.label(text="Constraints:")
-        # Icon-only buttons in a grid; the name still shows in the tooltip. Scale
-        # up a little so the constraint symbols are easier to read.
+        row = layout.row(align=True)
+        row.scale_x = 1.2
+        row.scale_y = 1.2
+        for op in declarations.DimensionalConstraintOperators:
+            row.operator(op, text="", icon_value=icon_manager.get_constraint_icon(op))
+
         grid = layout.grid_flow(
-            row_major=True, columns=4, even_columns=True, even_rows=True, align=True
+            row_major=True, columns=5, even_columns=True, even_rows=True, align=True
         )
-        grid.scale_x = 1.4
-        grid.scale_y = 1.4
-        for op in declarations.ConstraintOperators:
+        grid.scale_x = 1.2
+        grid.scale_y = 1.2
+        for op in declarations.GeometricConstraintOperators:
             grid.operator(op, text="", icon_value=icon_manager.get_constraint_icon(op))
 
         layout.separator()

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -22,9 +22,15 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
         layout.operator(declarations.Operators.ProjectGeometry, icon="MOD_SHRINKWRAP")
 
         layout.label(text="Constraints:")
-        col = layout.column(align=True)
+        # Icon-only buttons in a grid; the name still shows in the tooltip. Scale
+        # up a little so the constraint symbols are easier to read.
+        grid = layout.grid_flow(
+            row_major=True, columns=4, even_columns=True, even_rows=True, align=True
+        )
+        grid.scale_x = 1.4
+        grid.scale_y = 1.4
         for op in declarations.ConstraintOperators:
-            col.operator(op, icon_value=icon_manager.get_constraint_icon(op))
+            grid.operator(op, text="", icon_value=icon_manager.get_constraint_icon(op))
 
         layout.separator()
 

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -21,6 +21,7 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
         layout.operator(declarations.Operators.MergePoints)
         layout.operator(declarations.Operators.ProjectGeometry, icon="MOD_SHRINKWRAP")
 
+        layout.separator()
         prefs = preferences.get_prefs()
         header = layout.row(align=True)
         header.label(text="Constraints:")
@@ -42,8 +43,11 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
             # scale so the buttons are identically sized.
             def _icon_grid(operators):
                 grid = layout.grid_flow(
-                    row_major=True, columns=5, even_columns=True,
-                    even_rows=True, align=True,
+                    row_major=True,
+                    columns=5,
+                    even_columns=True,
+                    even_rows=True,
+                    align=True,
                 )
                 grid.scale_x = 1.2
                 grid.scale_y = 1.2


### PR DESCRIPTION
Show the geometric constraint buttons as a 4-column grid of icon-only buttons (name still shows in the tooltip), scaled up a little so the symbols are easier to read. Standard `grid_flow` layout; columns/scale are easy to tune.