### PR TITLE
Add unified Dimension tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ nul
 # Blender auto-backup files
 *.blend1
 CLAUDE.md
+.bltest/

--- a/declarations.py
+++ b/declarations.py
@@ -34,6 +34,7 @@ class Operators(str, Enum):
     AddCircle2D = "view3d.slvs_add_circle2d"
     AddCoincident = "view3d.slvs_add_coincident"
     AddDiameter = "view3d.slvs_add_diameter"
+    AddDimension = "view3d.slvs_add_dimension"
     AddDistance = "view3d.slvs_add_distance"
     AddEqual = "view3d.slvs_add_equal"
     AddHorizontal = "view3d.slvs_add_horizontal"
@@ -117,6 +118,7 @@ class VisibilityTypes(str, Enum):
 class WorkSpaceTools(str, Enum):
     AddArc2D = "sketcher.slvs_add_arc2d"
     AddCircle2D = "sketcher.slvs_add_circle2d"
+    AddDimension = "sketcher.slvs_add_dimension"
     AddLine2D = "sketcher.slvs_add_line2d"
     AddPoint2D = "sketcher.slvs_add_point2d"
     AddRectangle = "sketcher.slvs_add_rectangle"

--- a/gizmos/base.py
+++ b/gizmos/base.py
@@ -65,10 +65,6 @@ class ConstraintGizmoGeneric(ConstraintGizmo):
         constr = self._get_constraint(context)
         if not constr or not constr.visible:
             return
-        # While a stateful operator runs, the dimension label follows the cursor;
-        # keep it drawing but out of hover/picking so it can't swallow a click
-        # meant for the geometry underneath (e.g. picking a second entity).
-        self.hide_select = global_data.stateful_op_running
         self._set_colors(context, constr)
         self._update_matrix_basis(constr)
 
@@ -85,6 +81,12 @@ class ConstraintGizmoGeneric(ConstraintGizmo):
         self.draw_custom_shape(self.custom_shape)
 
     def draw_select(self, context, select_id):
+        # While a stateful operator runs, stay out of the gizmo select buffer so
+        # the dimension label (which follows the cursor) neither highlights nor
+        # swallows a click meant for the geometry underneath -- gating the select
+        # pass directly avoids the one-frame lag/flicker of toggling hide_select.
+        if global_data.stateful_op_running:
+            return
         constr = self._get_constraint(context)
         if not constr or not constr.visible:
             return

--- a/gizmos/base.py
+++ b/gizmos/base.py
@@ -1,3 +1,4 @@
+from .. import global_data
 from ..declarations import Operators
 from ..drawing import selection
 from ..model.types import GenericConstraint
@@ -64,6 +65,10 @@ class ConstraintGizmoGeneric(ConstraintGizmo):
         constr = self._get_constraint(context)
         if not constr or not constr.visible:
             return
+        # While a stateful operator runs, the dimension label follows the cursor;
+        # keep it drawing but out of hover/picking so it can't swallow a click
+        # meant for the geometry underneath (e.g. picking a second entity).
+        self.hide_select = global_data.stateful_op_running
         self._set_colors(context, constr)
         self._update_matrix_basis(constr)
 

--- a/gizmos/constraint.py
+++ b/gizmos/constraint.py
@@ -178,6 +178,9 @@ class VIEW3D_GT_slvs_constraint(ConstraintGizmo, Gizmo):
             self.matrix_basis = mat
 
     def test_select(self, context, location):
+        # Don't intercept hover/picking while a stateful operator is running.
+        if global_data.stateful_op_running:
+            return -1
         location = Vector(location).to_3d()
         location -= self.matrix_basis.translation
         location *= 1.0 / self.scale_basis
@@ -190,8 +193,6 @@ class VIEW3D_GT_slvs_constraint(ConstraintGizmo, Gizmo):
         constraint = self._get_constraint(context)
         if not constraint or not constraint.visible:
             return
-        # Don't intercept hover/picking while a stateful operator is running.
-        self.hide_select = global_data.stateful_op_running
         # Keep colors + matrix_basis current so test_select stays accurate; the
         # icon itself is rendered in one batched pass (drawing.constraint_icons)
         # to avoid a textured draw per constraint (Vulkan descriptor pressure).
@@ -210,6 +211,9 @@ class VIEW3D_GT_slvs_constraint_value(ConstraintGizmo, Gizmo):
     __slots__ = ("type", "index", "width", "height")
 
     def test_select(self, context, location):
+        # Don't intercept hover/picking while a stateful operator is running.
+        if global_data.stateful_op_running:
+            return -1
         coords = Vector(location) - self.matrix_basis.translation.to_2d()
 
         width, height = self.width, self.height
@@ -225,9 +229,6 @@ class VIEW3D_GT_slvs_constraint_value(ConstraintGizmo, Gizmo):
         # over-constrained sketch) -- skip drawing rather than dereference None.
         if not constr or not constr.visible or not hasattr(constr, "value_placement"):
             return
-
-        # Don't intercept hover/picking while a stateful operator is running.
-        self.hide_select = global_data.stateful_op_running
 
         color = get_color(Color.Text, self.is_highlight)
         text = _get_formatted_value(context, constr)

--- a/gizmos/constraint.py
+++ b/gizmos/constraint.py
@@ -4,7 +4,7 @@ import blf
 from bpy.types import Gizmo, GizmoGroup
 from mathutils import Matrix, Vector
 
-from .. import units
+from .. import global_data, units
 from ..declarations import GizmoGroups, Gizmos, Operators
 from ..utilities.preferences import get_prefs
 from ..utilities.view import get_2d_coords, get_scale_from_pos
@@ -190,6 +190,8 @@ class VIEW3D_GT_slvs_constraint(ConstraintGizmo, Gizmo):
         constraint = self._get_constraint(context)
         if not constraint or not constraint.visible:
             return
+        # Don't intercept hover/picking while a stateful operator is running.
+        self.hide_select = global_data.stateful_op_running
         # Keep colors + matrix_basis current so test_select stays accurate; the
         # icon itself is rendered in one batched pass (drawing.constraint_icons)
         # to avoid a textured draw per constraint (Vulkan descriptor pressure).
@@ -223,6 +225,9 @@ class VIEW3D_GT_slvs_constraint_value(ConstraintGizmo, Gizmo):
         # over-constrained sketch) -- skip drawing rather than dereference None.
         if not constr or not constr.visible or not hasattr(constr, "value_placement"):
             return
+
+        # Don't intercept hover/picking while a stateful operator is running.
+        self.hide_select = global_data.stateful_op_running
 
         color = get_color(Color.Text, self.is_highlight)
         text = _get_formatted_value(context, constr)

--- a/gizmos/distance.py
+++ b/gizmos/distance.py
@@ -23,11 +23,13 @@ class VIEW3D_GT_slvs_distance(Gizmo, ConstraintGizmoGeneric):
     bl_idname = Gizmos.Distance
     type = SlvsDistance.type
 
