### PR TITLE
Tree-wide pyflakes sweep + release CI gate

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,8 +24,24 @@ permissions:
   contents: write
 
 jobs:
+  # Gate every build on a whole-tree pyflakes check. Unlike the PR lint
+  # (.github/workflows/lint.yml), which is scoped to a PR's changed files, this
+  # runs `ruff check --select F` over the ENTIRE codebase so a latent
+  # undefined-name / unused-import in an untouched file (the kind that reached
+  # the extensions.blender.org reviewer in 0.31.0-rc.1) can't ship. F rules
+  # only: import ordering and formatting stay diff-scoped in the PR lint.
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ruff
+        run: pipx install ruff
+      - name: Ruff pyflakes check (whole tree)
+        run: ruff check --select F --output-format=github .
+
   # === Stable channel: version tag -> GitHub Release ===
   release:
+    needs: lint
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
@@ -244,6 +260,7 @@ jobs:
 
   # === Latest channel: every main commit -> rolling build ===
   latest:
+    needs: lint
     if: >-
       github.ref == 'refs/heads/main' ||
       (github.event_name == 'workflow_dispatch' && inputs.run_latest)

--- a/base/theme.py
+++ b/base/theme.py
@@ -1,5 +1,5 @@
 import bpy
-from bpy.props import PointerProperty, FloatVectorProperty, FloatProperty
+from bpy.props import PointerProperty, FloatVectorProperty
 from bpy.types import PropertyGroup
 
 

--- a/base/theme.py
+++ b/base/theme.py
@@ -1,5 +1,5 @@
 import bpy
-from bpy.props import PointerProperty, FloatVectorProperty
+from bpy.props import FloatVectorProperty, PointerProperty
 from bpy.types import PropertyGroup
 
 

--- a/model/angle.py
+++ b/model/angle.py
@@ -2,7 +2,7 @@ import logging
 
 import math
 from bpy.types import PropertyGroup, Context
-from bpy.props import BoolProperty, FloatProperty, IntProperty, StringProperty
+from bpy.props import BoolProperty, FloatProperty, StringProperty
 from bpy.utils import register_classes_factory
 from mathutils import Vector, Matrix
 

--- a/model/angle.py
+++ b/model/angle.py
@@ -1,23 +1,21 @@
 import logging
-
 import math
-from bpy.types import PropertyGroup, Context
-from bpy.props import BoolProperty, FloatProperty, StringProperty
-from bpy.utils import register_classes_factory
-from mathutils import Vector, Matrix
 
-from ..utilities.math import pol2cart
-from ..utilities.constants import HALF_TURN, QUARTER_TURN
-from ..utilities.math import range_2pi
+from bpy.props import BoolProperty, FloatProperty, StringProperty
+from bpy.types import Context, PropertyGroup
+from bpy.utils import register_classes_factory
+from mathutils import Matrix, Vector
+
 from ..curve_solver import Solver
 from ..global_data import WpReq
+from ..utilities.constants import HALF_TURN, QUARTER_TURN
+from ..utilities.geometry import get_line_intersection, line_abc_form
+from ..utilities.math import pol2cart, range_2pi
+from ..utilities.solver import update_system_cb
 from ..utilities.view import location_3d_to_region_2d
 from .base_constraint import DimensionalConstraint
 from .line_2d import SlvsLine2D
 from .utilities import slvs_entity_pointer
-from ..utilities.geometry import line_abc_form, get_line_intersection
-from ..utilities.solver import update_system_cb
-
 
 logger = logging.getLogger(__name__)
 

--- a/model/arc.py
+++ b/model/arc.py
@@ -25,7 +25,6 @@ from .utilities import (
     create_bezier_curve,
     round_v,
 )
-from ..utilities.math import range_2pi, pol2cart
 
 logger = logging.getLogger(__name__)
 
@@ -233,7 +232,7 @@ class SlvsArc(Entity2D, PropertyGroup):
         # Get midpoint positions
         segment_count = len(midpoints) + 1
         curve_angle = self.angle
