### PR TITLE
Fix orthogonal sketch planes collapsing onto XY (#670)

### DIFF
--- a/testing/test_origin_workplanes.py
+++ b/testing/test_origin_workplanes.py
@@ -1,16 +1,20 @@
-"""Origin workplane self-heal (#571): flattened/hidden/missing planes."""
+"""Origin workplane self-heal (#571) and eval-preserving hide (#670)."""
+
+import os
+import tempfile
+import unittest
 
 import bpy
 from mathutils import Matrix
 
-from .utils import Sketch2dTestCase
 from ..utilities.workplane import (
-    ensure_origin_workplane_empties,
-    repair_origin_workplanes,
-    iter_wp_empties,
-    _target_matrix,
     _ORIGIN_WP_CONFIGS,
+    _target_matrix,
+    ensure_origin_workplane_empties,
+    iter_wp_empties,
+    repair_origin_workplanes,
 )
+from .utils import Sketch2dTestCase
 
 
 class TestOriginWorkplanes(Sketch2dTestCase):
@@ -32,16 +36,33 @@ class TestOriginWorkplanes(Sketch2dTestCase):
             target = _target_matrix(euler)
             for j in range(3):
                 self.assertAlmostEqual(
-                    emp.matrix_world.col[2][j], target.col[2][j], places=5,
+                    emp.matrix_world.col[2][j],
+                    target.col[2][j],
+                    places=5,
                     msg=f"{prop} normal not restored",
                 )
 
-    def test_repair_rehides_origin_empty(self):
+    def test_planes_hidden_without_dropping_from_eval(self):
+        """Origin empties must be hidden (#571) but stay in the depsgraph so their
+        matrix_world tracks their rotation across reload/drivers (#670) -- i.e.
+        eye-hidden, never hide_viewport (which excludes them from evaluation)."""
         ensure_origin_workplane_empties(self.context)
         sk = self._sk()
-        sk.wp_xy.hide_viewport = False
+        for prop, _name, _euler, _id in _ORIGIN_WP_CONFIGS:
+            emp = getattr(sk, prop)
+            self.assertFalse(emp.hide_viewport, f"{prop} must not use hide_viewport")
+            self.assertTrue(emp.hide_get(), f"{prop} should be eye-hidden")
+            self.assertTrue(emp.hide_select, f"{prop} should be unselectable")
+
+    def test_repair_rehides_origin_empty(self):
+        """A drifted (unhidden) origin empty is re-hidden without hide_viewport."""
+        ensure_origin_workplane_empties(self.context)
+        sk = self._sk()
+        sk.wp_xy.hide_set(False)
+        sk.wp_xy.hide_viewport = True  # legacy state repair must also clear
         repair_origin_workplanes(self.context)
-        self.assertTrue(sk.wp_xy.hide_viewport)
+        self.assertTrue(sk.wp_xy.hide_get())
+        self.assertFalse(sk.wp_xy.hide_viewport)
 
     def test_ensure_recreates_missing_plane(self):
         ensure_origin_workplane_empties(self.context)
@@ -52,3 +73,37 @@ class TestOriginWorkplanes(Sketch2dTestCase):
         ensure_origin_workplane_empties(self.context)
         self.assertTrue(sk.wp_yz)
         self.assertEqual(len(list(iter_wp_empties(self.context))), 3)
+
+
+class TestOriginWorkplaneReload(unittest.TestCase):
+    """Regression for #670: orthogonal planes collapsed onto XY after reload.
+
+    A hide_viewport'd empty is dropped from depsgraph evaluation, so after a
+    file load its matrix_world is never recomputed from its rotation and reads
+    identity (normal +Z) -- collapsing XZ/YZ onto XY. Saving and reopening must
+    leave every origin plane's world normal intact.
+    """
+
+    def tearDown(self):
+        # Don't leak the reloaded scene into later test modules in this process.
+        bpy.ops.wm.read_homefile(use_empty=True)
+
+    def test_normals_survive_save_reload(self):
+        ensure_origin_workplane_empties(bpy.context)
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "origin_reload.blend")
+            bpy.ops.wm.save_as_mainfile(filepath=path)
+            bpy.ops.wm.open_mainfile(filepath=path)
+
+            sk = bpy.context.scene.sketcher
+            for prop, _name, euler, _id in _ORIGIN_WP_CONFIGS:
+                emp = getattr(sk, prop)
+                self.assertTrue(emp, f"{prop} missing after reload")
+                target = _target_matrix(euler)
+                for j in range(3):
+                    self.assertAlmostEqual(
+                        emp.matrix_world.col[2][j],
+                        target.col[2][j],
+                        places=5,
+                        msg=f"{prop} collapsed after reload (#670)",
+                    )

--- a/utilities/workplane.py
+++ b/utilities/workplane.py
@@ -209,6 +209,32 @@ def resolve_sketch_base(context, coords):
 # ---------------------------------------------------------------------------
 
 