-    bl_target_properties = ({
-        "id": "offset",
-        "type": "FLOAT",
-        "array_length": 1,
-    },)
+    bl_target_properties = (
+        {
+            "id": "offset",
+            "type": "FLOAT",
+            "array_length": 1,
+        },
+    )
 
     __slots__ = (
         "custom_shape",
@@ -41,7 +43,7 @@ class VIEW3D_GT_slvs_distance(Gizmo, ConstraintGizmoGeneric):
         offset = self.target_get_value("offset")
         entity1, entity2 = constr.ref(1), constr.ref(2)
         if entity1 is None or entity2 is None:
-            return ((0,0,0),) * 4
+            return ((0, 0, 0),) * 4
         if entity1.is_line():
             entity1, entity2 = entity1.p1, entity1.p2
 
@@ -65,20 +67,36 @@ class VIEW3D_GT_slvs_distance(Gizmo, ConstraintGizmoGeneric):
                 targetpoint, _ = intersect_point_line(
                     centerpoint, entity2.p1.co, entity2.p2.co
                 )
+            elif entity2.is_curve():
+                targetpoint = entity2.ct.co
             else:
                 # TODO: Handle the case for SlvsWorkplane
-                pass
+                targetpoint = centerpoint
 
             targetvec = targetpoint - centerpoint
-            points_local.append(get_local(
-                centerpoint + entity1.radius * targetvec / targetvec.length
-            ))
+            if targetvec.length:
+                points_local.append(
+                    get_local(
+                        centerpoint + entity1.radius * targetvec / targetvec.length
+                    )
+                )
+            else:
+                points_local.append(get_local(centerpoint))
 
         else:
             points_local.append(get_local(entity1.location))
 
         # Add endpoint for entity2 helpline
-        if entity2.is_point():
+        if entity2.is_curve():
+            # Edge of the second curve facing the first (line of centres).
+            centervec = entity2.ct.co - entity1.ct.co
+            if centervec.length:
+                edge = entity2.ct.co - entity2.radius * centervec / centervec.length
+            else:
+                edge = entity2.ct.co
+            points_local.append(get_local(edge))
+
+        elif entity2.is_point():
             points_local.append(get_local(entity2.location))
 
         elif entity2.is_line():
@@ -103,7 +121,7 @@ class VIEW3D_GT_slvs_distance(Gizmo, ConstraintGizmoGeneric):
 
         # Pick the points based on their x location
         if len(points_local) < 2:
-            return ((0,0,0),) * 4
+            return ((0, 0, 0),) * 4
         if points_local[0].x > points_local[1].x:
             point_right, point_left = points_local
         else:
@@ -133,10 +151,7 @@ class VIEW3D_GT_slvs_distance(Gizmo, ConstraintGizmoGeneric):
             p1, p2 = p2, p1
         p1_global, p2_global = [self.matrix_world @ p for p in (p1, p2)]
 
-        scale_1, scale_2 = [
-            get_scale_from_pos(p, rv3d)
-            for p in (p1_global, p2_global)
-        ]
+        scale_1, scale_2 = [get_scale_from_pos(p, rv3d) for p in (p1_global, p2_global)]
 
         arrow_1 = get_arrow_size(half_dist, scale_1)
         arrow_2 = get_arrow_size(half_dist, scale_2)
@@ -166,9 +181,7 @@ class VIEW3D_GT_slvs_distance(Gizmo, ConstraintGizmoGeneric):
                 # jitter back and forth to extend leader line for
                 # text_outside case but it is unnecessary work for
                 # text_inside case
-                Vector(
-                    (outset, offset, 0)
-                ),
+                Vector((outset, offset, 0)),
                 p1,
                 p2,
                 *draw_arrow_shape(

--- a/keymaps.py
+++ b/keymaps.py
@@ -174,6 +174,11 @@ tool_access = (
     ),
     tool_invoke_kmi("O", WorkSpaceTools.Offset, Operators.Offset),
     tool_invoke_kmi(
+        "D",
+        WorkSpaceTools.AddDimension,
+        Operators.AddDimension,
+    ),
+    tool_invoke_kmi(
         "S",
         WorkSpaceTools.AddSketch,
         Operators.AddSketch,

--- a/model/distance.py
+++ b/model/distance.py
@@ -202,6 +202,13 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
                     group, ct1_handle, ct2_handle, value + r1 + r2, wp
                 )
 
+            if t2 == SketchCurveType.LINE:
+                # Point-to-line distance is signed (see use_flipping): keep the
+                # radius on the same side as the centre so the circle doesn't jump
+                # across the line.
+                r1_signed = -r1 if self.flip else r1
+                return solvesys.distance(group, ct1_handle, h2, value + r1_signed, wp)
+
             return solvesys.distance(group, ct1_handle, h2, value + r1, wp)
 
         # Point-to-line or point-to-point
@@ -232,11 +239,10 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
         return WpReq.OPTIONAL
 
     def use_flipping(self):
-        # Only use flipping for constraint between point and line/workplane
+        # A distance to a line is signed so the point/curve keeps its side of the
+        # line; without it the solver may flip the entity across.
         r1, r2 = self.ref(1), self.ref(2)
         if not r1 or not r2:
-            return False
-        if r1.is_curve():
             return False
         return r2.is_line()
 
@@ -425,12 +431,16 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
             if r2 and r2.is_curve():
                 return (centerpoint - r2.ct.co).length - r1.radius - r2.radius
             if r2 and r2.is_line():
+                # Signed by the centre's side of the line, so init sets ``flip``
+                # and the circle keeps its side (matching point-to-line below).
                 endpoint, _ = intersect_point_line(centerpoint, r2.p1.co, r2.p2.co)
-            elif r2 and r2.is_point():
-                endpoint = r2.co
-            else:
-                return 0.0
-            return (centerpoint - endpoint).length - r1.radius
+                gap = (centerpoint - endpoint).length - r1.radius
+                return math.copysign(
+                    gap, get_side_of_line(r2.p1.co, r2.p2.co, centerpoint)
+                )
+            if r2 and r2.is_point():
+                return (centerpoint - r2.co).length - r1.radius
+            return 0.0
         if r2 and r2.is_line():
             orig = r2.p1.co
             end = r2.p2.co - orig

--- a/model/distance.py
+++ b/model/distance.py
@@ -1,31 +1,34 @@
 import logging
 import math
 
+from bpy.props import (
+    BoolProperty,
+    EnumProperty,
+    FloatProperty,
+    StringProperty,
+)
 from bpy.types import PropertyGroup
-from .sketch_ref import get_active_sketch
-from bpy.props import BoolProperty, FloatProperty, EnumProperty, IntProperty, StringProperty
 from bpy.utils import register_classes_factory
-from mathutils import Vector, Matrix
-from mathutils.geometry import distance_point_to_plane, intersect_point_line
+from mathutils import Matrix, Vector
+from mathutils.geometry import intersect_point_line
 
 from ..curve_solver import Solver
-from ..utilities import preferences
 from ..global_data import WpReq
-from ..utilities.view import location_3d_to_region_2d
+from ..utilities import preferences
+from ..utilities.bpy import bpyEnum
 from ..utilities.math import range_2pi
-from .base_constraint import DimensionalConstraint
-from .utilities import slvs_entity_pointer
-from .categories import POINT, LINE, POINT2D, CURVE
 from ..utilities.solver import update_system_cb
-from ..utilities.bpy import setprop, bpyEnum
-
-from .workplane import SlvsWorkplane
-from .point_3d import SlvsPoint3D
+from ..utilities.view import location_3d_to_region_2d
+from .arc import SlvsArc
+from .base_constraint import DimensionalConstraint
+from .categories import CURVE, LINE, POINT, POINT2D
+from .circle import SlvsCircle
+from .line_2d import SlvsLine2D
 from .line_3d import SlvsLine3D
 from .point_2d import SlvsPoint2D
-from .line_2d import SlvsLine2D
-from .arc import SlvsArc
-from .circle import SlvsCircle
+from .point_3d import SlvsPoint3D
+from .utilities import slvs_entity_pointer
+from .workplane import SlvsWorkplane
 
 logger = logging.getLogger(__name__)
 
@@ -53,11 +56,13 @@ align_items = [
     ("VERTICAL", "Vertical", "", 2),
 ]
 
+
 def _get_value(self):
     if self.is_reference:
         val = self.init_props(align=self.align)["value"]
         return self.to_displayed_value(val)
     import bpy
+
     scene = bpy.context.scene
     uid = getattr(self, "constraint_uid", "")
     if scene is not None and uid:
@@ -140,9 +145,9 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
     curve_id_2: StringProperty(name="Curve ID 2", default="")
 
     def create_slvs_data_from_curves(self, solvesys, handle_map, wp, group):
-        from ..utilities.curve_data import get_curve_data, get_curve_position, get_uuid
+
         from ..model.constants import SketchCurveType
-        import bpy
+        from ..utilities.curve_data import get_curve_data, get_curve_position, get_uuid
 
         h1 = handle_map.get(self.curve_id_1)
         h2 = handle_map.get(self.curve_id_2)
@@ -169,18 +174,35 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
             if h1 is None:
                 return None
 
-        # Curve/arc entity1 → distance from center + radius offset
+        # Curve/arc entity1 → measure from its edge, i.e. constrain the centre a
+        # radius further out. A curve entity2 adds its own radius too, so the
+        # value is the edge-to-edge gap along the line of centres.
         if t1 in (SketchCurveType.ARC, SketchCurveType.CIRCLE):
-            ct_id = get_uuid(cd, "center_point_id", idx1)
-            ct_handle = handle_map.get(ct_id)
-            ct_pos = get_curve_position(sketch, ct_id)
-            if ct_handle and ct_pos:
-                from mathutils import Vector
-                curve_slice = cd.curves[idx1]
-                edge_pos = Vector(cd.points[curve_slice.points[0].index].position)
-                radius = (edge_pos - Vector(ct_pos)).length
-                return solvesys.distance(group, ct_handle, h2, value + radius, wp)
-            return None
+            from mathutils import Vector
+
+            def _center_radius(index):
+                cid = get_uuid(cd, "center_point_id", index)
+                handle = handle_map.get(cid)
+                pos = get_curve_position(sketch, cid)
+                if not handle or not pos:
+                    return None, 0.0
+                slice_ = cd.curves[index]
+                edge = Vector(cd.points[slice_.points[0].index].position)
+                return handle, (edge - Vector(pos)).length
+
+            ct1_handle, r1 = _center_radius(idx1)
+            if ct1_handle is None:
+                return None
+
+            if t2 in (SketchCurveType.ARC, SketchCurveType.CIRCLE):
+                ct2_handle, r2 = _center_radius(idx2)
+                if ct2_handle is None:
+                    return None
+                return solvesys.distance(
+                    group, ct1_handle, ct2_handle, value + r1 + r2, wp
+                )
+
+            return solvesys.distance(group, ct1_handle, h2, value + r1, wp)
 
         # Point-to-line or point-to-point
         if t2 == SketchCurveType.LINE:
@@ -277,25 +299,18 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
             func = solvesys.distance
         elif type(e2) in POINT:
             if align and all([e.is_2d() for e in (e1, e2)]):
-
                 # Get Point in between
                 p1, p2 = e1.co, e2.co
                 coords = (p2.x, p1.y)
 
                 p = solvesys.add_point_2d(group, *coords, wp)
 
-                handles.append(
-                    solvesys.horizontal(group, p, wp, entityB=e2.py_data)
-                )
-                handles.append(
-                    solvesys.vertical(group, p, wp, entityB=e1.py_data)
-                )
+                handles.append(solvesys.horizontal(group, p, wp, entityB=e2.py_data))
+                handles.append(solvesys.vertical(group, p, wp, entityB=e1.py_data))
 
                 base_point = e1 if alignment == "VERTICAL" else e2
                 handles.append(
-                    solvesys.distance(
-                        group, p, base_point.py_data, value, wp
-                    )
+                    solvesys.distance(group, p, base_point.py_data, value, wp)
                 )
                 return handles
             else:
@@ -320,6 +335,20 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
         alignment = self.align
         align = self.is_align()
         angle = 0
+
+        # Curve-to-curve: the gap is measured edge-to-edge along the line of
+        # centres, so place the label between the two facing edge points.
+        if e1.is_curve() and e2 is not None and e2.is_curve():
+            c1, c2 = e1.ct.co, e2.ct.co
+            axis = c2 - c1
+            axis = axis.normalized() if axis.length else x_axis
+            edge1 = c1 + e1.radius * axis
+            edge2 = c2 - e2.radius * axis
+            rot = axis.angle_signed(x_axis) if axis.length else 0.0
+            mat_rot = Matrix.Rotation(rot, 2, "Z")
+            v_translation = (edge1 + edge2) / 2
+            mat_local = Matrix.Translation(v_translation.to_3d()) @ mat_rot.to_4x4()
+            return wp_mat @ mat_local
 
         # Resolve p1 and p2 as 2D positions
         if e1.is_curve():
@@ -392,6 +421,9 @@ class SlvsDistance(DimensionalConstraint, PropertyGroup):
             return _get_aligned_distance(r1.p1, r1.p2, alignment)
         if r1.is_curve():
             centerpoint = r1.ct.co
+            # Curve-to-curve: edge-to-edge gap along the line of centres.
+            if r2 and r2.is_curve():
+                return (centerpoint - r2.ct.co).length - r1.radius - r2.radius
             if r2 and r2.is_line():
                 endpoint, _ = intersect_point_line(centerpoint, r2.p1.co, r2.p2.co)
             elif r2 and r2.is_point():

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -33,6 +33,7 @@ modules = [
     "add_distance",
     "add_diameter",
     "add_angle",
+    "add_dimension",
     "add_geometric_constraints",
     "align_workplane",
     "align_view",

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -32,17 +32,22 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
 
     The user does not choose between distance, angle and diameter up front:
 
-    - a line              -> distance (its length); click a second line while
-                             placing to switch to an angle (or the perpendicular
-                             distance if the two lines are parallel), or a point
-                             for a point-to-line distance
-    - a circle or arc     -> diameter
+    - a line              -> distance (its length); click a second entity while
+                             placing to switch: a line -> angle (or the
+                             perpendicular distance if the two are parallel), a
+                             point -> point-to-line distance, a circle/arc ->
+                             edge-to-line distance
+    - a circle or arc     -> diameter; click a point or line while placing to
+                             switch to an edge-to-point / edge-to-line distance
     - two points          -> distance
+    - point + line        -> point-to-line distance
+    - point/line + circle/arc -> edge distance (measured from the curve's edge)
 
     A line/circle/arc drops straight into an interactive placement state after
     the first pick, where the label is dragged into place (display only, no
     re-solve) and confirmed with a click. A point needs a partner, so it takes a
-    required second pick before placement.
+    required second pick before placement. Curve-to-curve distance is not
+    supported by the solver.
     """
 
     bl_idname = Operators.AddDimension
@@ -87,7 +92,7 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
                     "Entity 2",
                     description="Pick the entity to measure to.",
                     pointer="entity2",
-                    types=(SlvsPoint2D, SlvsLine2D),
+                    types=(SlvsPoint2D, SlvsLine2D, SlvsCircle, SlvsArc),
                     use_create=False,
                     optional=e1 is None,
                 )
@@ -141,6 +146,27 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         """True if two lines are (anti-)parallel, i.e. their angle is ~0/180."""
         angle = SlvsAngle._get_angle(l1.direction_vec(), l2.direction_vec())
         return angle < tol_deg or angle > 180.0 - tol_deg
+
+    @staticmethod
+    def _distance_pair(e1, e2):
+        """Order two entities as the native distance solver needs, or return None
+        if the pair isn't a supported distance.
+
+        The solver measures a curve (circle/arc) from its edge and requires it as
+        entity1; a point/line pair measures point-to-line, so the point goes
+        first. Curve-to-curve distance is not supported.
+        """
+        c1 = isinstance(e1, (CircleRef, ArcRef))
+        c2 = isinstance(e2, (CircleRef, ArcRef))
+        if c1 and c2:
+            return None
+        if c2:
+            return e2, e1
+        if c1:
+            return e1, e2
+        if isinstance(e1, LineRef) and isinstance(e2, PointRef):
+            return e2, e1
+        return e1, e2
 
     def _is_duplicate(self, context: Context, target) -> bool:
         """True if another constraint already matches ``target``'s type + curve ids.
@@ -228,15 +254,19 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
                     "Dimension -> angle between %s and %s", e1.curve_id, e2.curve_id
                 )
         else:
-            # Distance's natural form is point-to-line/point. The model collapses
-            # a *line* entity1 to its endpoints, so a line+point pair must be
-            # ordered point-first to measure the point-to-line distance.
-            if isinstance(e1, LineRef) and isinstance(e2, PointRef):
-                e1, e2 = e2, e1
+            # A mixed pair -> a distance. Order it as the solver needs (curve or
+            # point first); an unsupported pair (curve-to-curve) makes nothing.
+            pair = self._distance_pair(e1, e2)
+            if pair is None:
+                logger.debug(
+                    "Dimension: unsupported pair %s + %s", e1.curve_id, e2.curve_id
+                )
+                return
+            a, b = pair
             self.target = constraints.add_distance(
-                init=init, curve_id_1=e1.curve_id, curve_id_2=e2.curve_id
+                init=init, curve_id_1=a.curve_id, curve_id_2=b.curve_id
             )
-            logger.debug("Dimension -> distance %s -> %s", e1.curve_id, e2.curve_id)
+            logger.debug("Dimension -> distance %s -> %s", a.curve_id, b.curve_id)
 
         # Give the freshly created label a sensible default offset so it is
         # visible before the first placement move (overwritten while dragging).
@@ -265,14 +295,16 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         return None
 
     def _pick_second(self, context: Context, event: Event):
-        """A compatible entity under the cursor to dimension the line against.
+        """A compatible entity under the cursor to dimension the first pick against.
 
-        Only meaningful for a line first pick: another line gives an angle, a
-        point gives a point-to-line distance. The line's own endpoints and the
-        already-adopted partner are excluded.
+        Meaningful for a line, circle or arc first pick. A line can pair with a
+        line (angle / perpendicular distance), a point or a curve (distance). A
+        circle/arc can pair with a point or a line (edge distance) -- not another
+        curve. The first entity's own sub-parts and the adopted partner are
+        excluded.
         """
         e1 = self.entity1
-        if not isinstance(e1, LineRef):
+        if not isinstance(e1, (LineRef, CircleRef, ArcRef)):
             return None
 
         from ..drawing import picking
@@ -283,9 +315,14 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
             return None
 
         excluded = {e1.curve_id}
-        for p in (e1.p1, e1.p2):
-            if p:
-                excluded.add(p.curve_id)
+        if isinstance(e1, LineRef):
+            for p in (e1.p1, e1.p2):
+                if p:
+                    excluded.add(p.curve_id)
+        else:  # circle/arc -- don't dimension it against its own center
+            ct = getattr(e1, "ct", None)
+            if ct is not None:
+                excluded.add(ct.curve_id)
         current = getattr(self, "_second_ref", None)
         if current is not None:
             excluded.add(current.curve_id)
@@ -293,7 +330,12 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
             return None
 
         ref = curve_ref(self.sketch, cid)
-        return ref if isinstance(ref, (LineRef, PointRef)) else None
+        if isinstance(e1, LineRef):
+            allowed = (LineRef, PointRef, CircleRef, ArcRef)
+        else:
+            # A curve dimensions only against a point or line (no curve-to-curve).
+            allowed = (LineRef, PointRef)
+        return ref if isinstance(ref, allowed) else None
 
     def _switch_second(self, context: Context, ref):
         """Adopt a second entity mid-placement and rebuild as the new type."""

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -17,6 +17,8 @@ from ..model.line_2d import SlvsLine2D
 from ..model.point_2d import SlvsPoint2D
 from ..model.sketch_ref import get_active_constraints
 from ..stateful_operator.state import state_from_args
+from ..stateful_operator.utilities.keymap import is_numeric_input, is_unit_input
+from ..stateful_operator.utilities.numeric import NumericInput, parse_numeric
 from ..stateful_operator.utilities.register import register_stateops_factory
 from ..utilities.curve_data import refresh_curve_geometry
 from ..utilities.view import get_picking_origin_end, refresh
@@ -282,19 +284,62 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         refresh(context)
         logger.debug("Dimension: adopted second entity %s", ref.curve_id)
 
+    def _value_input(self) -> NumericInput:
+        """Lazily-created numeric buffer for typing the dimension value during
+        placement (kept separate from the state machine's own ``_numeric``, which
+        stays idle because the placement state has no property)."""
+        numeric = getattr(self, "_value_numeric", None)
+        if numeric is None:
+            numeric = self._value_numeric = NumericInput()
+            numeric.is_active = True
+        return numeric
+
+    def _apply_value(self, context: Context):
+        """Set the dimension value from the typed buffer, then re-solve.
+
+        Routes through the constraint's own ``value`` property so the differing
+        subtypes/units (distance, angle, diameter) are parsed correctly -- the
+        same reason the standalone tweak modal reads the constraint directly.
+        """
+        target = getattr(self, "target", None)
+        if target is None:
+            return
+        prop = target.rna_type.properties.get("value")
+        if prop is None:
+            return
+        value = parse_numeric(
+            prop, self._value_numeric.current, context.scene.unit_settings.system
+        )
+        if value is None:
+            # Empty or mid-typing/invalid -- keep the current value.
+            return
+        target.value = value
+        if self.sketch and solve_system(context, sketch=self.sketch):
+            refresh_curve_geometry(self.sketch)
+        refresh(context)
+        context.workspace.status_text_set(
+            "Value: {}".format(self._value_numeric.current)
+        )
+
     def modal(self, context: Context, event: Event):
-        # During placement a click on a second compatible entity switches the
-        # inferred dimension (line length -> angle / point-to-line distance) and
-        # keeps dragging, instead of confirming. Anything else defers to the base.
-        if (
-            self._is_placement_state()
-            and event.type == "LEFTMOUSE"
-            and event.value == "PRESS"
-        ):
-            ref = self._pick_second(context, event)
-            if ref is not None:
-                self._switch_second(context, ref)
+        if self._is_placement_state():
+            # Numeric value entry: type a number (with units) to set the
+            # dimension value, independent of the label drag -- mirrors the tweak
+            # modal and the dimensional constraint operators.
+            if event.value == "PRESS" and (
+                is_numeric_input(event) or is_unit_input(event)
+            ):
+                self._value_input().evaluate_event(event)
+                self._apply_value(context)
                 return {"RUNNING_MODAL"}
+            # A click on a second compatible entity switches the inferred
+            # dimension (line length -> angle / point-to-line distance) and keeps
+            # dragging, instead of confirming.
+            if event.type == "LEFTMOUSE" and event.value == "PRESS":
+                ref = self._pick_second(context, event)
+                if ref is not None:
+                    self._switch_second(context, ref)
+                    return {"RUNNING_MODAL"}
         return super().modal(context, event)
 
     def main(self, context: Context):

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -35,8 +35,9 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
     The user does not choose between distance, angle and diameter up front:
 
     - a line              -> distance (its length); click a second line while
-                             placing to switch to an angle, or a point for a
-                             point-to-line distance
+                             placing to switch to an angle (or the perpendicular
+                             distance if the two lines are parallel), or a point
+                             for a point-to-line distance
     - a circle or arc     -> diameter
     - two points          -> distance
 
@@ -137,6 +138,12 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
             return
         super()._apply_undo(context)
 
+    @staticmethod
+    def _lines_parallel(l1: LineRef, l2: LineRef, tol_deg: float = 0.5) -> bool:
+        """True if two lines are (anti-)parallel, i.e. their angle is ~0/180."""
+        angle = SlvsAngle._get_angle(l1.direction_vec(), l2.direction_vec())
+        return angle < tol_deg or angle > 180.0 - tol_deg
+
     def _distance_exists(self, context: Context, cids) -> bool:
         """True if a distance constraint already spans exactly ``cids``."""
         want = set(cids)
@@ -194,7 +201,21 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
                 logger.debug("Dimension: point %s needs a second entity", e1.curve_id)
                 return
         elif isinstance(e1, LineRef) and isinstance(e2, LineRef):
-            if not self.exists(context, SlvsAngle):
+            if self._lines_parallel(e1, e2):
+                # Parallel lines have no angle vertex (their intersection is at
+                # infinity), so measure the perpendicular gap instead: a
+                # point-to-line distance from one line's endpoint to the other.
+                p = e1.p1
+                if p and not self._distance_exists(context, (p.curve_id, e2.curve_id)):
+                    self.target = constraints.add_distance(
+                        init=init, curve_id_1=p.curve_id, curve_id_2=e2.curve_id
+                    )
+                    logger.debug(
+                        "Dimension -> distance (parallel lines) %s -> %s",
+                        p.curve_id,
+                        e2.curve_id,
+                    )
+            elif not self.exists(context, SlvsAngle):
                 self.target = constraints.add_angle(
                     init=init, curve_id_1=e1.curve_id, curve_id_2=e2.curve_id
                 )

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -144,11 +144,16 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         angle = SlvsAngle._get_angle(l1.direction_vec(), l2.direction_vec())
         return angle < tol_deg or angle > 180.0 - tol_deg
 
-    def _distance_exists(self, context: Context, cids) -> bool:
-        """True if a distance constraint already spans exactly ``cids``."""
+    def _constraint_exists(self, context: Context, constraint_type, cids) -> bool:
+        """True if a constraint of ``constraint_type`` already spans exactly ``cids``.
+
+        Compared against explicit curve ids rather than the base ``exists`` (which
+        only reads entity1..entity4) so it also covers a partner adopted during
+        placement via ``_second_ref``, and blocks a second identical dimension.
+        """
         want = set(cids)
         for c in get_active_constraints(context).all:
-            if isinstance(c, SlvsDistance) and set(c.curve_id_placements()) == want:
+            if isinstance(c, constraint_type) and set(c.curve_id_placements()) == want:
                 return True
         return False
 
@@ -179,7 +184,7 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
 
         if e2 is None:
             if isinstance(e1, (CircleRef, ArcRef)):
-                if not self.exists(context, SlvsDiameter):
+                if not self._constraint_exists(context, SlvsDiameter, (e1.curve_id,)):
                     self.target = constraints.add_diameter(
                         init=init, curve_id_1=e1.curve_id
                     )
@@ -188,11 +193,8 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
                 # The native solver needs two point ids, so measure the line as
                 # the distance between its own endpoints.
                 p1, p2 = e1.p1, e1.p2
-                if (
-                    p1
-                    and p2
-                    and not self._distance_exists(context, (p1.curve_id, p2.curve_id))
-                ):
+                cids = (p1.curve_id, p2.curve_id) if p1 and p2 else None
+                if cids and not self._constraint_exists(context, SlvsDistance, cids):
                     self.target = constraints.add_distance(
                         init=init, curve_id_1=p1.curve_id, curve_id_2=p2.curve_id
                     )
@@ -206,7 +208,8 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
                 # infinity), so measure the perpendicular gap instead: a
                 # point-to-line distance from one line's endpoint to the other.
                 p = e1.p1
-                if p and not self._distance_exists(context, (p.curve_id, e2.curve_id)):
+                cids = (p.curve_id, e2.curve_id) if p else None
+                if cids and not self._constraint_exists(context, SlvsDistance, cids):
                     self.target = constraints.add_distance(
                         init=init, curve_id_1=p.curve_id, curve_id_2=e2.curve_id
                     )
@@ -215,7 +218,9 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
                         p.curve_id,
                         e2.curve_id,
                     )
-            elif not self.exists(context, SlvsAngle):
+            elif not self._constraint_exists(
+                context, SlvsAngle, (e1.curve_id, e2.curve_id)
+            ):
                 self.target = constraints.add_angle(
                     init=init, curve_id_1=e1.curve_id, curve_id_2=e2.curve_id
                 )
@@ -228,10 +233,9 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
             # ordered point-first to measure the point-to-line distance.
             if isinstance(e1, LineRef) and isinstance(e2, PointRef):
                 e1, e2 = e2, e1
-            max_constraints = (
-                2 if isinstance(e1, PointRef) and isinstance(e2, PointRef) else 1
-            )
-            if not self.exists(context, SlvsDistance, max_constraints):
+            if not self._constraint_exists(
+                context, SlvsDistance, (e1.curve_id, e2.curve_id)
+            ):
                 self.target = constraints.add_distance(
                     init=init, curve_id_1=e1.curve_id, curve_id_2=e2.curve_id
                 )

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -203,22 +203,6 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         if target and context.region_data:
             target.draw_offset = 0.05 * context.region_data.view_distance
 
-    def _ensure_gizmo(self, context: Context):
-        """Nudge the persistent constraint gizmo group to rebuild for the new
-        dimension.
-
-        The label is drawn by a persistent gizmo group whose ``setup`` only runs
-        on a gizmo-map refresh, which Blender does not do on its own while our
-        modal is running -- so a constraint created mid-modal starts with no
-        gizmo and its label can't be dragged. Toggling ``show_gizmo`` off here
-        lets the placement state's ``refresh`` (which turns it back on) drive the
-        off->on transition that re-runs the group's setup. ``gizmo_group_type_ensure``
-        cannot be used for this -- it rejects PERSISTENT groups.
-        """
-        space = context.space_data
-        if space and getattr(space, "type", None) == "VIEW_3D":
-            space.show_gizmo = False
-
     def _place_dimension(self, context: Context, coords):
         """Drag the dimension label onto the cursor, display only.
 
@@ -228,6 +212,7 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         """
         target = getattr(self, "target", None)
         if not target or not hasattr(target, "update_draw_offset"):
+            logger.debug("Placement: no target to place")
             return None
 
         origin, end_point = get_picking_origin_end(context, coords)
@@ -237,6 +222,15 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
             target.update_draw_offset(pos, context.preferences.system.ui_scale)
             # Full refresh (show_gizmo + redraw) so the gizmo re-reads the offset.
             refresh(context)
+        # One line per placement session tells us whether this runs and whether
+        # the offset actually moves (drop the counter once the drag is confirmed).
+        if not getattr(self, "_placement_logged", False):
+            self._placement_logged = True
+            logger.debug(
+                "Placement active: pos=%s draw_offset=%s",
+                None if pos is None else tuple(round(v, 3) for v in pos),
+                round(getattr(target, "draw_offset", 0.0), 4),
+            )
         return None
 
     def main(self, context: Context):
@@ -249,20 +243,17 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         if self.initialized and self._is_placement_state():
             return bool(getattr(self, "target", None))
 
-        # An entity pick changed the inference -- rebuild the constraint.
+        # An entity pick changed the inference -- rebuild the constraint. Reset
+        # the once-per-session placement log so it re-arms after a type switch.
+        self._placement_logged = False
         self._clear_target(context)
         self._create_constraint(context)
-        result = super().main(context)
-        # Force the gizmo group to pick up the new constraint so its label can be
-        # dragged in the placement state that follows.
-        self._ensure_gizmo(context)
-        return result
+        return super().main(context)
 
     def fini(self, context: Context, succeede: bool):
         # Placement now happens in this operator's own placement state, so there
         # is no hand-off to the standalone tweak modal (unlike GenericConstraintOp).
-        # Always leave gizmos visible: _ensure_gizmo may have toggled show_gizmo
-        # off, and on cancel the placement refresh never turns it back on.
+        # Make sure gizmos end up visible and the label reflects the final offset.
         refresh(context)
         target = getattr(self, "target", None)
         if target is not None:

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -1,6 +1,8 @@
 import logging
 
+from bpy.props import FloatProperty
 from bpy.types import Context, Operator
+from mathutils.geometry import intersect_line_plane
 
 from ..declarations import Operators
 from ..model.angle import SlvsAngle
@@ -11,49 +13,72 @@ from ..model.diameter import SlvsDiameter
 from ..model.distance import SlvsDistance
 from ..model.line_2d import SlvsLine2D
 from ..model.point_2d import SlvsPoint2D
+from ..model.sketch_ref import get_active_constraints
 from ..stateful_operator.state import state_from_args
 from ..stateful_operator.utilities.register import register_stateops_factory
+from ..utilities.view import get_picking_origin_end
 from .base_constraint import GenericConstraintOp
 
 logger = logging.getLogger(__name__)
 
+_PLACEMENT_STATE = "Placement"
+
 
 class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
-    """Add a dimension. The constraint type (distance, diameter or angle) is
-    inferred from the selected geometry, so the user doesn't pick it up front."""
+    """Add a dimension.
+
+    The concrete constraint type is inferred from the selected geometry, so the
+    user does not have to choose between distance, angle and diameter up front:
+
+    - a single line              -> distance (its length)
+    - two lines                  -> angle
+    - a circle or arc            -> diameter
+    - two points / point + line  -> distance
+
+    After the geometry is picked the same operator stays live in a final
+    placement state where the dimension label is dragged into place (display
+    only, no re-solve) and confirmed with a click.
+    """
 
     bl_idname = Operators.AddDimension
     bl_label = "Dimension"
     bl_options = {"UNDO", "REGISTER"}
 
-    # No single constraint type -- dispatched at runtime in main(). Both
-    # states()/_available_entities() are overridden so cls.type is never used.
+    # GenericConstraintOp keys off a single constraint ``type``; this operator
+    # spans several, so it drives ``states``/creation itself and never resolves a
+    # type from the base machinery.
     type = None
     property_keys = ()
     has_value_state = False
 
+    # Live label offset. Filled by the placement state's ``state_func`` as a
+    # display-only side effect; the property itself is only a confirm carrier.
+    placement: FloatProperty(options={"SKIP_SAVE", "HIDDEN"})
+
     @staticmethod
     def _second_slot(operator):
-        """(types, optional) for the second pick, narrowed by the first entity.
+        """Return ``(types, optional)`` for the second pick, given the first.
 
-        A lone point can't be dimensioned so its second pick is required; a line
-        or curve can (length / diameter), so theirs is optional -- picking a
-        second entity then switches the inferred type (e.g. line -> angle).
+        The second slot is narrowed by what the first entity was: a line pairs
+        with another line (angle) or a point/line (distance); a point needs a
+        partner to be dimensionable at all; a circle/arc needs nothing more.
+        ``optional`` marks whether the operator can finish on the first pick.
         """
         e1 = getattr(operator, "entity1", None) if operator else None
+        if isinstance(e1, (CircleRef, ArcRef)):
+            # Diameter needs no second entity.
+            return (), False
         if isinstance(e1, PointRef):
+            # A lone point cannot be dimensioned -- require a partner.
             return (SlvsPoint2D, SlvsLine2D), False
         if isinstance(e1, LineRef):
-            # + line -> angle, + point -> point/line distance, none -> length.
+            # A single line already has a length; a second line switches to angle.
             return (SlvsLine2D, SlvsPoint2D), True
-        if isinstance(e1, (CircleRef, ArcRef)):
-            # + line/point -> distance, none -> diameter/radius.
-            return (SlvsLine2D, SlvsPoint2D), True
-        # Before the first pick: offer a generic optional second entity.
         return (SlvsPoint2D, SlvsLine2D), True
 
     @classmethod
     def states(cls, operator=None):
+        """Build the pick states, then a terminal interactive placement state."""
         first_types = (SlvsPoint2D, SlvsLine2D, SlvsCircle, SlvsArc)
         states = [
             state_from_args(
@@ -64,6 +89,7 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
                 use_create=False,
             )
         ]
+
         second_types, optional = cls._second_slot(operator)
         if second_types:
             states.append(
@@ -76,56 +102,90 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
                     optional=optional,
                 )
             )
+
+        # Placement: no property/pointer, so it neither re-solves nor snapshots
+        # per move -- its ``state_func`` just drags the label offset, and a click
+        # confirms via the optional-state skip in the state machine.
+        states.append(
+            state_from_args(
+                _PLACEMENT_STATE,
+                description="Move to place the dimension label, click to confirm.",
+                property=None,
+                state_func="_place_dimension",
+                interactive=True,
+                optional=True,
+                allow_prefill=False,
+            )
+        )
         return states
 
     def _available_entities(self):
         return [getattr(self, "entity1", None), getattr(self, "entity2", None)]
 
-    def _add_line_length(self, context):
-        """Distance = a line's length: expand the line to its two endpoints and
-        constrain their distance (mirrors VIEW3D_OT_slvs_add_distance)."""
+    def _is_placement_state(self) -> bool:
+        return self.state.name == _PLACEMENT_STATE
+
+    def _distance_exists(self, context: Context, cids) -> bool:
+        """True if a distance constraint already spans exactly ``cids``."""
+        want = set(cids)
+        for c in get_active_constraints(context).all:
+            if isinstance(c, SlvsDistance) and set(c.curve_id_placements()) == want:
+                return True
+        return False
+
+    def _clear_target(self, context: Context):
+        """Drop a previously created constraint before re-inferring the type.
+
+        Picking a second line after a first turns a tentative length into an
+        angle; without a snapshot in the placement path we remove the stale one
+        explicitly so the two never coexist.
+        """
+        target = getattr(self, "target", None)
+        if target is None:
+            return
+        try:
+            self.sketch.constraints.remove(target)
+        except (ValueError, RuntimeError):
+            pass
+        self.target = None
+
+    def _create_constraint(self, context: Context):
+        """Infer and create the dimensional constraint from the current picks."""
         e1 = self.entity1
-        p1, p2 = e1.p1, e1.p2
-        if p1 and p2:
-            for i, pt in enumerate((p1, p2)):
-                state_data = self.get_state_data(i)
-                state_data["hovered"] = 0
-                state_data["type"] = PointRef
-                state_data["is_existing_entity"] = True
-                state_data["curve_id"] = pt.curve_id
-            self.next_state(context)
-        e1, e2 = self.entity1, self.entity2
-        if not self.exists(context, SlvsDistance, max_constraints=2):
-            self.target = self.sketch.constraints.add_distance(
-                init=not self.initialized,
-                curve_id_1=e1.curve_id if e1 else "",
-                curve_id_2=e2.curve_id if e2 else "",
-            )
-
-    def main(self, context):
-        e1, e2 = self.entity1, self.entity2
-        if e1 is None:
-            return False
-
+        e2 = getattr(self, "entity2", None)
         constraints = self.sketch.constraints
+        init = not self.initialized
 
         if e2 is None:
             if isinstance(e1, (CircleRef, ArcRef)):
                 if not self.exists(context, SlvsDiameter):
                     self.target = constraints.add_diameter(
-                        init=not self.initialized, curve_id_1=e1.curve_id
+                        init=init, curve_id_1=e1.curve_id
                     )
+                    logger.debug("Dimension -> diameter on %s", e1.curve_id)
             elif isinstance(e1, LineRef):
-                self._add_line_length(context)
+                # The native solver needs two point ids, so measure the line as
+                # the distance between its own endpoints.
+                p1, p2 = e1.p1, e1.p2
+                if (
+                    p1
+                    and p2
+                    and not self._distance_exists(context, (p1.curve_id, p2.curve_id))
+                ):
+                    self.target = constraints.add_distance(
+                        init=init, curve_id_1=p1.curve_id, curve_id_2=p2.curve_id
+                    )
+                    logger.debug("Dimension -> line length on %s", e1.curve_id)
             else:
-                self.report({"WARNING"}, "Select a second entity to add a dimension")
-                return False
+                logger.debug("Dimension: point %s needs a second entity", e1.curve_id)
+                return
         elif isinstance(e1, LineRef) and isinstance(e2, LineRef):
             if not self.exists(context, SlvsAngle):
                 self.target = constraints.add_angle(
-                    init=not self.initialized,
-                    curve_id_1=e1.curve_id,
-                    curve_id_2=e2.curve_id,
+                    init=init, curve_id_1=e1.curve_id, curve_id_2=e2.curve_id
+                )
+                logger.debug(
+                    "Dimension -> angle between %s and %s", e1.curve_id, e2.curve_id
                 )
         else:
             max_constraints = (
@@ -133,18 +193,57 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
             )
             if not self.exists(context, SlvsDistance, max_constraints):
                 self.target = constraints.add_distance(
-                    init=not self.initialized,
-                    curve_id_1=e1.curve_id,
-                    curve_id_2=e2.curve_id,
+                    init=init, curve_id_1=e1.curve_id, curve_id_2=e2.curve_id
                 )
+                logger.debug("Dimension -> distance %s -> %s", e1.curve_id, e2.curve_id)
 
+        # Give the freshly created label a sensible default offset so it is
+        # visible before the first placement move (overwritten while dragging).
+        target = getattr(self, "target", None)
+        if target and context.region_data:
+            target.draw_offset = 0.05 * context.region_data.view_distance
+
+    def _place_dimension(self, context: Context, coords):
+        """Drag the dimension label onto the cursor, display only.
+
+        Projects the cursor onto the constraint's draw plane and offsets the
+        label there. Returns ``None`` so the placement state stores no value and
+        never triggers a re-solve; confirmation happens via the state click.
+        """
+        target = getattr(self, "target", None)
+        if not target or not hasattr(target, "update_draw_offset"):
+            return None
+
+        origin, end_point = get_picking_origin_end(context, coords)
+        pos = intersect_line_plane(origin, end_point, *target.draw_plane())
+        if pos is not None:
+            pos = target.matrix_basis().inverted() @ pos
+            target.update_draw_offset(pos, context.preferences.system.ui_scale)
+            if context.area:
+                context.area.tag_redraw()
+        return None
+
+    def main(self, context: Context):
+        e1 = getattr(self, "entity1", None)
+        if e1 is None:
+            return False
+
+        # While placing the label the geometry is fixed and only ``draw_offset``
+        # changes, so skip the recreate/solve and keep the existing constraint.
+        if self.initialized and self._is_placement_state():
+            return bool(getattr(self, "target", None))
+
+        # An entity pick changed the inference -- rebuild the constraint.
+        self._clear_target(context)
+        self._create_constraint(context)
         return super().main(context)
 
     def fini(self, context: Context, succeede: bool):
-        # Default label offset before the placement handoff (see add_distance).
-        if getattr(self, "target", None):
-            self.target.draw_offset = 0.1 * context.region_data.view_distance
-        super().fini(context, succeede)
+        # Placement now happens in this operator's own placement state, so there
+        # is no hand-off to the standalone tweak modal (unlike GenericConstraintOp).
+        target = getattr(self, "target", None)
+        if target is not None:
+            logger.debug("Dimension committed: %s (succeeded=%s)", target, succeede)
 
 
 register, unregister = register_stateops_factory((VIEW3D_OT_slvs_add_dimension,))

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -1,14 +1,16 @@
 import logging
 
 from bpy.props import FloatProperty
-from bpy.types import Context, Operator
+from bpy.types import Context, Event, Operator
+from mathutils import Vector
 from mathutils.geometry import intersect_line_plane
 
+from ..curve_solver import solve_system
 from ..declarations import Operators
 from ..model.angle import SlvsAngle
 from ..model.arc import SlvsArc
 from ..model.circle import SlvsCircle
-from ..model.curve_ref import ArcRef, CircleRef, LineRef, PointRef
+from ..model.curve_ref import ArcRef, CircleRef, LineRef, PointRef, curve_ref
 from ..model.diameter import SlvsDiameter
 from ..model.distance import SlvsDistance
 from ..model.line_2d import SlvsLine2D
@@ -16,6 +18,7 @@ from ..model.point_2d import SlvsPoint2D
 from ..model.sketch_ref import get_active_constraints
 from ..stateful_operator.state import state_from_args
 from ..stateful_operator.utilities.register import register_stateops_factory
+from ..utilities.curve_data import refresh_curve_geometry
 from ..utilities.view import get_picking_origin_end, refresh
 from .base_constraint import GenericConstraintOp
 
@@ -25,19 +28,20 @@ _PLACEMENT_STATE = "Placement"
 
 
 class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
-    """Add a dimension.
+    """Add a dimension, inferring the constraint type from the geometry.
 
-    The concrete constraint type is inferred from the selected geometry, so the
-    user does not have to choose between distance, angle and diameter up front:
+    The user does not choose between distance, angle and diameter up front:
 
-    - a single line              -> distance (its length)
-    - two lines                  -> angle
-    - a circle or arc            -> diameter
-    - two points / point + line  -> distance
+    - a line              -> distance (its length); click a second line while
+                             placing to switch to an angle, or a point for a
+                             point-to-line distance
+    - a circle or arc     -> diameter
+    - two points          -> distance
 
-    After the geometry is picked the same operator stays live in a final
-    placement state where the dimension label is dragged into place (display
-    only, no re-solve) and confirmed with a click.
+    A line/circle/arc drops straight into an interactive placement state after
+    the first pick, where the label is dragged into place (display only, no
+    re-solve) and confirmed with a click. A point needs a partner, so it takes a
+    required second pick before placement.
     """
 
     bl_idname = Operators.AddDimension
@@ -55,30 +59,10 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
     # display-only side effect; the property itself is only a confirm carrier.
     placement: FloatProperty(options={"SKIP_SAVE", "HIDDEN"})
 
-    @staticmethod
-    def _second_slot(operator):
-        """Return ``(types, optional)`` for the second pick, given the first.
-
-        The second slot is narrowed by what the first entity was: a line pairs
-        with another line (angle) or a point/line (distance); a point needs a
-        partner to be dimensionable at all; a circle/arc needs nothing more.
-        ``optional`` marks whether the operator can finish on the first pick.
-        """
-        e1 = getattr(operator, "entity1", None) if operator else None
-        if isinstance(e1, (CircleRef, ArcRef)):
-            # Diameter needs no second entity.
-            return (), False
-        if isinstance(e1, PointRef):
-            # A lone point cannot be dimensioned -- require a partner.
-            return (SlvsPoint2D, SlvsLine2D), False
-        if isinstance(e1, LineRef):
-            # A single line already has a length; a second line switches to angle.
-            return (SlvsLine2D, SlvsPoint2D), True
-        return (SlvsPoint2D, SlvsLine2D), True
-
     @classmethod
     def states(cls, operator=None):
-        """Build the pick states, then a terminal interactive placement state."""
+        """Pick the first entity (+ a required partner for a lone point), then a
+        terminal interactive placement state."""
         first_types = (SlvsPoint2D, SlvsLine2D, SlvsCircle, SlvsArc)
         states = [
             state_from_args(
@@ -90,16 +74,21 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
             )
         ]
 
-        second_types, optional = cls._second_slot(operator)
-        if second_types:
+        # Add a partner-pick state when the first entity needs one (a lone point)
+        # or when it isn't known yet -- the latter lets a pre-selected pair (e.g.
+        # two points) prefill a second entity. A known line/circle/arc goes
+        # straight to placement; a line gains its optional partner by a click
+        # during placement instead.
+        e1 = getattr(operator, "entity1", None) if operator else None
+        if e1 is None or isinstance(e1, PointRef):
             states.append(
                 state_from_args(
                     "Entity 2",
-                    description="Optionally pick a second entity to dimension against.",
+                    description="Pick the entity to measure to.",
                     pointer="entity2",
-                    types=second_types,
+                    types=(SlvsPoint2D, SlvsLine2D),
                     use_create=False,
-                    optional=optional,
+                    optional=e1 is None,
                 )
             )
 
@@ -119,8 +108,13 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         )
         return states
 
+    def _second_entity(self):
+        """The partner entity, from the state machine (point flow) or from a
+        click made during placement (line flow)."""
+        return getattr(self, "entity2", None) or getattr(self, "_second_ref", None)
+
     def _available_entities(self):
-        return [getattr(self, "entity1", None), getattr(self, "entity2", None)]
+        return [getattr(self, "entity1", None), self._second_entity()]
 
     def _is_placement_state(self) -> bool:
         return self.state.name == _PLACEMENT_STATE
@@ -152,9 +146,9 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
     def _clear_target(self, context: Context):
         """Drop a previously created constraint before re-inferring the type.
 
-        Picking a second line after a first turns a tentative length into an
-        angle; without a snapshot in the placement path we remove the stale one
-        explicitly so the two never coexist.
+        Adopting a second entity turns a tentative length into an angle/distance;
+        the placement path suppresses the snapshot, so remove the stale one
+        explicitly rather than relying on an undo to do it.
         """
         target = getattr(self, "target", None)
         if target is None:
@@ -168,9 +162,11 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
     def _create_constraint(self, context: Context):
         """Infer and create the dimensional constraint from the current picks."""
         e1 = self.entity1
-        e2 = getattr(self, "entity2", None)
+        e2 = self._second_entity()
         constraints = self.sketch.constraints
-        init = not self.initialized
+        # The dimension value is always the measured geometry (drag only moves the
+        # label), so always initialise it from the current geometry.
+        init = True
 
         if e2 is None:
             if isinstance(e1, (CircleRef, ArcRef)):
@@ -233,7 +229,6 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         """
         target = getattr(self, "target", None)
         if not target or not hasattr(target, "update_draw_offset"):
-            logger.debug("Placement: no target to place")
             return None
 
         origin, end_point = get_picking_origin_end(context, coords)
@@ -243,23 +238,64 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
             target.update_draw_offset(pos, context.preferences.system.ui_scale)
             # Full refresh (show_gizmo + redraw) so the gizmo re-reads the offset.
             refresh(context)
-        # Per-move diagnostic (throttled): confirms _place_dimension keeps being
-        # called as the cursor moves and that draw_offset actually changes, and
-        # whether the target's index stays stable (a churned index would leave
-        # the gizmo bound to a stale constraint).
-        self._place_calls = getattr(self, "_place_calls", 0) + 1
-        if self._place_calls % 4 == 1:
-            constraints = get_active_constraints(context)
-            logger.debug(
-                "Placement #%d: draw_offset=%.3f outset=%.3f target=%s idx=%s n=%d",
-                self._place_calls,
-                getattr(target, "draw_offset", 0.0),
-                getattr(target, "draw_outset", 0.0),
-                target.type,
-                constraints.get_index(target) if constraints else -1,
-                len(list(constraints.all)) if constraints else -1,
-            )
         return None
+
+    def _pick_second(self, context: Context, event: Event):
+        """A compatible entity under the cursor to dimension the line against.
+
+        Only meaningful for a line first pick: another line gives an angle, a
+        point gives a point-to-line distance. The line's own endpoints and the
+        already-adopted partner are excluded.
+        """
+        e1 = self.entity1
+        if not isinstance(e1, LineRef):
+            return None
+
+        from ..drawing import picking
+
+        coords = Vector((event.mouse_region_x, event.mouse_region_y))
+        cid = picking.update_hover(context, coords)
+        if not cid:
+            return None
+
+        excluded = {e1.curve_id}
+        for p in (e1.p1, e1.p2):
+            if p:
+                excluded.add(p.curve_id)
+        current = getattr(self, "_second_ref", None)
+        if current is not None:
+            excluded.add(current.curve_id)
+        if cid in excluded:
+            return None
+
+        ref = curve_ref(self.sketch, cid)
+        return ref if isinstance(ref, (LineRef, PointRef)) else None
+
+    def _switch_second(self, context: Context, ref):
+        """Adopt a second entity mid-placement and rebuild as the new type."""
+        self._second_ref = ref
+        self._clear_target(context)
+        self._create_constraint(context)
+        if self.sketch:
+            solve_system(context, sketch=self.sketch)
+            refresh_curve_geometry(self.sketch)
+        refresh(context)
+        logger.debug("Dimension: adopted second entity %s", ref.curve_id)
+
+    def modal(self, context: Context, event: Event):
+        # During placement a click on a second compatible entity switches the
+        # inferred dimension (line length -> angle / point-to-line distance) and
+        # keeps dragging, instead of confirming. Anything else defers to the base.
+        if (
+            self._is_placement_state()
+            and event.type == "LEFTMOUSE"
+            and event.value == "PRESS"
+        ):
+            ref = self._pick_second(context, event)
+            if ref is not None:
+                self._switch_second(context, ref)
+                return {"RUNNING_MODAL"}
+        return super().modal(context, event)
 
     def main(self, context: Context):
         e1 = getattr(self, "entity1", None)
@@ -277,8 +313,8 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         return super().main(context)
 
     def fini(self, context: Context, succeede: bool):
-        # Placement now happens in this operator's own placement state, so there
-        # is no hand-off to the standalone tweak modal (unlike GenericConstraintOp).
+        # Placement happens in this operator's own placement state, so there is no
+        # hand-off to the standalone tweak modal (unlike GenericConstraintOp).
         # Make sure gizmos end up visible and the label reflects the final offset.
         refresh(context)
         target = getattr(self, "target", None)

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -311,6 +311,7 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
 
         coords = Vector((event.mouse_region_x, event.mouse_region_y))
         cid = picking.update_hover(context, coords)
+        logger.debug("_pick_second: hover cid=%s", cid or None)
         if not cid:
             return None
 
@@ -399,6 +400,10 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
             # dragging, instead of confirming.
             if event.type == "LEFTMOUSE" and event.value == "PRESS":
                 ref = self._pick_second(context, event)
+                logger.debug(
+                    "Placement LEFTMOUSE: pick_second -> %s",
+                    ref.curve_id if ref else None,
+                )
                 if ref is not None:
                     self._switch_second(context, ref)
                     return {"RUNNING_MODAL"}

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -42,12 +42,12 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
     - two points          -> distance
     - point + line        -> point-to-line distance
     - point/line + circle/arc -> edge distance (measured from the curve's edge)
+    - circle/arc + circle/arc -> center-to-center distance
 
     A line/circle/arc drops straight into an interactive placement state after
     the first pick, where the label is dragged into place (display only, no
     re-solve) and confirmed with a click. A point needs a partner, so it takes a
-    required second pick before placement. Curve-to-curve distance is not
-    supported by the solver.
+    required second pick before placement.
     """
 
     bl_idname = Operators.AddDimension
@@ -154,12 +154,16 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
 
         The solver measures a curve (circle/arc) from its edge and requires it as
         entity1; a point/line pair measures point-to-line, so the point goes
-        first. Curve-to-curve distance is not supported.
+        first. Two curves have no edge-to-edge distance in the solver, so they are
+        measured center-to-center (the common hole-spacing dimension) by pairing
+        their center points.
         """
         c1 = isinstance(e1, (CircleRef, ArcRef))
         c2 = isinstance(e2, (CircleRef, ArcRef))
         if c1 and c2:
-            return None
+            ct1 = getattr(e1, "ct", None)
+            ct2 = getattr(e2, "ct", None)
+            return (ct1, ct2) if ct1 is not None and ct2 is not None else None
         if c2:
             return e2, e1
         if c1:
@@ -329,13 +333,11 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         if cid in excluded:
             return None
 
+        # A line pairs with a line (angle/parallel) or anything for a distance; a
+        # curve pairs with a point/line (edge distance) or another curve
+        # (center-to-center). So any dimensionable entity is a valid partner.
         ref = curve_ref(self.sketch, cid)
-        if isinstance(e1, LineRef):
-            allowed = (LineRef, PointRef, CircleRef, ArcRef)
-        else:
-            # A curve dimensions only against a point or line (no curve-to-curve).
-            allowed = (LineRef, PointRef)
-        return ref if isinstance(ref, allowed) else None
+        return ref if isinstance(ref, (LineRef, PointRef, CircleRef, ArcRef)) else None
 
     def _switch_second(self, context: Context, ref):
         """Adopt a second entity mid-placement and rebuild as the new type."""

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -7,6 +7,7 @@ from mathutils.geometry import intersect_line_plane
 
 from ..curve_solver import solve_system
 from ..declarations import Operators
+from ..drawing import selection
 from ..model.angle import SlvsAngle
 from ..model.arc import SlvsArc
 from ..model.circle import SlvsCircle
@@ -114,10 +115,57 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         )
         return states
 
+    def init(self, context: Context, event: Event):
+        if not super().init(context, event):
+            return False
+        # Snapshot the pre-selection: a first-pick type that goes straight to
+        # placement (line/circle/arc) has no E2 slot, so a pre-selected partner
+        # is adopted from here in _create_constraint rather than via a state.
+        self._prefill_selection = list(selection.selected)
+        return True
+
     def _second_entity(self):
         """The partner entity, from the state machine (point flow) or from a
         click made during placement (line flow)."""
         return getattr(self, "entity2", None) or getattr(self, "_second_ref", None)
+
+    def _prefill_second(self):
+        """Adopt a pre-selected partner for a line/circle/arc first pick.
+
+        Prefill fills only ``entity1`` for these types (their dynamic states drop
+        the E2 slot once the type is known), so a pre-selected pair would only
+        dimension the first entity. Pull a compatible second from the snapshot.
+        """
+        if self._second_entity() is not None:
+            return
+        e1 = getattr(self, "entity1", None)
+        if not isinstance(e1, (LineRef, CircleRef, ArcRef)):
+            return
+
+        excluded = {e1.curve_id}
+        if isinstance(e1, LineRef):
+            for p in (e1.p1, e1.p2):
+                if p:
+                    excluded.add(p.curve_id)
+        else:
+            ct = getattr(e1, "ct", None)
+            if ct is not None:
+                excluded.add(ct.curve_id)
+
+        # Prefer the init snapshot; fall back to the live selection (the test
+        # harness drives the op without invoke/init). _create_constraint runs
+        # before the deselect in super().main(), so the selection is still intact.
+        candidates = getattr(self, "_prefill_selection", None)
+        if candidates is None:
+            candidates = list(selection.selected)
+
+        for cid in candidates:
+            if cid in excluded:
+                continue
+            ref = curve_ref(self.sketch, cid)
+            if isinstance(ref, (LineRef, PointRef, CircleRef, ArcRef)):
+                self._second_ref = ref
+                return
 
     def _available_entities(self):
         return [getattr(self, "entity1", None), self._second_entity()]
@@ -204,6 +252,7 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
 
     def _create_constraint(self, context: Context):
         """Infer and create the dimensional constraint from the current picks."""
+        self._prefill_second()
         e1 = self.entity1
         e2 = self._second_entity()
         constraints = self.sketch.constraints

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -16,7 +16,7 @@ from ..model.point_2d import SlvsPoint2D
 from ..model.sketch_ref import get_active_constraints
 from ..stateful_operator.state import state_from_args
 from ..stateful_operator.utilities.register import register_stateops_factory
-from ..utilities.view import get_picking_origin_end
+from ..utilities.view import get_picking_origin_end, refresh
 from .base_constraint import GenericConstraintOp
 
 logger = logging.getLogger(__name__)
@@ -203,6 +203,22 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         if target and context.region_data:
             target.draw_offset = 0.05 * context.region_data.view_distance
 
+    def _ensure_gizmo(self, context: Context):
+        """Nudge the persistent constraint gizmo group to rebuild for the new
+        dimension.
+
+        The label is drawn by a persistent gizmo group whose ``setup`` only runs
+        on a gizmo-map refresh, which Blender does not do on its own while our
+        modal is running -- so a constraint created mid-modal starts with no
+        gizmo and its label can't be dragged. Toggling ``show_gizmo`` off here
+        lets the placement state's ``refresh`` (which turns it back on) drive the
+        off->on transition that re-runs the group's setup. ``gizmo_group_type_ensure``
+        cannot be used for this -- it rejects PERSISTENT groups.
+        """
+        space = context.space_data
+        if space and getattr(space, "type", None) == "VIEW_3D":
+            space.show_gizmo = False
+
     def _place_dimension(self, context: Context, coords):
         """Drag the dimension label onto the cursor, display only.
 
@@ -219,8 +235,8 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         if pos is not None:
             pos = target.matrix_basis().inverted() @ pos
             target.update_draw_offset(pos, context.preferences.system.ui_scale)
-            if context.area:
-                context.area.tag_redraw()
+            # Full refresh (show_gizmo + redraw) so the gizmo re-reads the offset.
+            refresh(context)
         return None
 
     def main(self, context: Context):
@@ -236,11 +252,18 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         # An entity pick changed the inference -- rebuild the constraint.
         self._clear_target(context)
         self._create_constraint(context)
-        return super().main(context)
+        result = super().main(context)
+        # Force the gizmo group to pick up the new constraint so its label can be
+        # dragged in the placement state that follows.
+        self._ensure_gizmo(context)
+        return result
 
     def fini(self, context: Context, succeede: bool):
         # Placement now happens in this operator's own placement state, so there
         # is no hand-off to the standalone tweak modal (unlike GenericConstraintOp).
+        # Always leave gizmos visible: _ensure_gizmo may have toggled show_gizmo
+        # off, and on cancel the placement refresh never turns it back on.
+        refresh(context)
         target = getattr(self, "target", None)
         if target is not None:
             logger.debug("Dimension committed: %s (succeeded=%s)", target, succeede)

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -42,7 +42,7 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
     - two points          -> distance
     - point + line        -> point-to-line distance
     - point/line + circle/arc -> edge distance (measured from the curve's edge)
-    - circle/arc + circle/arc -> center-to-center distance
+    - circle/arc + circle/arc -> edge-to-edge distance (along the line of centres)
 
     A line/circle/arc drops straight into an interactive placement state after
     the first pick, where the label is dragged into place (display only, no
@@ -154,16 +154,12 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
 
         The solver measures a curve (circle/arc) from its edge and requires it as
         entity1; a point/line pair measures point-to-line, so the point goes
-        first. Two curves have no edge-to-edge distance in the solver, so they are
-        measured center-to-center (the common hole-spacing dimension) by pairing
-        their center points.
+        first. Two curves are measured edge-to-edge along the line of centres.
         """
         c1 = isinstance(e1, (CircleRef, ArcRef))
         c2 = isinstance(e2, (CircleRef, ArcRef))
         if c1 and c2:
-            ct1 = getattr(e1, "ct", None)
-            ct2 = getattr(e2, "ct", None)
-            return (ct1, ct2) if ct1 is not None and ct2 is not None else None
+            return e1, e2
         if c2:
             return e2, e1
         if c1:

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -11,8 +11,6 @@ from ..model.angle import SlvsAngle
 from ..model.arc import SlvsArc
 from ..model.circle import SlvsCircle
 from ..model.curve_ref import ArcRef, CircleRef, LineRef, PointRef, curve_ref
-from ..model.diameter import SlvsDiameter
-from ..model.distance import SlvsDistance
 from ..model.line_2d import SlvsLine2D
 from ..model.point_2d import SlvsPoint2D
 from ..model.sketch_ref import get_active_constraints
@@ -144,17 +142,22 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         angle = SlvsAngle._get_angle(l1.direction_vec(), l2.direction_vec())
         return angle < tol_deg or angle > 180.0 - tol_deg
 
-    def _constraint_exists(self, context: Context, constraint_type, cids) -> bool:
-        """True if a constraint of ``constraint_type`` already spans exactly ``cids``.
+    def _is_duplicate(self, context: Context, target) -> bool:
+        """True if another constraint already matches ``target``'s type + curve ids.
 
-        Compared against explicit curve ids rather than the base ``exists`` (which
-        only reads entity1..entity4) so it also covers a partner adopted during
-        placement via ``_second_ref``, and blocks a second identical dimension.
+        Checked at commit rather than while creating, because the inferred type
+        can still change during placement (e.g. picking an already-length-
+        constrained line, then a second line, to add an *angle*): a premature
+        check would block the tentative length and its preview. Counting > 1
+        means one besides ``target`` itself exists.
         """
-        want = set(cids)
+        want = set(target.curve_id_placements())
+        count = 0
         for c in get_active_constraints(context).all:
-            if isinstance(c, constraint_type) and set(c.curve_id_placements()) == want:
-                return True
+            if type(c) is type(target) and set(c.curve_id_placements()) == want:
+                count += 1
+                if count > 1:
+                    return True
         return False
 
     def _clear_target(self, context: Context):
@@ -182,19 +185,19 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         # label), so always initialise it from the current geometry.
         init = True
 
+        # No dedup here -- see _is_duplicate (checked at fini). The tentative
+        # constraint is always created so it previews and can still change type.
         if e2 is None:
             if isinstance(e1, (CircleRef, ArcRef)):
-                if not self._constraint_exists(context, SlvsDiameter, (e1.curve_id,)):
-                    self.target = constraints.add_diameter(
-                        init=init, curve_id_1=e1.curve_id
-                    )
-                    logger.debug("Dimension -> diameter on %s", e1.curve_id)
+                self.target = constraints.add_diameter(
+                    init=init, curve_id_1=e1.curve_id
+                )
+                logger.debug("Dimension -> diameter on %s", e1.curve_id)
             elif isinstance(e1, LineRef):
                 # The native solver needs two point ids, so measure the line as
                 # the distance between its own endpoints.
                 p1, p2 = e1.p1, e1.p2
-                cids = (p1.curve_id, p2.curve_id) if p1 and p2 else None
-                if cids and not self._constraint_exists(context, SlvsDistance, cids):
+                if p1 and p2:
                     self.target = constraints.add_distance(
                         init=init, curve_id_1=p1.curve_id, curve_id_2=p2.curve_id
                     )
@@ -208,8 +211,7 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
                 # infinity), so measure the perpendicular gap instead: a
                 # point-to-line distance from one line's endpoint to the other.
                 p = e1.p1
-                cids = (p.curve_id, e2.curve_id) if p else None
-                if cids and not self._constraint_exists(context, SlvsDistance, cids):
+                if p:
                     self.target = constraints.add_distance(
                         init=init, curve_id_1=p.curve_id, curve_id_2=e2.curve_id
                     )
@@ -218,9 +220,7 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
                         p.curve_id,
                         e2.curve_id,
                     )
-            elif not self._constraint_exists(
-                context, SlvsAngle, (e1.curve_id, e2.curve_id)
-            ):
+            else:
                 self.target = constraints.add_angle(
                     init=init, curve_id_1=e1.curve_id, curve_id_2=e2.curve_id
                 )
@@ -233,13 +233,10 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
             # ordered point-first to measure the point-to-line distance.
             if isinstance(e1, LineRef) and isinstance(e2, PointRef):
                 e1, e2 = e2, e1
-            if not self._constraint_exists(
-                context, SlvsDistance, (e1.curve_id, e2.curve_id)
-            ):
-                self.target = constraints.add_distance(
-                    init=init, curve_id_1=e1.curve_id, curve_id_2=e2.curve_id
-                )
-                logger.debug("Dimension -> distance %s -> %s", e1.curve_id, e2.curve_id)
+            self.target = constraints.add_distance(
+                init=init, curve_id_1=e1.curve_id, curve_id_2=e2.curve_id
+            )
+            logger.debug("Dimension -> distance %s -> %s", e1.curve_id, e2.curve_id)
 
         # Give the freshly created label a sensible default offset so it is
         # visible before the first placement move (overwritten while dragging).
@@ -385,9 +382,21 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
     def fini(self, context: Context, succeede: bool):
         # Placement happens in this operator's own placement state, so there is no
         # hand-off to the standalone tweak modal (unlike GenericConstraintOp).
+        target = getattr(self, "target", None)
+
+        # Duplicate check happens here, at commit: the tentative constraint may
+        # have changed type during placement, so only its final form matters.
+        if succeede and target is not None and self._is_duplicate(context, target):
+            logger.debug("Dimension: discarding duplicate %s", target)
+            self._clear_target(context)
+            if self.sketch and solve_system(context, sketch=self.sketch):
+                refresh_curve_geometry(self.sketch)
+            if hasattr(self, "report"):
+                self.report({"INFO"}, "Dimension already exists")
+            target = None
+
         # Make sure gizmos end up visible and the label reflects the final offset.
         refresh(context)
-        target = getattr(self, "target", None)
         if target is not None:
             logger.debug("Dimension committed: %s (succeeded=%s)", target, succeede)
 

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -311,7 +311,6 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
 
         coords = Vector((event.mouse_region_x, event.mouse_region_y))
         cid = picking.update_hover(context, coords)
-        logger.debug("_pick_second: hover cid=%s", cid or None)
         if not cid:
             return None
 
@@ -400,10 +399,6 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
             # dragging, instead of confirming.
             if event.type == "LEFTMOUSE" and event.value == "PRESS":
                 ref = self._pick_second(context, event)
-                logger.debug(
-                    "Placement LEFTMOUSE: pick_second -> %s",
-                    ref.curve_id if ref else None,
-                )
                 if ref is not None:
                     self._switch_second(context, ref)
                     return {"RUNNING_MODAL"}

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -1,0 +1,150 @@
+import logging
+
+from bpy.types import Context, Operator
+
+from ..declarations import Operators
+from ..model.angle import SlvsAngle
+from ..model.arc import SlvsArc
+from ..model.circle import SlvsCircle
+from ..model.curve_ref import ArcRef, CircleRef, LineRef, PointRef
+from ..model.diameter import SlvsDiameter
+from ..model.distance import SlvsDistance
+from ..model.line_2d import SlvsLine2D
+from ..model.point_2d import SlvsPoint2D
+from ..stateful_operator.state import state_from_args
+from ..stateful_operator.utilities.register import register_stateops_factory
+from .base_constraint import GenericConstraintOp
+
+logger = logging.getLogger(__name__)
+
+
+class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
+    """Add a dimension. The constraint type (distance, diameter or angle) is
+    inferred from the selected geometry, so the user doesn't pick it up front."""
+
+    bl_idname = Operators.AddDimension
+    bl_label = "Dimension"
+    bl_options = {"UNDO", "REGISTER"}
+
+    # No single constraint type -- dispatched at runtime in main(). Both
+    # states()/_available_entities() are overridden so cls.type is never used.
+    type = None
+    property_keys = ()
+    has_value_state = False
+
+    @staticmethod
+    def _second_slot(operator):
+        """(types, optional) for the second pick, narrowed by the first entity.
+
+        A lone point can't be dimensioned so its second pick is required; a line
+        or curve can (length / diameter), so theirs is optional -- picking a
+        second entity then switches the inferred type (e.g. line -> angle).
+        """
+        e1 = getattr(operator, "entity1", None) if operator else None
+        if isinstance(e1, PointRef):
+            return (SlvsPoint2D, SlvsLine2D), False
+        if isinstance(e1, LineRef):
+            # + line -> angle, + point -> point/line distance, none -> length.
+            return (SlvsLine2D, SlvsPoint2D), True
+        if isinstance(e1, (CircleRef, ArcRef)):
+            # + line/point -> distance, none -> diameter/radius.
+            return (SlvsLine2D, SlvsPoint2D), True
+        # Before the first pick: offer a generic optional second entity.
+        return (SlvsPoint2D, SlvsLine2D), True
+
+    @classmethod
+    def states(cls, operator=None):
+        first_types = (SlvsPoint2D, SlvsLine2D, SlvsCircle, SlvsArc)
+        states = [
+            state_from_args(
+                "Entity 1",
+                description="Pick geometry to dimension.",
+                pointer="entity1",
+                types=first_types,
+                use_create=False,
+            )
+        ]
+        second_types, optional = cls._second_slot(operator)
+        if second_types:
+            states.append(
+                state_from_args(
+                    "Entity 2",
+                    description="Optionally pick a second entity to dimension against.",
+                    pointer="entity2",
+                    types=second_types,
+                    use_create=False,
+                    optional=optional,
+                )
+            )
+        return states
+
+    def _available_entities(self):
+        return [getattr(self, "entity1", None), getattr(self, "entity2", None)]
+
+    def _add_line_length(self, context):
+        """Distance = a line's length: expand the line to its two endpoints and
+        constrain their distance (mirrors VIEW3D_OT_slvs_add_distance)."""
+        e1 = self.entity1
+        p1, p2 = e1.p1, e1.p2
+        if p1 and p2:
+            for i, pt in enumerate((p1, p2)):
+                state_data = self.get_state_data(i)
+                state_data["hovered"] = 0
+                state_data["type"] = PointRef
+                state_data["is_existing_entity"] = True
+                state_data["curve_id"] = pt.curve_id
+            self.next_state(context)
+        e1, e2 = self.entity1, self.entity2
+        if not self.exists(context, SlvsDistance, max_constraints=2):
+            self.target = self.sketch.constraints.add_distance(
+                init=not self.initialized,
+                curve_id_1=e1.curve_id if e1 else "",
+                curve_id_2=e2.curve_id if e2 else "",
+            )
+
+    def main(self, context):
+        e1, e2 = self.entity1, self.entity2
+        if e1 is None:
+            return False
+
+        constraints = self.sketch.constraints
+
+        if e2 is None:
+            if isinstance(e1, (CircleRef, ArcRef)):
+                if not self.exists(context, SlvsDiameter):
+                    self.target = constraints.add_diameter(
+                        init=not self.initialized, curve_id_1=e1.curve_id
+                    )
+            elif isinstance(e1, LineRef):
+                self._add_line_length(context)
+            else:
+                self.report({"WARNING"}, "Select a second entity to add a dimension")
+                return False
+        elif isinstance(e1, LineRef) and isinstance(e2, LineRef):
+            if not self.exists(context, SlvsAngle):
+                self.target = constraints.add_angle(
+                    init=not self.initialized,
+                    curve_id_1=e1.curve_id,
+                    curve_id_2=e2.curve_id,
+                )
+        else:
+            max_constraints = (
+                2 if isinstance(e1, PointRef) and isinstance(e2, PointRef) else 1
+            )
+            if not self.exists(context, SlvsDistance, max_constraints):
+                self.target = constraints.add_distance(
+                    init=not self.initialized,
+                    curve_id_1=e1.curve_id,
+                    curve_id_2=e2.curve_id,
+                )
+
+        return super().main(context)
+
+    def fini(self, context: Context, succeede: bool):
+        # Default label offset before the placement handoff (see add_distance).
+        if getattr(self, "target", None):
+            self.target.draw_offset = 0.1 * context.region_data.view_distance
+        super().fini(context, succeede)
+
+
+register, unregister = register_stateops_factory((VIEW3D_OT_slvs_add_dimension,))

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -204,6 +204,11 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
                     "Dimension -> angle between %s and %s", e1.curve_id, e2.curve_id
                 )
         else:
+            # Distance's natural form is point-to-line/point. The model collapses
+            # a *line* entity1 to its endpoints, so a line+point pair must be
+            # ordered point-first to measure the point-to-line distance.
+            if isinstance(e1, LineRef) and isinstance(e2, PointRef):
+                e1, e2 = e2, e1
             max_constraints = (
                 2 if isinstance(e1, PointRef) and isinstance(e2, PointRef) else 1
             )
@@ -238,14 +243,21 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
             target.update_draw_offset(pos, context.preferences.system.ui_scale)
             # Full refresh (show_gizmo + redraw) so the gizmo re-reads the offset.
             refresh(context)
-        # One line per placement session tells us whether this runs and whether
-        # the offset actually moves (drop the counter once the drag is confirmed).
-        if not getattr(self, "_placement_logged", False):
-            self._placement_logged = True
+        # Per-move diagnostic (throttled): confirms _place_dimension keeps being
+        # called as the cursor moves and that draw_offset actually changes, and
+        # whether the target's index stays stable (a churned index would leave
+        # the gizmo bound to a stale constraint).
+        self._place_calls = getattr(self, "_place_calls", 0) + 1
+        if self._place_calls % 4 == 1:
+            constraints = get_active_constraints(context)
             logger.debug(
-                "Placement active: pos=%s draw_offset=%s",
-                None if pos is None else tuple(round(v, 3) for v in pos),
-                round(getattr(target, "draw_offset", 0.0), 4),
+                "Placement #%d: draw_offset=%.3f outset=%.3f target=%s idx=%s n=%d",
+                self._place_calls,
+                getattr(target, "draw_offset", 0.0),
+                getattr(target, "draw_outset", 0.0),
+                target.type,
+                constraints.get_index(target) if constraints else -1,
+                len(list(constraints.all)) if constraints else -1,
             )
         return None
 
@@ -259,9 +271,7 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         if self.initialized and self._is_placement_state():
             return bool(getattr(self, "target", None))
 
-        # An entity pick changed the inference -- rebuild the constraint. Reset
-        # the once-per-session placement log so it re-arms after a type switch.
-        self._placement_logged = False
+        # An entity pick changed the inference -- rebuild the constraint.
         self._clear_target(context)
         self._create_constraint(context)
         return super().main(context)

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -125,6 +125,22 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
     def _is_placement_state(self) -> bool:
         return self.state.name == _PLACEMENT_STATE
 
+    def _apply_undo(self, context: Context):
+        """Keep label placement out of the state machine's per-move undo cycle.
+
+        Once the geometry is picked the constraint is stable and only its display
+        offset changes. The framework otherwise restores its snapshot on every
+        move here -- which deletes the constraint (main() is guarded, so nothing
+        recreates it) and resets the offset, leaving the gizmo nothing to track.
+        Suppressing it makes placement behave like the standalone tweak modal: a
+        single live constraint whose gizmo follows the cursor. Outside placement
+        the normal undo/redo still runs so each pick can re-infer the type.
+        """
+        if self._is_placement_state():
+            self._undo = False
+            return
+        super()._apply_undo(context)
+
     def _distance_exists(self, context: Context, cids) -> bool:
         """True if a distance constraint already spans exactly ``cids``."""
         want = set(cids)

--- a/operators/add_dimension.py
+++ b/operators/add_dimension.py
@@ -379,24 +379,58 @@ class VIEW3D_OT_slvs_add_dimension(Operator, GenericConstraintOp):
         self._create_constraint(context)
         return super().main(context)
 
-    def fini(self, context: Context, succeede: bool):
-        # Placement happens in this operator's own placement state, so there is no
-        # hand-off to the standalone tweak modal (unlike GenericConstraintOp).
-        target = getattr(self, "target", None)
+    def _should_reject(self, context: Context, target):
+        """Return ``(report_level, message)`` if the committed dimension must be
+        dropped, else ``None``.
 
-        # Duplicate check happens here, at commit: the tentative constraint may
-        # have changed type during placement, so only its final form matters.
-        if succeede and target is not None and self._is_duplicate(context, target):
-            logger.debug("Dimension: discarding duplicate %s", target)
+        On rejection the target is already removed and the sketch re-solved; on
+        keep, the target stays and the sketch is solved. Rejects an exact
+        duplicate, and a dimension that leaves the sketch unsolvable -- but the
+        latter only when removing it restores solvability, so an inconsistency
+        that pre-dates this dimension doesn't discard the user's work.
+        """
+        if self._is_duplicate(context, target):
             self._clear_target(context)
             if self.sketch and solve_system(context, sketch=self.sketch):
                 refresh_curve_geometry(self.sketch)
-            if hasattr(self, "report"):
-                self.report({"INFO"}, "Dimension already exists")
-            target = None
+            return "INFO", "Dimension already exists"
+
+        if self.sketch is None:
+            return None
+
+        if solve_system(context, sketch=self.sketch):
+            refresh_curve_geometry(self.sketch)
+            return None
+
+        # Unsolvable with the new dimension -- reject only if removing it helps.
+        self._clear_target(context)
+        if solve_system(context, sketch=self.sketch):
+            refresh_curve_geometry(self.sketch)
+            return "WARNING", "Dimension conflicts with the existing constraints"
+
+        # Pre-existing inconsistency: restore the user's dimension and keep it.
+        self._create_constraint(context)
+        if solve_system(context, sketch=self.sketch):
+            refresh_curve_geometry(self.sketch)
+        return None
+
+    def fini(self, context: Context, succeede: bool):
+        # Placement happens in this operator's own placement state, so there is no
+        # hand-off to the standalone tweak modal (unlike GenericConstraintOp).
+        #
+        # Both the duplicate and solvability checks happen here, at commit: the
+        # tentative constraint may change type and value during placement, so only
+        # its final form matters.
+        if succeede and getattr(self, "target", None) is not None:
+            reason = self._should_reject(context, self.target)
+            if reason is not None:
+                logger.debug("Dimension: rejected -- %s", reason[1])
+                if hasattr(self, "report"):
+                    self.report({reason[0]}, reason[1])
 
         # Make sure gizmos end up visible and the label reflects the final offset.
         refresh(context)
+        target = getattr(self, "target", None)
         if target is not None:
             logger.debug("Dimension committed: %s (succeeded=%s)", target, succeede)
 

--- a/stateful_operator/logic.py
+++ b/stateful_operator/logic.py
@@ -669,6 +669,14 @@ class StatefulOperatorLogic(_StateMachineMixin):
         context.area.tag_redraw()
 
         if triggered and not ok:
+            # An optional state whose overall requirements are already met can be
+            # skipped rather than cancelled: advance to the next state (e.g. the
+            # dimension tool leaving its optional "second entity" pick to fall
+            # through to label placement), or finish if it was the last one.
+            if state.optional and self.check_props():
+                if not self.next_state(context):
+                    return self._end(context, succeede)
+                return {"RUNNING_MODAL"}
             # Triggered on non-valid target — cancel to avoid confusion
             return self._end(context, False)
 
@@ -794,7 +802,9 @@ class StatefulOperatorLogic(_StateMachineMixin):
             if ptype is None:
                 continue
             data["type"] = ptype
-            data["is_existing_entity"] = bool(getattr(self, "ptr%d_existing" % i, False))
+            data["is_existing_entity"] = bool(
+                getattr(self, "ptr%d_existing" % i, False)
+            )
             vals = self._unpack_pointer_vals(
                 getattr(self, "ptr%d_name" % i, ""),
                 getattr(self, "ptr%d_index" % i, -1),

--- a/testing/test_dimension_op.py
+++ b/testing/test_dimension_op.py
@@ -73,6 +73,21 @@ class TestDimensionOp(Sketch2dTestCase):
         target = self._dispatch(line)
         self.assertEqual(set(target.curve_id_placements()), {p1.curve_id, p2.curve_id})
 
+    def test_parallel_second_line_uses_distance(self):
+        # Two parallel lines have no angle vertex -> the tool measures the
+        # perpendicular gap as a point-to-line distance, not an angle.
+        from ..model.curve_ref import curve_ref
+        from ..model.distance import SlvsDistance
+
+        l1 = self._line((0.0, 0.0), (4.0, 0.0))
+        l2 = self._line((0.0, 2.0), (4.0, 2.0))
+        self._select(l1)
+        h = self._harness()
+        h.prefill()
+        h.op._second_ref = curve_ref(self.sketch, l2.curve_id)
+        h.op._create_constraint(self.context)
+        self.assertIsInstance(h.op.target, SlvsDistance)
+
     def test_placement_value_entry_sets_value(self):
         # Typing a value during placement sets the constraint's value (routed
         # through the constraint's own subtype-aware ``value`` property).

--- a/testing/test_dimension_op.py
+++ b/testing/test_dimension_op.py
@@ -99,20 +99,29 @@ class TestDimensionOp(Sketch2dTestCase):
         # The curve must be entity1 for the native distance solver.
         self.assertEqual(target.curve_id_1, c.curve_id)
 
-    def test_curve_to_curve_is_center_distance(self):
-        # No edge-to-edge distance in the solver; two curves measure their
-        # center-to-center distance (hole spacing).
+    def test_curve_to_curve_is_edge_distance(self):
+        # Two curves measure edge-to-edge along the line of centres: centres are
+        # 6 apart with radii 2 and 1, so the gap is 3.
         from ..model.distance import SlvsDistance
 
-        ct1 = self.add_point((0.0, 0.0))
-        ct2 = self.add_point((6.0, 0.0))
-        c1 = self.add_circle(ct1, 2.0)
-        c2 = self.add_circle(ct2, 1.0)
+        c1 = self.add_circle(self.add_point((0.0, 0.0)), 2.0)
+        c2 = self.add_circle(self.add_point((6.0, 0.0)), 1.0)
         target = self._switch(c1, c2)
         self.assertIsInstance(target, SlvsDistance)
-        self.assertEqual(
-            set(target.curve_id_placements()), {c1.ct.curve_id, c2.ct.curve_id}
-        )
+        # The constraint references the curves themselves (so the solver adds
+        # both radii), not their centres.
+        self.assertEqual(set(target.curve_id_placements()), {c1.curve_id, c2.curve_id})
+        self.assertAlmostEqual(target.value, 3.0, places=3)
+
+    def test_curve_to_curve_edge_distance_solves(self):
+        # Enforcing an edge gap of 5 with radii 2 and 1 must place the centres 8
+        # apart (the solver constrains centre-to-centre = value + r1 + r2).
+        c1 = self.add_circle(self.add_point((0.0, 0.0), fixed=True), 2.0)
+        c2 = self.add_circle(self.add_point((6.0, 0.0)), 1.0)
+        target = self._switch(c1, c2)
+        target.value = 5.0
+        self.assertTrue(self.sketch.solve(self.context))
+        self.assertAlmostEqual((c2.ct.co - c1.ct.co).length, 8.0, places=2)
 
     def test_line_length_spans_endpoints(self):
         # The native solver needs two point ids, so a lone line is measured as

--- a/testing/test_dimension_op.py
+++ b/testing/test_dimension_op.py
@@ -1,0 +1,61 @@
+"""The unified Dimension tool infers the constraint type from the selection.
+
+Driven through the interaction harness (select entities, prefill, run main) so
+each selection combo is asserted to produce the right dimensional constraint.
+``run_fini=False`` skips the label-placement modal handoff (not headless-safe).
+"""
+
+from ..drawing import selection
+from .utils import OpHarness, Sketch2dTestCase
+
+
+class TestDimensionOp(Sketch2dTestCase):
+    def _harness(self):
+        from ..operators.add_dimension import VIEW3D_OT_slvs_add_dimension
+
+        return OpHarness(VIEW3D_OT_slvs_add_dimension, self.sketch, self.context)
+
+    def _line(self, p1, p2):
+        return self.add_line(self.add_point(p1), self.add_point(p2))
+
+    def _select(self, *refs):
+        selection.selected.clear()
+        for r in refs:
+            selection.selected.append(r.curve_id)
+
+    def _dispatch(self, *refs):
+        self._select(*refs)
+        h = self._harness()
+        h.prefill()
+        h.finish(run_fini=False)
+        return h.op.target
+
+    def test_single_line_infers_distance(self):
+        from ..model.distance import SlvsDistance
+
+        line = self._line((0.0, 0.0), (4.0, 0.0))
+        self.assertIsInstance(self._dispatch(line), SlvsDistance)
+
+    def test_two_lines_infer_angle(self):
+        from ..model.angle import SlvsAngle
+
+        l1 = self._line((0.0, 0.0), (4.0, 0.0))
+        l2 = self._line((0.0, 0.0), (3.0, 3.0))
+        self.assertIsInstance(self._dispatch(l1, l2), SlvsAngle)
+
+    def test_two_points_infer_distance(self):
+        from ..model.distance import SlvsDistance
+
+        p1 = self.add_point((0.0, 0.0))
+        p2 = self.add_point((3.0, 0.0))
+        self.assertIsInstance(self._dispatch(p1, p2), SlvsDistance)
+
+    def test_circle_infers_diameter(self):
+        from ..model.diameter import SlvsDiameter
+
+        c = self.add_circle(self.add_point((0.0, 0.0)), 2.0)
+        self.assertIsInstance(self._dispatch(c), SlvsDiameter)
+
+    def tearDown(self):
+        selection.selected.clear()
+        return super().tearDown()

--- a/testing/test_dimension_op.py
+++ b/testing/test_dimension_op.py
@@ -99,10 +99,20 @@ class TestDimensionOp(Sketch2dTestCase):
         # The curve must be entity1 for the native distance solver.
         self.assertEqual(target.curve_id_1, c.curve_id)
 
-    def test_curve_to_curve_unsupported(self):
-        c1 = self.add_circle(self.add_point((0.0, 0.0)), 2.0)
-        c2 = self.add_circle(self.add_point((6.0, 0.0)), 1.0)
-        self.assertIsNone(self._switch(c1, c2))
+    def test_curve_to_curve_is_center_distance(self):
+        # No edge-to-edge distance in the solver; two curves measure their
+        # center-to-center distance (hole spacing).
+        from ..model.distance import SlvsDistance
+
+        ct1 = self.add_point((0.0, 0.0))
+        ct2 = self.add_point((6.0, 0.0))
+        c1 = self.add_circle(ct1, 2.0)
+        c2 = self.add_circle(ct2, 1.0)
+        target = self._switch(c1, c2)
+        self.assertIsInstance(target, SlvsDistance)
+        self.assertEqual(
+            set(target.curve_id_placements()), {c1.ct.curve_id, c2.ct.curve_id}
+        )
 
     def test_line_length_spans_endpoints(self):
         # The native solver needs two point ids, so a lone line is measured as

--- a/testing/test_dimension_op.py
+++ b/testing/test_dimension_op.py
@@ -56,6 +56,23 @@ class TestDimensionOp(Sketch2dTestCase):
         c = self.add_circle(self.add_point((0.0, 0.0)), 2.0)
         self.assertIsInstance(self._dispatch(c), SlvsDiameter)
 
+    def test_line_length_spans_endpoints(self):
+        # The native solver needs two point ids, so a lone line is measured as
+        # the distance between its own endpoints.
+        p1 = self.add_point((0.0, 0.0))
+        p2 = self.add_point((4.0, 0.0))
+        line = self.add_line(p1, p2)
+        target = self._dispatch(line)
+        self.assertEqual(set(target.curve_id_placements()), {p1.curve_id, p2.curve_id})
+
+    def test_states_end_with_placement(self):
+        from ..operators.add_dimension import VIEW3D_OT_slvs_add_dimension
+
+        states = VIEW3D_OT_slvs_add_dimension.states()
+        self.assertEqual(states[-1].name, "Placement")
+        self.assertTrue(states[-1].optional)
+        self.assertIsNone(states[-1].property)
+
     def tearDown(self):
         selection.selected.clear()
         return super().tearDown()

--- a/testing/test_dimension_op.py
+++ b/testing/test_dimension_op.py
@@ -113,6 +113,23 @@ class TestDimensionOp(Sketch2dTestCase):
         self.assertEqual(set(target.curve_id_placements()), {c1.curve_id, c2.curve_id})
         self.assertAlmostEqual(target.value, 3.0, places=3)
 
+    def test_circle_line_keeps_side(self):
+        # A circle above a line must stay above it after solving (no jump across).
+        c = self.add_circle(self.add_point((0.0, 3.0)), 1.0)
+        line = self._line((-5.0, 0.0), (5.0, 0.0))
+        self._switch(c, line)
+        self.assertTrue(self.sketch.solve(self.context))
+        self.assertGreater(c.ct.co.y, 0.0)
+
+    def test_two_circles_prefill_distance(self):
+        # Pre-selecting two circles and pressing D must dimension the distance
+        # between them (not just diameter the first).
+        from ..model.distance import SlvsDistance
+
+        c1 = self.add_circle(self.add_point((0.0, 0.0)), 2.0)
+        c2 = self.add_circle(self.add_point((6.0, 0.0)), 1.0)
+        self.assertIsInstance(self._dispatch(c1, c2), SlvsDistance)
+
     def test_curve_to_curve_edge_distance_solves(self):
         # Enforcing an edge gap of 5 with radii 2 and 1 must place the centres 8
         # apart (the solver constrains centre-to-centre = value + r1 + r2).

--- a/testing/test_dimension_op.py
+++ b/testing/test_dimension_op.py
@@ -73,6 +73,20 @@ class TestDimensionOp(Sketch2dTestCase):
         target = self._dispatch(line)
         self.assertEqual(set(target.curve_id_placements()), {p1.curve_id, p2.curve_id})
 
+    def test_placement_value_entry_sets_value(self):
+        # Typing a value during placement sets the constraint's value (routed
+        # through the constraint's own subtype-aware ``value`` property).
+        line = self._line((0.0, 0.0), (4.0, 0.0))
+        self._select(line)
+        h = self._harness()
+        h.prefill()
+        h.finish(run_fini=False)
+        target = h.op.target
+        self.assertIsNotNone(target)
+        h.op._value_input().current = "10"
+        h.op._apply_value(self.context)
+        self.assertAlmostEqual(target.value, 10.0, places=3)
+
     def test_states_end_with_placement(self):
         from ..operators.add_dimension import VIEW3D_OT_slvs_add_dimension
 

--- a/testing/test_dimension_op.py
+++ b/testing/test_dimension_op.py
@@ -88,39 +88,53 @@ class TestDimensionOp(Sketch2dTestCase):
         h.op._create_constraint(self.context)
         self.assertIsInstance(h.op.target, SlvsDistance)
 
-    def test_no_duplicate_line_length(self):
+    def test_duplicate_discarded_at_fini(self):
+        # The tentative constraint is always created (so it previews and can still
+        # change type); a duplicate is only discarded at commit (fini).
         from ..model.distance import SlvsDistance
 
         line = self._line((0.0, 0.0), (4.0, 0.0))
         self.assertIsInstance(self._dispatch(line), SlvsDistance)
         n1 = len(list(self.sketch.constraints.all))
-        # A second run on the same line must not add another length.
+
         self._select(line)
         h = self._harness()
         h.prefill()
         h.finish(run_fini=False)
+        # Tentative duplicate exists before commit ...
+        self.assertIsInstance(h.op.target, SlvsDistance)
+        self.assertEqual(len(list(self.sketch.constraints.all)), n1 + 1)
+        # ... and is discarded at fini.
+        h.op.fini(self.context, True)
         self.assertIsNone(h.op.target)
         self.assertEqual(len(list(self.sketch.constraints.all)), n1)
 
-    def test_no_duplicate_angle_via_switch(self):
-        # The switch path stores the partner in _second_ref (not entity2), so
-        # dedup must compare curve ids explicitly -- this is the case the base
-        # ``exists`` missed.
+    def test_duplicate_angle_via_switch_discarded_at_fini(self):
+        # The switch path stores the partner in _second_ref (not entity2); dedup
+        # must compare curve ids explicitly -- the case the base ``exists`` missed.
         from ..model.angle import SlvsAngle
         from ..model.curve_ref import curve_ref
 
         l1 = self._line((0.0, 0.0), (4.0, 0.0))
         l2 = self._line((0.0, 0.0), (3.0, 3.0))
-        for expected_none in (False, True):
-            self._select(l1)
-            h = self._harness()
-            h.prefill()
-            h.op._second_ref = curve_ref(self.sketch, l2.curve_id)
-            h.op._create_constraint(self.context)
-            if expected_none:
-                self.assertIsNone(h.op.target)
-            else:
-                self.assertIsInstance(h.op.target, SlvsAngle)
+
+        self._select(l1)
+        h = self._harness()
+        h.prefill()
+        h.op._second_ref = curve_ref(self.sketch, l2.curve_id)
+        h.op._create_constraint(self.context)
+        self.assertIsInstance(h.op.target, SlvsAngle)
+        n1 = len(list(self.sketch.constraints.all))
+
+        self._select(l1)
+        h2 = self._harness()
+        h2.prefill()
+        h2.op._second_ref = curve_ref(self.sketch, l2.curve_id)
+        h2.op._create_constraint(self.context)
+        self.assertIsInstance(h2.op.target, SlvsAngle)  # tentative created
+        h2.op.fini(self.context, True)
+        self.assertIsNone(h2.op.target)  # discarded at commit
+        self.assertEqual(len(list(self.sketch.constraints.all)), n1)
 
     def test_placement_value_entry_sets_value(self):
         # Typing a value during placement sets the constraint's value (routed

--- a/testing/test_dimension_op.py
+++ b/testing/test_dimension_op.py
@@ -136,6 +136,27 @@ class TestDimensionOp(Sketch2dTestCase):
         self.assertIsNone(h2.op.target)  # discarded at commit
         self.assertEqual(len(list(self.sketch.constraints.all)), n1)
 
+    def test_conflicting_value_rejected_at_fini(self):
+        # Two fixed points are 3 apart; a length dimension typed to 5 can't solve,
+        # so it must be rejected (and removed) at commit.
+        p0 = self.add_point((0.0, 0.0), fixed=True)
+        p1 = self.add_point((3.0, 0.0), fixed=True)
+        n0 = len(list(self.sketch.constraints.all))
+
+        self._select(p0, p1)
+        h = self._harness()
+        h.prefill()
+        h.finish(run_fini=False)
+        self.assertIsNotNone(h.op.target)
+        self.assertEqual(len(list(self.sketch.constraints.all)), n0 + 1)
+
+        h.op._value_input().current = "5"
+        h.op._apply_value(self.context)  # forces distance 5 -> inconsistent
+
+        h.op.fini(self.context, True)
+        self.assertIsNone(h.op.target)
+        self.assertEqual(len(list(self.sketch.constraints.all)), n0)
+
     def test_placement_value_entry_sets_value(self):
         # Typing a value during placement sets the constraint's value (routed
         # through the constraint's own subtype-aware ``value`` property).

--- a/testing/test_dimension_op.py
+++ b/testing/test_dimension_op.py
@@ -64,6 +64,46 @@ class TestDimensionOp(Sketch2dTestCase):
         c = self.add_circle(self.add_point((0.0, 0.0)), 2.0)
         self.assertIsInstance(self._dispatch(c), SlvsDiameter)
 
+    def _switch(self, first, second):
+        """Pick ``first``, adopt ``second`` mid-placement, return the target."""
+        from ..model.curve_ref import curve_ref
+
+        self._select(first)
+        h = self._harness()
+        h.prefill()
+        h.op._second_ref = curve_ref(self.sketch, second.curve_id)
+        h.op._create_constraint(self.context)
+        return h.op.target
+
+    def test_circle_plus_point_is_distance(self):
+        from ..model.distance import SlvsDistance
+
+        c = self.add_circle(self.add_point((0.0, 0.0)), 2.0)
+        p = self.add_point((5.0, 0.0))
+        self.assertIsInstance(self._switch(c, p), SlvsDistance)
+
+    def test_circle_plus_line_is_distance(self):
+        from ..model.distance import SlvsDistance
+
+        c = self.add_circle(self.add_point((0.0, 0.0)), 2.0)
+        line = self._line((5.0, -3.0), (5.0, 3.0))
+        self.assertIsInstance(self._switch(c, line), SlvsDistance)
+
+    def test_line_plus_circle_orders_curve_first(self):
+        from ..model.distance import SlvsDistance
+
+        c = self.add_circle(self.add_point((6.0, 0.0)), 2.0)
+        line = self._line((0.0, 0.0), (0.0, 4.0))
+        target = self._switch(line, c)
+        self.assertIsInstance(target, SlvsDistance)
+        # The curve must be entity1 for the native distance solver.
+        self.assertEqual(target.curve_id_1, c.curve_id)
+
+    def test_curve_to_curve_unsupported(self):
+        c1 = self.add_circle(self.add_point((0.0, 0.0)), 2.0)
+        c2 = self.add_circle(self.add_point((6.0, 0.0)), 1.0)
+        self.assertIsNone(self._switch(c1, c2))
+
     def test_line_length_spans_endpoints(self):
         # The native solver needs two point ids, so a lone line is measured as
         # the distance between its own endpoints.

--- a/testing/test_dimension_op.py
+++ b/testing/test_dimension_op.py
@@ -36,12 +36,20 @@ class TestDimensionOp(Sketch2dTestCase):
         line = self._line((0.0, 0.0), (4.0, 0.0))
         self.assertIsInstance(self._dispatch(line), SlvsDistance)
 
-    def test_two_lines_infer_angle(self):
+    def test_line_second_line_switches_to_angle(self):
+        # A line drops into placement as a length; adopting a second line during
+        # placement (a click, simulated here via _second_ref) switches to angle.
         from ..model.angle import SlvsAngle
+        from ..model.curve_ref import curve_ref
 
         l1 = self._line((0.0, 0.0), (4.0, 0.0))
         l2 = self._line((0.0, 0.0), (3.0, 3.0))
-        self.assertIsInstance(self._dispatch(l1, l2), SlvsAngle)
+        self._select(l1)
+        h = self._harness()
+        h.prefill()
+        h.op._second_ref = curve_ref(self.sketch, l2.curve_id)
+        h.op._create_constraint(self.context)
+        self.assertIsInstance(h.op.target, SlvsAngle)
 
     def test_two_points_infer_distance(self):
         from ..model.distance import SlvsDistance

--- a/testing/test_dimension_op.py
+++ b/testing/test_dimension_op.py
@@ -88,6 +88,40 @@ class TestDimensionOp(Sketch2dTestCase):
         h.op._create_constraint(self.context)
         self.assertIsInstance(h.op.target, SlvsDistance)
 
+    def test_no_duplicate_line_length(self):
+        from ..model.distance import SlvsDistance
+
+        line = self._line((0.0, 0.0), (4.0, 0.0))
+        self.assertIsInstance(self._dispatch(line), SlvsDistance)
+        n1 = len(list(self.sketch.constraints.all))
+        # A second run on the same line must not add another length.
+        self._select(line)
+        h = self._harness()
+        h.prefill()
+        h.finish(run_fini=False)
+        self.assertIsNone(h.op.target)
+        self.assertEqual(len(list(self.sketch.constraints.all)), n1)
+
+    def test_no_duplicate_angle_via_switch(self):
+        # The switch path stores the partner in _second_ref (not entity2), so
+        # dedup must compare curve ids explicitly -- this is the case the base
+        # ``exists`` missed.
+        from ..model.angle import SlvsAngle
+        from ..model.curve_ref import curve_ref
+
+        l1 = self._line((0.0, 0.0), (4.0, 0.0))
+        l2 = self._line((0.0, 0.0), (3.0, 3.0))
+        for expected_none in (False, True):
+            self._select(l1)
+            h = self._harness()
+            h.prefill()
+            h.op._second_ref = curve_ref(self.sketch, l2.curve_id)
+            h.op._create_constraint(self.context)
+            if expected_none:
+                self.assertIsNone(h.op.target)
+            else:
+                self.assertIsInstance(h.op.target, SlvsAngle)
+
     def test_placement_value_entry_sets_value(self):
         # Typing a value during placement sets the constraint's value (routed
         # through the constraint's own subtype-aware ``value`` property).

--- a/workspacetools/__init__.py
+++ b/workspacetools/__init__.py
@@ -1,6 +1,7 @@
 from . import manager
 from .add_arc2d import VIEW3D_T_slvs_add_arc2d
 from .add_circle2d import VIEW3D_T_slvs_add_circle2d
+from .add_dimension import VIEW3D_T_slvs_add_dimension
 from .add_line2d import VIEW3D_T_slvs_add_line2d
 from .add_point2d import VIEW3D_T_slvs_add_point2d
 from .add_rectangle import VIEW3D_T_slvs_add_rectangle
@@ -21,19 +22,60 @@ add(VIEW3D_T_slvs_select, visibility=ToolGroup.SKETCH, separator=True, group=Fal
 # Sketch-only tools (visible when a sketch is active)
 add(VIEW3D_T_slvs_add_point2d, visibility=ToolGroup.SKETCH, separator=True, group=False)
 add(VIEW3D_T_slvs_add_line2d, visibility=ToolGroup.SKETCH, separator=False, group=False)
-add(VIEW3D_T_slvs_add_circle2d, visibility=ToolGroup.SKETCH, separator=False, group=False)
+add(
+    VIEW3D_T_slvs_add_circle2d,
+    visibility=ToolGroup.SKETCH,
+    separator=False,
+    group=False,
+)
 add(VIEW3D_T_slvs_add_arc2d, visibility=ToolGroup.SKETCH, separator=False, group=False)
-add(VIEW3D_T_slvs_add_rectangle, visibility=ToolGroup.SKETCH, separator=False, group=False)
+add(
+    VIEW3D_T_slvs_add_rectangle,
+    visibility=ToolGroup.SKETCH,
+    separator=False,
+    group=False,
+)
 add(VIEW3D_T_slvs_trim, visibility=ToolGroup.SKETCH, separator=True, group=False)
 add(VIEW3D_T_slvs_bevel, visibility=ToolGroup.SKETCH, separator=False, group=False)
 add(VIEW3D_T_slvs_offset, visibility=ToolGroup.SKETCH, separator=False, group=False)
-add(VIEW3D_T_slvs_project_geometry, visibility=ToolGroup.SKETCH, separator=True, group=False)
+add(
+    VIEW3D_T_slvs_project_geometry,
+    visibility=ToolGroup.SKETCH,
+    separator=True,
+    group=False,
+)
+add(
+    VIEW3D_T_slvs_add_dimension,
+    visibility=ToolGroup.SKETCH,
+    separator=True,
+    group=False,
+)
 
 # Non-sketch tools (visible when no sketch is active)
-add(VIEW3D_T_slvs_add_sketch, visibility=ToolGroup.NON_SKETCH, separator=True, group=False)
-add(VIEW3D_T_slvs_node_extrude, visibility=ToolGroup.NON_SKETCH, separator=True, group=False)
-add(VIEW3D_T_slvs_node_revolve, visibility=ToolGroup.NON_SKETCH, separator=False, group=False)
-add(VIEW3D_T_slvs_node_array_linear, visibility=ToolGroup.NON_SKETCH, separator=False, group=False)
+add(
+    VIEW3D_T_slvs_add_sketch,
+    visibility=ToolGroup.NON_SKETCH,
+    separator=True,
+    group=False,
+)
+add(
+    VIEW3D_T_slvs_node_extrude,
+    visibility=ToolGroup.NON_SKETCH,
+    separator=True,
+    group=False,
+)
+add(
+    VIEW3D_T_slvs_node_revolve,
+    visibility=ToolGroup.NON_SKETCH,
+    separator=False,
+    group=False,
+)
+add(
+    VIEW3D_T_slvs_node_array_linear,
+    visibility=ToolGroup.NON_SKETCH,
+    separator=False,
+    group=False,
+)
 
 
 def register():

--- a/workspacetools/add_dimension.py
+++ b/workspacetools/add_dimension.py
@@ -1,0 +1,20 @@
+from bpy.types import WorkSpaceTool
+
+from ..declarations import GizmoGroups, Operators, WorkSpaceTools
+from ..keymaps import tool_generic
+from ..stateful_operator.tool import GenericStateTool
+from ..stateful_operator.utilities.keymap import operator_access
+
+
+class VIEW3D_T_slvs_add_dimension(GenericStateTool, WorkSpaceTool):
+    bl_space_type = "VIEW_3D"
+    bl_context_mode = "OBJECT"
+    bl_idname = WorkSpaceTools.AddDimension
+    bl_label = "Dimension"
+    bl_operator = Operators.AddDimension
+    bl_icon = "ops.view3d.ruler"
+    bl_widget = GizmoGroups.Preselection
+    bl_keymap = (
+        *tool_generic,
+        *operator_access(Operators.AddDimension),
+    )


### PR DESCRIPTION
## Unified Dimension tool

Adds a single **Dimension** tool (shortcut **D**) that infers the dimensional
constraint from the selection, so you don't pick between Distance / Angle /
Diameter up front. Pick geometry, drag the label into place, click to confirm —
or type a value while placing.

### Inferred combinations

| Selection | Constraint |
|---|---|
| line | distance (length) |
| circle / arc | diameter |
| line + line (non-parallel) | angle |
| line + line (parallel) | perpendicular distance |
| point + point | distance |
| point + line | point-to-line distance |
| circle/arc + point | edge-to-point distance |
| circle/arc + line | edge-to-line distance |
| circle/arc + circle/arc | edge-to-edge distance (along the line of centres) |

### Interaction

- A **line / circle / arc** drops straight into placement after one pick and the
  label drags immediately.
- While placing, **click a second entity to switch** the inferred type and keep
  dragging (line + second line → angle, line + point → distance, etc.).
- A **point** needs a partner, so it takes a required second pick first.
- **Type a value** during placement to set the dimension (routed through the
  constraint's own `value`, so distance/angle/diameter units all parse).
- Pre-selecting a compatible pair and pressing **D** prefills.

### Validation at commit

The tentative constraint is always created so it previews and can still change
type; the checks run in `fini`:

- **Duplicate** — discarded (an existing identical dimension is kept).
- **Over-constrains / conflicts** — if the sketch can't solve *and* removing the
  new dimension restores solvability, it's rejected (a pre-existing inconsistency
  is left alone, so a valid dimension is never eaten).

### Supporting changes

- **`SlvsDistance` gains edge-to-edge circle/arc distance** (solver, measured
  value, label transform, and gizmo help-lines) — a genuinely useful dimension
  that the model couldn't express before. Curve+curve constrains
  `centre-to-centre = value + r1 + r2`.
- **Constraint gizmos drop out of hover/picking while a stateful operator runs**
  (`draw_select` / `test_select` gated on `stateful_op_running`), so the label
  that follows the cursor can't steal a click meant for the geometry underneath.
- **stateful_operator**: an optional state can now be skipped/confirmed by a
  click when its requirements are already met (used by the placement state).

### Testing

`testing/test_dimension_op.py` covers the dispatch for every combination, the
type-switch path, value entry, duplicate/conflict rejection, and the edge-to-edge
solve end-to-end. The interactive drag/placement is GUI-verified.