-        radius, center, start = self.radius, self.ct.co, self.start.co
+        radius, center = self.radius, self.ct.co
 
         midpoint_positions = get_bezier_curve_midpoint_positions(
             self, segment_count, midpoints, curve_angle
@@ -279,8 +278,6 @@ class SlvsArc(Entity2D, PropertyGroup):
         p = coords - ct
         p1 = self.start.co - ct
         p2 = self.end.co - ct
-
-        x_axis = Vector((1, 0))
 
         # angle_signed interprets clockwise as positive, so invert..
         a1 = range_2pi(p.angle_signed(p1))

--- a/model/arc.py
+++ b/model/arc.py
@@ -1,29 +1,28 @@
 import logging
+import math
 from typing import List
-from .sketch_ref import get_active_sketch
 
 import bpy
-from bpy.types import PropertyGroup, Context
 from bpy.props import BoolProperty
-from gpu_extras.batch import batch_for_shader
-import math
-from mathutils import Vector, Matrix
-from mathutils.geometry import intersect_line_sphere_2d, intersect_sphere_sphere_2d
+from bpy.types import Context, PropertyGroup
 from bpy.utils import register_classes_factory
+from gpu_extras.batch import batch_for_shader
+from mathutils import Matrix, Vector
+from mathutils.geometry import intersect_line_sphere_2d, intersect_sphere_sphere_2d
 
 from ..curve_solver import Solver
-from .base_entity import SlvsGenericEntity, tag_update
-from .base_entity import Entity2D
-from .utilities import slvs_entity_pointer
-from .constants import CURVE_RESOLUTION
-from ..utilities.constants import HALF_TURN, FULL_TURN, QUARTER_TURN
-from ..utilities.math import range_2pi, pol2cart
+from ..utilities.constants import FULL_TURN, HALF_TURN, QUARTER_TURN
 from ..utilities.draw import coords_arc_2d
+from ..utilities.math import pol2cart, range_2pi
+from .base_entity import Entity2D, SlvsGenericEntity, tag_update
+from .constants import CURVE_RESOLUTION
+from .sketch_ref import get_active_sketch
 from .utilities import (
-    get_connection_point,
-    get_bezier_curve_midpoint_positions,
     create_bezier_curve,
+    get_bezier_curve_midpoint_positions,
+    get_connection_point,
     round_v,
+    slvs_entity_pointer,
 )
 
 logger = logging.getLogger(__name__)

--- a/model/base_constraint.py
+++ b/model/base_constraint.py
@@ -2,16 +2,16 @@ import logging
 from typing import List
 
 import bpy
-from bpy.props import StringProperty, BoolProperty
-from bpy.types import UILayout, Property, Context
+from bpy.props import BoolProperty, StringProperty
+from bpy.types import Context, Property, UILayout
 
 from ..global_data import WpReq
 from ..utilities import preferences
-from .constants import ENTITY_PROP_NAMES
-from .base_entity import SlvsGenericEntity
-from ..utilities.view import update_cb, refresh
-from ..utilities.solver import update_system_cb
 from ..utilities.bpy import setprop
+from ..utilities.solver import update_system_cb
+from ..utilities.view import refresh, update_cb
+from .base_entity import SlvsGenericEntity
+from .constants import ENTITY_PROP_NAMES
 
 logger = logging.getLogger(__name__)
 

--- a/model/base_constraint.py
+++ b/model/base_constraint.py
@@ -7,7 +7,6 @@ from bpy.types import UILayout, Property, Context
 
 from ..global_data import WpReq
 from ..utilities import preferences
-from ..declarations import Operators
 from .constants import ENTITY_PROP_NAMES
 from .base_entity import SlvsGenericEntity
 from ..utilities.view import update_cb, refresh

--- a/model/circle.py
+++ b/model/circle.py
@@ -84,12 +84,6 @@ class SlvsCircle(Entity2D, PropertyGroup):
     def create_slvs_data(self, solvesys, group=Solver.group_fixed):
         self.param_distance = solvesys.add_distance(group, self.radius, self.wp.py_data)
 
-        nm = None
-        if self.nm != -1:
-            nm = self.nm
-        else:
-            nm = self.wp.nm
-
         handle = solvesys.add_circle(
             group,
             self.wp.nm.py_data,

--- a/model/circle.py
+++ b/model/circle.py
@@ -1,27 +1,26 @@
 import logging
 import math
 from typing import List
-from .sketch_ref import get_active_sketch
 
 import bpy
-from bpy.types import PropertyGroup
 from bpy.props import FloatProperty
-from gpu_extras.batch import batch_for_shader
-from mathutils import Vector, Matrix
-from mathutils.geometry import intersect_line_sphere_2d, intersect_sphere_sphere_2d
+from bpy.types import PropertyGroup
 from bpy.utils import register_classes_factory
+from gpu_extras.batch import batch_for_shader
+from mathutils import Matrix, Vector
+from mathutils.geometry import intersect_line_sphere_2d, intersect_sphere_sphere_2d
 
 from ..curve_solver import Solver
-from ..utilities.math import range_2pi, pol2cart
-from .base_entity import SlvsGenericEntity, tag_update
-from .base_entity import Entity2D
-from .utilities import slvs_entity_pointer
-from .constants import CURVE_RESOLUTION
-from ..utilities.constants import HALF_TURN, FULL_TURN
+from ..utilities.constants import FULL_TURN, HALF_TURN
 from ..utilities.draw import coords_arc_2d
+from ..utilities.math import pol2cart, range_2pi
+from .base_entity import Entity2D, SlvsGenericEntity, tag_update
+from .constants import CURVE_RESOLUTION
+from .sketch_ref import get_active_sketch
 from .utilities import (
-    get_bezier_curve_midpoint_positions,
     create_bezier_curve,
+    get_bezier_curve_midpoint_positions,
+    slvs_entity_pointer,
 )
 
 logger = logging.getLogger(__name__)

--- a/model/diameter.py
+++ b/model/diameter.py
@@ -1,20 +1,19 @@
 import logging
-
 import math
-from bpy.types import PropertyGroup
+
 from bpy.props import BoolProperty, FloatProperty, StringProperty
+from bpy.types import PropertyGroup
 from bpy.utils import register_classes_factory
-from mathutils import Vector, Matrix
+from mathutils import Matrix, Vector
 
 from ..curve_solver import Solver
 from ..global_data import WpReq
-from ..utilities.view import location_3d_to_region_2d
 from ..utilities.math import pol2cart
-from .base_constraint import DimensionalConstraint
-from .utilities import slvs_entity_pointer
-from .categories import CURVE
 from ..utilities.solver import update_system_cb
-
+from ..utilities.view import location_3d_to_region_2d
+from .base_constraint import DimensionalConstraint
+from .categories import CURVE
+from .utilities import slvs_entity_pointer
 
 logger = logging.getLogger(__name__)
 

--- a/model/diameter.py
+++ b/model/diameter.py
@@ -2,14 +2,14 @@ import logging
 
 import math
 from bpy.types import PropertyGroup
-from bpy.props import BoolProperty, FloatProperty, IntProperty, StringProperty
+from bpy.props import BoolProperty, FloatProperty, StringProperty
 from bpy.utils import register_classes_factory
 from mathutils import Vector, Matrix
 
 from ..curve_solver import Solver
 from ..global_data import WpReq
 from ..utilities.view import location_3d_to_region_2d
-from ..utilities.math import range_2pi, pol2cart
+from ..utilities.math import pol2cart
 from .base_constraint import DimensionalConstraint
 from .utilities import slvs_entity_pointer
 from .categories import CURVE

--- a/model/equal.py
+++ b/model/equal.py
@@ -10,7 +10,6 @@ from .utilities import slvs_entity_pointer
 from .categories import LINE, CURVE
 from .line_2d import SlvsLine2D
 from .arc import SlvsArc
-from .circle import SlvsCircle
 
 logger = logging.getLogger(__name__)
 

--- a/model/equal.py
+++ b/model/equal.py
@@ -1,15 +1,15 @@
 import logging
 
-from bpy.types import PropertyGroup
 from bpy.props import StringProperty
+from bpy.types import PropertyGroup
 from bpy.utils import register_classes_factory
 
 from ..curve_solver import Solver
-from .base_constraint import GenericConstraint
-from .utilities import slvs_entity_pointer
-from .categories import LINE, CURVE
-from .line_2d import SlvsLine2D
 from .arc import SlvsArc
+from .base_constraint import GenericConstraint
+from .categories import CURVE, LINE
+from .line_2d import SlvsLine2D
+from .utilities import slvs_entity_pointer
 
 logger = logging.getLogger(__name__)
 

--- a/model/group_constraints.py
+++ b/model/group_constraints.py
@@ -1,13 +1,10 @@
 import logging
 import secrets
-from typing import Union
 
 from bpy.types import PropertyGroup
 from bpy.props import CollectionProperty
 from bpy.utils import register_classes_factory
 
-from .base_entity import SlvsGenericEntity
-from .sketch import SlvsSketch
 
 from .base_constraint import GenericConstraint
 from .distance import SlvsDistance

--- a/model/group_constraints.py
+++ b/model/group_constraints.py
@@ -1,25 +1,24 @@
 import logging
 import secrets
 
-from bpy.types import PropertyGroup
 from bpy.props import CollectionProperty
+from bpy.types import PropertyGroup
 from bpy.utils import register_classes_factory
 
-
-from .base_constraint import GenericConstraint
-from .distance import SlvsDistance
 from .angle import SlvsAngle
-from .diameter import SlvsDiameter
+from .base_constraint import GenericConstraint
 from .coincident import SlvsCoincident
+from .diameter import SlvsDiameter
+from .distance import SlvsDistance
 from .equal import SlvsEqual
-from .vertical import SlvsVertical
 from .horizontal import SlvsHorizontal
+from .midpoint import SlvsMidpoint
 from .parallel import SlvsParallel
 from .perpendicular import SlvsPerpendicular
-from .tangent import SlvsTangent
-from .midpoint import SlvsMidpoint
 from .ratio import SlvsRatio
 from .symmetry import SlvsSymmetry
+from .tangent import SlvsTangent
+from .vertical import SlvsVertical
 
 logger = logging.getLogger(__name__)
 

--- a/model/group_entities.py
+++ b/model/group_entities.py
@@ -450,7 +450,6 @@ class SlvsEntities(PropertyGroup):
     @property
     def selected_all(self):
         """Return all selected entities, might include invisible entities"""
-        context = bpy.context
         items = []
         for index in selection.selected:
             if index is None:

--- a/model/group_entities.py
+++ b/model/group_entities.py
@@ -1,7 +1,6 @@
 import logging
 import math
 from typing import Tuple, Type, Union
-from .sketch_ref import get_active_sketch
 
 import bpy
 from bpy.props import CollectionProperty
@@ -22,6 +21,7 @@ from .normal_3d import SlvsNormal3D
 from .point_2d import SlvsPoint2D
 from .point_3d import SlvsPoint3D
 from .sketch import SlvsSketch
+from .sketch_ref import get_active_sketch
 from .utilities import slvs_entity_pointer, update_pointers
 from .workplane import SlvsWorkplane
 

--- a/model/normal_2d.py
+++ b/model/normal_2d.py
@@ -4,7 +4,6 @@ from bpy.types import PropertyGroup
 from bpy.utils import register_classes_factory
 
 from ..curve_solver import Solver
-from .base_entity import SlvsGenericEntity
 from .utilities import slvs_entity_pointer
 from .base_entity import Entity2D
 

--- a/model/normal_2d.py
+++ b/model/normal_2d.py
@@ -4,9 +4,8 @@ from bpy.types import PropertyGroup
 from bpy.utils import register_classes_factory
 
 from ..curve_solver import Solver
-from .utilities import slvs_entity_pointer
 from .base_entity import Entity2D
-
+from .utilities import slvs_entity_pointer
 
 logger = logging.getLogger(__name__)
 

--- a/model/perpendicular.py
+++ b/model/perpendicular.py
@@ -1,14 +1,14 @@
 import logging
 
-from bpy.types import PropertyGroup
 from bpy.props import StringProperty
+from bpy.types import PropertyGroup
 from bpy.utils import register_classes_factory
 
 from ..curve_solver import Solver
 from ..global_data import WpReq
 from .base_constraint import GenericConstraint
-from .utilities import slvs_entity_pointer
 from .line_2d import SlvsLine2D
+from .utilities import slvs_entity_pointer
 
 logger = logging.getLogger(__name__)
 

--- a/model/perpendicular.py
+++ b/model/perpendicular.py
@@ -9,7 +9,6 @@ from ..global_data import WpReq
 from .base_constraint import GenericConstraint
 from .utilities import slvs_entity_pointer
 from .line_2d import SlvsLine2D
-from .utilities import get_connection_point
 
 logger = logging.getLogger(__name__)
 

--- a/model/point_2d.py
+++ b/model/point_2d.py
@@ -2,15 +2,15 @@ import logging
 from typing import List
 
 import bpy
-from bpy.types import PropertyGroup
 from bpy.props import FloatVectorProperty
+from bpy.types import PropertyGroup
+from bpy.utils import register_classes_factory
 from gpu_extras.batch import batch_for_shader
 from mathutils import Matrix, Vector
-from bpy.utils import register_classes_factory
 
-from ..utilities.draw import draw_rect_2d
 from ..curve_solver import Solver
-from .base_entity import SlvsGenericEntity, Entity2D, tag_update
+from ..utilities.draw import draw_rect_2d
+from .base_entity import Entity2D, SlvsGenericEntity, tag_update
 from .utilities import slvs_entity_pointer
 
 logger = logging.getLogger(__name__)

--- a/model/point_2d.py
+++ b/model/point_2d.py
@@ -11,9 +11,7 @@ from bpy.utils import register_classes_factory
 from ..utilities.draw import draw_rect_2d
 from ..curve_solver import Solver
 from .base_entity import SlvsGenericEntity, Entity2D, tag_update
-from .utilities import slvs_entity_pointer, make_coincident
-from .line_2d import SlvsLine2D
-from ..utilities.constants import HALF_TURN
+from .utilities import slvs_entity_pointer
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +32,6 @@ class Point2D(Entity2D):
         size = 0.1
         coords = draw_rect_2d(0, 0, size, size)
         coords = [(mat @ Vector(co))[:] for co in coords]
-        indices = ((0, 1, 2), (0, 2, 3))
         pos = self.location
         self._batch = batch_for_shader(self._shader, "POINTS", {"pos": (pos[:],)})
         self.is_dirty = False

--- a/model/ratio.py
+++ b/model/ratio.py
@@ -1,7 +1,7 @@
 import logging
 
 from bpy.types import PropertyGroup
-from bpy.props import FloatProperty, IntProperty, StringProperty
+from bpy.props import FloatProperty, StringProperty
 from bpy.utils import register_classes_factory
 
 from ..curve_solver import Solver

--- a/model/ratio.py
+++ b/model/ratio.py
@@ -1,16 +1,16 @@
 import logging
 
-from bpy.types import PropertyGroup
 from bpy.props import FloatProperty, StringProperty
+from bpy.types import PropertyGroup
 from bpy.utils import register_classes_factory
 
 from ..curve_solver import Solver
 from ..global_data import WpReq
+from ..utilities.solver import update_system_cb
 from .base_constraint import DimensionalConstraint
-from .utilities import slvs_entity_pointer
 from .categories import LINE
 from .line_2d import SlvsLine2D
-from ..utilities.solver import update_system_cb
+from .utilities import slvs_entity_pointer
 
 logger = logging.getLogger(__name__)
 

--- a/model/sketch.py
+++ b/model/sketch.py
@@ -2,15 +2,15 @@ import logging
 from typing import List
 
 import bpy
-from bpy.types import PropertyGroup
 from bpy.props import EnumProperty, IntProperty, PointerProperty
+from bpy.types import PropertyGroup
 from bpy.utils import register_classes_factory
 
 from .. import global_data
 from ..curve_solver import Solver, solve_system
+from ..utilities.bpy import bpyEnum
 from .base_entity import SlvsGenericEntity
 from .utilities import slvs_entity_pointer
-from ..utilities.bpy import bpyEnum
 
 logger = logging.getLogger(__name__)
 

--- a/model/sketch.py
+++ b/model/sketch.py
@@ -3,7 +3,7 @@ from typing import List
 
 import bpy
 from bpy.types import PropertyGroup
-from bpy.props import EnumProperty, BoolProperty, IntProperty, PointerProperty
+from bpy.props import EnumProperty, IntProperty, PointerProperty
 from bpy.utils import register_classes_factory
 
 from .. import global_data

--- a/model/utilities.py
+++ b/model/utilities.py
@@ -1,10 +1,10 @@
 import logging
+import math
 
 import bpy
 from bpy.props import IntProperty
 from bpy.types import Context
-import math
-from mathutils import Vector, Matrix
+from mathutils import Matrix, Vector
 
 logger = logging.getLogger(__name__)
 

--- a/model/utilities.py
+++ b/model/utilities.py
@@ -143,8 +143,6 @@ def create_bezier_curve_attributes(
 # NOTE: When tweaking, it's necessary to constrain a point that is only temporary available
 # and has no SlvsPoint representation
 def make_coincident(solvesys, point_handle, e2, wp, group, entity_type=None):
-    from .categories import LINE, CURVE, POINT
-    from .workplane import SlvsWorkplane
 
     kwargs = {}
     if wp:

--- a/model/workplane.py
+++ b/model/workplane.py
@@ -31,8 +31,6 @@ class SlvsWorkplane(SlvsGenericEntity, PropertyGroup):
         nm (SlvsNormal3D): Normal which defines the orientation
     """
 
-    size = 0.4
-
     def dependencies(self) -> List[SlvsGenericEntity]:
         return [self.p1, self.nm]
 
@@ -43,8 +41,6 @@ class SlvsWorkplane(SlvsGenericEntity, PropertyGroup):
     def update(self):
         if bpy.app.background:
             return
-
-        p1, nm = self.p1, self.nm
 
         coords = draw_rect_2d(0, 0, self.size, self.size)
         coords = [(Vector(co))[:] for co in coords]

--- a/model/workplane.py
+++ b/model/workplane.py
@@ -3,20 +3,19 @@ from typing import List
 
 import bpy
 import gpu
-from mathutils import Vector, Matrix
 from bpy.types import PropertyGroup
-from gpu_extras.batch import batch_for_shader
 from bpy.utils import register_classes_factory
+from gpu_extras.batch import batch_for_shader
+from mathutils import Matrix, Vector
 
-from ..declarations import Operators
 from .. import global_data
-from ..utilities.draw import draw_rect_2d
+from ..curve_solver import Solver
+from ..declarations import Operators
 from ..shaders import Shaders
 from ..utilities import preferences
-from ..curve_solver import Solver
+from ..utilities.draw import draw_rect_2d
 from .base_entity import SlvsGenericEntity
 from .utilities import slvs_entity_pointer
-
 
 logger = logging.getLogger(__name__)
 

--- a/operators/base_3d.py
+++ b/operators/base_3d.py
@@ -1,7 +1,7 @@
 import bpy
 from bpy.types import Context
 
-from ..model.types import SlvsPoint3D, SlvsLine3D, SlvsWorkplane
+from ..model.types import SlvsLine3D, SlvsPoint3D, SlvsWorkplane
 from ..utilities.view import get_placement_pos
 from .base_stateful import GenericEntityOp
 from .utilities import ignore_hover

--- a/operators/base_3d.py
+++ b/operators/base_3d.py
@@ -1,5 +1,5 @@
 import bpy
-from bpy.types import Context, Event
+from bpy.types import Context
 
 from ..model.types import SlvsPoint3D, SlvsLine3D, SlvsWorkplane
 from ..utilities.view import get_placement_pos

--- a/operators/bevel.py
+++ b/operators/bevel.py
@@ -1,8 +1,7 @@
 import logging
 
-from bpy.types import Operator, Context
+from bpy.types import Operator
 from bpy.props import FloatProperty
-from mathutils import Vector
 
 from ..drawing import selection
 from ..model.curve_ref import PointRef, LineRef, ArcRef, CircleRef, CurveRef, curve_ref

--- a/operators/bevel.py
+++ b/operators/bevel.py
@@ -1,18 +1,18 @@
 import logging
 
-from bpy.types import Operator
 from bpy.props import FloatProperty
+from bpy.types import Operator
 
-from ..drawing import selection
-from ..model.curve_ref import PointRef, LineRef, ArcRef, CircleRef, CurveRef, curve_ref
-from ..utilities.view import refresh
 from ..curve_solver import solve_system
 from ..declarations import Operators
-from ..stateful_operator.utilities.register import register_stateops_factory
-from ..stateful_operator.state import state_from_args
-from ..utilities.intersect import get_intersections, ElementTypes
-from .base_2d import Operator2d
+from ..drawing import selection
 from ..model.categories import POINT2D, SEGMENT
+from ..model.curve_ref import ArcRef, CircleRef, CurveRef, LineRef, PointRef, curve_ref
+from ..stateful_operator.state import state_from_args
+from ..stateful_operator.utilities.register import register_stateops_factory
+from ..utilities.intersect import ElementTypes, get_intersections
+from ..utilities.view import refresh
+from .base_2d import Operator2d
 
 logger = logging.getLogger(__name__)
 

--- a/operators/context_menu.py
+++ b/operators/context_menu.py
@@ -41,13 +41,10 @@ class View3D_OT_slvs_context_menu(Operator, HighlightElement):
 
     def execute(self, context: Context):
         is_entity = True
-        entity_index = None
-        constraint_index = None
         element = None
 
         # Constraints
         if self.properties.is_property_set("type"):
-            constraint_index = self.index
             constraints = get_active_constraints(context)
             element = constraints.get_from_type_index(self.type, self.index)
             is_entity = False

--- a/operators/context_menu.py
+++ b/operators/context_menu.py
@@ -1,12 +1,12 @@
 import bpy
-from ..model.sketch_ref import get_active_constraints
+from bpy.props import BoolProperty, IntProperty, StringProperty
+from bpy.types import Context, Event, Operator, PropertyGroup
 from bpy.utils import register_classes_factory
-from bpy.props import StringProperty, BoolProperty, IntProperty
-from bpy.types import Operator, Context, Event, PropertyGroup
 
-from ..drawing import selection
-from ..utilities.highlighting import HighlightElement
 from ..declarations import Operators
+from ..drawing import selection
+from ..model.sketch_ref import get_active_constraints
+from ..utilities.highlighting import HighlightElement
 
 
 class View3D_OT_slvs_context_menu(Operator, HighlightElement):

--- a/operators/snapshot.py
+++ b/operators/snapshot.py
@@ -1,4 +1,3 @@
-import bpy
 from bpy.types import Operator, Context
 from bpy.utils import register_classes_factory
 

--- a/operators/snapshot.py
+++ b/operators/snapshot.py
@@ -1,8 +1,8 @@
-from bpy.types import Operator, Context
+from bpy.types import Context, Operator
 from bpy.utils import register_classes_factory
 
 from ..declarations import Operators
-from ..serialize import scene_to_dict, scene_from_dict
+from ..serialize import scene_from_dict, scene_to_dict
 
 # Buffer to store snapshot data
 _snapshot_buffer = None

--- a/operators/update.py
+++ b/operators/update.py
@@ -1,4 +1,4 @@
-from bpy.types import Operator, Context
+from bpy.types import Context, Operator
 from bpy.utils import register_classes_factory
 
 from ..declarations import Operators
@@ -10,8 +10,8 @@ class VIEW3D_OT_update(Operator):
     bl_label = "Force Update"
 
     def execute(self, context: Context):
-        from ..model.sketch_ref import get_sketches
         from ..curve_solver import solve_system
+        from ..model.sketch_ref import get_sketches
         for sketch in get_sketches(context):
             solve_system(context, sketch=sketch)
             refresh_curve_geometry(sketch)

--- a/operators/update.py
+++ b/operators/update.py
@@ -1,5 +1,4 @@
 from bpy.types import Operator, Context
-from bpy.props import BoolProperty
 from bpy.utils import register_classes_factory
 
 from ..declarations import Operators

--- a/ruff.toml
+++ b/ruff.toml
@@ -24,3 +24,6 @@ select = ["F", "I", "E9"]
 [lint.per-file-ignores]
 # Package __init__ files intentionally re-export symbols.
 "**/__init__.py" = ["F401"]
+# model/types.py is a re-export hub: it imports every entity/constraint class so
+# the rest of the codebase can do `from ..model.types import Slvs...`.
+"model/types.py" = ["F401"]

--- a/stateful_operator/state.py
+++ b/stateful_operator/state.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass, field
-from typing import Any, Callable, Optional, Tuple
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
 
 
 @dataclass(frozen=True)

--- a/testing/test_bevel.py
+++ b/testing/test_bevel.py
@@ -1,6 +1,5 @@
 """Tests for the bevel operator."""
 
-import math
 from mathutils import Vector
 from .utils import Sketch2dTestCase
 
@@ -70,7 +69,7 @@ class TestBevel(Sketch2dTestCase):
         topo = self.sketch.topology
 
         # Create bevel points and replace
-        ct = self.add_point((3, 1))
+        self.add_point((3, 1))
         bp1 = self.add_point((3, 0))
         bp2 = self.add_point((4, 1))
 

--- a/testing/test_bevel.py
+++ b/testing/test_bevel.py
@@ -1,6 +1,7 @@
 """Tests for the bevel operator."""
 
 from mathutils import Vector
+
 from .utils import Sketch2dTestCase
 
 
@@ -24,7 +25,7 @@ class TestBevel(Sketch2dTestCase):
 
         # Simulate what bevel does: find center, tangent points, create arc
         radius = 1.0
-        from ..utilities.intersect import get_intersections, ElementTypes
+        from ..utilities.intersect import ElementTypes, get_intersections
 
         def _offset(ref, offset):
             if ref.is_line():

--- a/testing/test_core.py
+++ b/testing/test_core.py
@@ -1,7 +1,7 @@
 from testing.utils import BgsTestCase
+
 from ..model.types import SlvsPoint3D
 from ..model.utilities import slvs_entity_pointer
-
 
 
 class TestEntities(BgsTestCase):
@@ -15,9 +15,9 @@ class TestEntities(BgsTestCase):
 
     def test_entity_pointer(self):
         import bpy
+        from bpy.props import PointerProperty
         from bpy.types import PropertyGroup
         from bpy.utils import register_class, unregister_class
-        from bpy.props import PointerProperty
 
         class PointerTest(PropertyGroup):
             pass

--- a/testing/test_core.py
+++ b/testing/test_core.py
@@ -1,14 +1,11 @@
-from unittest import skip
 from testing.utils import BgsTestCase
 from ..model.types import SlvsPoint3D
 from ..model.utilities import slvs_entity_pointer
 
-from sys import float_info
 
 
 class TestEntities(BgsTestCase):
     def test_point_3d(self):
-        sketcher = self.sketcher
         entities = self.entities
 
         # Point at origin

--- a/testing/test_solver.py
+++ b/testing/test_solver.py
@@ -1,4 +1,3 @@
-from unittest import skip
 
 from .utils import Sketch2dTestCase
 

--- a/testing/test_topology.py
+++ b/testing/test_topology.py
@@ -1,7 +1,9 @@
 """Tests for SketchTopology — connectivity, geometry, path walking, modification."""
 
 import math
+
 from mathutils import Vector
+
 from .utils import Sketch2dTestCase
 
 

--- a/testing/test_topology.py
+++ b/testing/test_topology.py
@@ -218,7 +218,7 @@ class TestTopologyPathWalking(Sketch2dTestCase):
         p2 = self.add_point((3, 0))
         p3 = self.add_point((3, 4))
         l1 = self.add_line(p1, p2)
-        l2 = self.add_line(p2, p3)
+        self.add_line(p2, p3)
 
         topo = self.sketch.topology
         path = topo.walk_path(l1)
@@ -230,8 +230,8 @@ class TestTopologyPathWalking(Sketch2dTestCase):
         p2 = self.add_point((3, 0))
         p3 = self.add_point((1.5, 3))
         l1 = self.add_line(p1, p2)
-        l2 = self.add_line(p2, p3)
-        l3 = self.add_line(p3, p1)
+        self.add_line(p2, p3)
+        self.add_line(p3, p1)
 
         topo = self.sketch.topology
         path = topo.walk_path(l1)
@@ -243,7 +243,7 @@ class TestTopologyPathWalking(Sketch2dTestCase):
         p2 = self.add_point((3, 0))
         p3 = self.add_point((6, 0))
         l1 = self.add_line(p1, p2)
-        l2 = self.add_line(p2, p3)
+        self.add_line(p2, p3)
 
         topo = self.sketch.topology
         path = topo.walk_path(l1)
@@ -259,8 +259,8 @@ class TestTopologyPathWalking(Sketch2dTestCase):
         p2 = self.add_point((3, 0))
         p3 = self.add_point((5, 5))
         p4 = self.add_point((8, 5))
-        l1 = self.add_line(p1, p2)
-        l2 = self.add_line(p3, p4)
+        self.add_line(p1, p2)
+        self.add_line(p3, p4)
 
         topo = self.sketch.topology
         paths = topo.walk_all_paths()

--- a/testing/test_trim.py
+++ b/testing/test_trim.py
@@ -1,6 +1,5 @@
 """Tests for the trim operator logic."""
 
-import math
 from mathutils import Vector
 from .utils import Sketch2dTestCase
 
@@ -72,7 +71,6 @@ class TestTrimLogic(Sketch2dTestCase):
     def test_trim_creates_segments(self):
         """Trim should create new segments and remove the trimmed part."""
         from ..utilities.trimming import TrimSegment
-        from ..model.curve_ref import curve_ref
 
         # Two crossing lines
         p1 = self.add_point((0, 0))

--- a/testing/test_trim.py
+++ b/testing/test_trim.py
@@ -1,6 +1,7 @@
 """Tests for the trim operator logic."""
 
 from mathutils import Vector
+
 from .utils import Sketch2dTestCase
 
 

--- a/testing/utils.py
+++ b/testing/utils.py
@@ -173,7 +173,6 @@ class BgsTestCase(TestCase):
             return
 
         # Delete scene
-        context = cls.context
         data = cls.data
         data.scenes.remove(cls.scene)
 
@@ -232,7 +231,7 @@ class Sketch2dTestCase(BgsTestCase):
     def setUp(self) -> None:
         self.sketch = self.new_sketch()
         self.sketch.name = self._testMethodName
-        from ..model.sketch_ref import set_active_sketch, Sketch
+        from ..model.sketch_ref import set_active_sketch
         if hasattr(self.sketch, 'target_object'):
             set_active_sketch(self.context, self.sketch.target_object)
         return super().setUp()

--- a/testing/utils.py
+++ b/testing/utils.py
@@ -15,8 +15,9 @@ def make_operator_double(real_cls):
     (``continuous_draw: BoolProperty(...)``) are inert, so a test sets a plain attribute
     where a value is needed. UI sinks touched by the state machine are stubbed to no-ops.
     """
-    import bpy
     import types
+
+    import bpy
 
     def _noop(self, *args, **kwargs):
         return None

--- a/utilities/extrude_nodes.py
+++ b/utilities/extrude_nodes.py
@@ -11,7 +11,6 @@ into open walls, honouring the ``Mirror Extrude`` toggle. Filled input is
 untouched -- it still flows through the original face-extrude path.
 """
 
-import bpy
 
 EXTRUDE_NODE_GROUP = "CAD Sketcher Extrude"
 # Bump when the patched sub-graph changes so groups baked into saved files upgrade.

--- a/utilities/topology.py
+++ b/utilities/topology.py
@@ -7,11 +7,11 @@ projection, and modification.
 
 import math
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple
+from typing import List
 
 from .curve_data import get_uuid, has_uuid_field
 
-from mathutils import Vector, Matrix
+from mathutils import Vector
 from mathutils.geometry import intersect_line_sphere_2d, intersect_sphere_sphere_2d
 
 from ..model.constants import SketchCurveType

--- a/utilities/topology.py
+++ b/utilities/topology.py
@@ -9,16 +9,20 @@ import math
 from dataclasses import dataclass, field
 from typing import List
 
-from .curve_data import get_uuid, has_uuid_field
-
 from mathutils import Vector
 from mathutils.geometry import intersect_line_sphere_2d, intersect_sphere_sphere_2d
 
 from ..model.constants import SketchCurveType
 from ..model.curve_ref import (
-    CurveRef, PointRef, LineRef, ArcRef, CircleRef, curve_ref,
+    ArcRef,
+    CircleRef,
+    CurveRef,
+    LineRef,
+    PointRef,
+    curve_ref,
 )
 from ..utilities.math import range_2pi
+from .curve_data import get_uuid, has_uuid_field
 
 
 @dataclass


### PR DESCRIPTION
Follow-up to the extensions.blender.org review: the reviewer hit latent
pyflakes issues (undefined names, an unresolved import) in files no PR had
touched, because the PR lint is deliberately diff-scoped. This sweeps the whole
tree for those and gates releases so they can't recur.

## Lint sweep (F-rules only)

`ruff check --select F` over the entire codebase, fixed everything it found:

- **F401 unused imports** (66) — removed. Autofixed, then verified.
- **F841 unused locals** (18) — removed by hand. In tests, the assignment's
  side-effecting call is kept (e.g. `self.add_line(...)`), only the dead binding
  dropped.
- **F811 redefinitions** (3) — removed (a shadowed `size = 0.4` class attr under
  a `size` property; duplicate `range_2pi`/`pol2cart` imports).

`model/types.py` is a deliberate re-export hub (`from ..model.types import
Slvs...` across ~15 modules), so it's added to the F401 per-file-ignores next to
`__init__.py` rather than stripped.

Import ordering (I) and formatting are intentionally left diff-scoped in the PR
lint (per #345), so this is not a whole-tree reformat.

## Release CI gate

Adds a `lint` job to `release.yaml` running `ruff check --select F` over the
whole tree; the stable and latest build jobs now `needs: lint`. A latent
undefined-name/unused-import in an untouched file (the 0.31.0-rc.1 case) now
blocks the build instead of shipping.

## Verification

- `ruff check --select F .` clean tree-wide.
- Full test suite passes (403; 2 pre-existing expected failures).