+def _hide_managed_empty(empty, scene):
+    """Hide an addon-managed workplane empty without dropping it from eval.
+
+    ``hide_viewport`` (the monitor icon) excludes the object from depsgraph
+    evaluation, so its ``matrix_world`` is never recomputed from its
+    rotation/parent after a file load or when driven/animated. That left every
+    orthogonal plane's ``matrix_world`` stale at identity, collapsing them onto
+    XY (#670). The eye-icon hide keeps the object evaluated, so use that (in
+    every view layer) plus ``hide_select`` so it can't be clicked, and clear any
+    legacy ``hide_viewport`` so old files re-evaluate. The empty must already be
+    linked to the view layer.
+    """
+    empty.hide_viewport = False
+    empty.hide_select = True
+    for view_layer in scene.view_layers:
+        empty.hide_set(True, view_layer=view_layer)
+
+
+def _managed_empty_needs_hide(empty, scene):
+    """Whether ``empty`` has drifted from the hidden state ``_hide_managed_empty``
+    enforces (undo/redo or a new view layer can unhide it)."""
+    if empty.hide_viewport or not empty.hide_select:
+        return True
+    return any(not empty.hide_get(view_layer=vl) for vl in scene.view_layers)
+
+
 def ensure_workplane_empty(sketch):
     """Ensure the sketch has a workplane empty object.
 
@@ -226,7 +252,6 @@ def ensure_workplane_empty(sketch):
     name = f"WP_{sketch.name}"
     empty = bpy.data.objects.new(name, None)
     empty.empty_display_type = "SINGLE_ARROW"
-    empty.hide_viewport = True
     empty.lock_location = (True, True, True)
     empty.lock_rotation = (True, True, True)
     empty.lock_scale = (True, True, True)
@@ -235,6 +260,9 @@ def ensure_workplane_empty(sketch):
     scene = bpy.context.scene
     if empty.name not in scene.collection.objects:
         scene.collection.objects.link(empty)
+
+    # Hide only after linking: hide_set needs the object in the view layer.
+    _hide_managed_empty(empty, scene)
 
     sketch.workplane_object = empty
     return empty
@@ -258,7 +286,7 @@ def _target_matrix(euler_tuple):
     return Euler(euler_tuple).to_matrix().to_4x4()
 
 
-def _enforce_origin_empty(empty, euler_tuple):
+def _enforce_origin_empty(empty, euler_tuple, scene):
     """Re-assert an origin empty's fixed transform and hidden state.
 
     Undo/redo can leave these at identity (all three then stack flat -> the
@@ -269,18 +297,19 @@ def _enforce_origin_empty(empty, euler_tuple):
     target = _target_matrix(euler_tuple)
     if _matrix_differs(empty.matrix_world, target):
         empty.matrix_world = target
-    if not empty.hide_viewport:
-        empty.hide_viewport = True
+    if _managed_empty_needs_hide(empty, scene):
+        _hide_managed_empty(empty, scene)
 
 
 def repair_origin_workplanes(context):
     """Fix the transform/visibility of existing origin empties (no creation)."""
     sketcher = context.scene.sketcher
+    scene = context.scene
     for prop_name, _name, euler_tuple, wp_id in _ORIGIN_WP_CONFIGS:
         existing = getattr(sketcher, prop_name)
         if existing:
             WP_ID_MAP[wp_id] = existing
-            _enforce_origin_empty(existing, euler_tuple)
+            _enforce_origin_empty(existing, euler_tuple, scene)
 
 
 def ensure_origin_workplane_empties(context):
@@ -293,19 +322,21 @@ def ensure_origin_workplane_empties(context):
         existing = getattr(sketcher, prop_name)
         if existing:
             WP_ID_MAP[wp_id] = existing
-            _enforce_origin_empty(existing, euler_tuple)
+            _enforce_origin_empty(existing, euler_tuple, scene)
             continue
 
         empty = bpy.data.objects.new(name, None)
         empty.empty_display_type = "SINGLE_ARROW"
         empty.matrix_world = _target_matrix(euler_tuple)
-        empty.hide_viewport = True
         empty.lock_location = (True, True, True)
         empty.lock_rotation = (True, True, True)
         empty.lock_scale = (True, True, True)
 
         if empty.name not in scene.collection.objects:
             scene.collection.objects.link(empty)
+
+        # Hide only after linking: hide_set needs the object in the view layer.
+        _hide_managed_empty(empty, scene)
 
         setattr(sketcher, prop_name, empty)
         WP_ID_MAP[wp_id] = empty


### PR DESCRIPTION
## Problem

After making a sketch on XY, orthogonal sketch planes render collapsed flat
onto XY (their labels stack in one corner), as in #670. Reproducible by
creating origin-plane sketches, saving, and reopening the file.

## Root cause

The origin/sketch workplane empties are hidden with `hide_viewport = True` (the
monitor icon). That flag also **removes the object from depsgraph evaluation**,
so its `matrix_world` is never recomputed from `rotation_euler`/parent after a
file load (or when driven/animated). The stale matrix reads identity, so every
non-XY plane draws with a +Z normal and collapses onto XY.

Minimal confirmation (animate an empty's rotation, jump to the frame):

| Hide method | `matrix_world` |
|---|---|
| `hide_viewport = True` | **stale** |
| `hide_set(True)` (eye) | live |
| `empty_display_size = 0` | live |
| `hide_select = True` | live |

`matrix_basis` alone can't fix it (wrong for parented/driven empties), and a
load-time repair can't fix a driven empty that updates every frame.

## Fix

Hide the addon-managed workplane empties with `hide_set(True)` (in every view
layer) + `hide_select = True` instead, and clear any legacy `hide_viewport` so
old files re-evaluate. They stay in the depsgraph, so `matrix_world` tracks
reload, drivers, animation, and parenting. The #571 undo self-heal is preserved
(it now re-asserts the eye-hide). Old files self-heal on open via the existing
`repair_origin_workplanes` depsgraph pass.

## Tests

- New regression `test_normals_survive_save_reload` (save + reopen keeps every
  origin plane's world normal) — fails on the old code.
- Updated the hide-state assertions to the eval-preserving hide.
- Full suite: 403 passed (2 pre-existing expected failures).
