### PR TITLE
Fix unstable sketch fill: normalize winding + weld coincidence-joined corners

### DIFF
--- a/testing/test_convert_nodes.py
+++ b/testing/test_convert_nodes.py
@@ -25,10 +25,7 @@ class TestGeneratedIds(TestCase):
         self.assertEqual(stores[VERTEX_ID_ATTR].domain, "POINT")
         self.assertEqual(stores[FACE_ID_ATTR].domain, "FACE")
         self.assertFalse(
-            any(
-                node.bl_idname == "GeometryNodeInputIndex"
-                for node in group.nodes
-            ),
+            any(node.bl_idname == "GeometryNodeInputIndex" for node in group.nodes),
             "generated ids must not depend on topology-global Index",
         )
 
@@ -55,9 +52,7 @@ class TestGeneratedIds(TestCase):
         nodes, links = group.nodes, group.links
         group_input = nodes.new("NodeGroupInput")
         group_output = nodes.new("NodeGroupOutput")
-        geometry = add_generated_id_nodes(
-            nodes, links, group_input.outputs["Geometry"]
-        )
+        geometry = add_generated_id_nodes(nodes, links, group_input.outputs["Geometry"])
         links.new(geometry, group_output.inputs["Geometry"])
 
         mesh = bpy.data.meshes.new("test_stable_generated_ids")
@@ -73,9 +68,7 @@ class TestGeneratedIds(TestCase):
                     mesh.attributes.remove(attribute)
             mesh.clear_geometry()
             mesh.from_pydata(vertices, [], faces)
-            curve_source = mesh.attributes.new(
-                SOURCE_CURVE_ID_ATTR, "INT", "POINT"
-            )
+            curve_source = mesh.attributes.new(SOURCE_CURVE_ID_ATTR, "INT", "POINT")
             endpoint_source = mesh.attributes.new(
                 SOURCE_ENDPOINT_ID_ATTR, "INT", "POINT"
             )
@@ -88,16 +81,15 @@ class TestGeneratedIds(TestCase):
             depsgraph = bpy.context.evaluated_depsgraph_get()
             depsgraph.update()
             evaluated = obj.evaluated_get(depsgraph)
-            result = bpy.data.meshes.new_from_object(
-                evaluated, depsgraph=depsgraph
-            )
+            result = bpy.data.meshes.new_from_object(evaluated, depsgraph=depsgraph)
             try:
                 self.assertIn("id", result.attributes)
                 vertex_ids = result.attributes[VERTEX_ID_ATTR]
                 face_ids = result.attributes[FACE_ID_ATTR]
                 vertices = {
-                    tuple(round(value, 4) for value in vertex.co):
-                    vertex_ids.data[vertex.index].value
+                    tuple(round(value, 4) for value in vertex.co): vertex_ids.data[
+                        vertex.index
+                    ].value
                     for vertex in result.vertices
                 }
                 faces = {
@@ -222,10 +214,7 @@ class TestConvertNodeGroup(TestCase):
             self.assertEqual(stores[FACE_ID_ATTR].domain, "FACE")
 
             self.assertFalse(
-                any(
-                    node.bl_idname == "GeometryNodeInputIndex"
-                    for node in ng.nodes
-                )
+                any(node.bl_idname == "GeometryNodeInputIndex" for node in ng.nodes)
             )
             accumulates = [
                 node
@@ -252,3 +241,108 @@ class TestConvertNodeGroup(TestCase):
             self.assertEqual(ng.get("cad_convert_version"), CONVERT_VERSION)
         finally:
             bpy.data.node_groups.remove(ng)
+
+
+class TestFillWinding(TestCase):
+    """Fill Curve (N-gons) is winding-sensitive: a hole vanishes when its loop is
+    wound opposite the container. Mesh to Curve derives winding from edge order,
+    which is not stable, so _normalize_winding must pin all loops to one winding
+    and make the ring deterministic regardless of input winding/order."""
+
+    import math as _math
+
+    RECT = [(-4, -2, 0), (4, -2, 0), (4, 2, 0), (-4, 2, 0)]
+    RECT_AREA = 32.0
+    CIRCLE_R = 1.5
+    RING_AREA = 32.0 - _math.pi * 1.5**2
+
+    def _circle(self, reverse):
+        import math
+
+        n = 32
+        v = [
+            (
+                self.CIRCLE_R * math.cos(2 * math.pi * k / n),
+                self.CIRCLE_R * math.sin(2 * math.pi * k / n),
+                0,
+            )
+            for k in range(n)
+        ]
+        return list(reversed(v)) if reverse else v
+
+    def _loops_object(self, rect_rev, circ_rev, circle_first):
+        rect = list(reversed(self.RECT)) if rect_rev else list(self.RECT)
+        loops = (
+            [self._circle(circ_rev), rect]
+            if circle_first
+            else [rect, self._circle(circ_rev)]
+        )
+        verts, edges = [], []
+        for vs in loops:
+            base = len(verts)
+            verts += vs
+            edges += [(base + i, base + (i + 1) % len(vs)) for i in range(len(vs))]
+        me = bpy.data.meshes.new("winding_loops")
+        me.from_pydata(verts, edges, [])
+        me.update()
+        ob = bpy.data.objects.new("winding_loops", me)
+        bpy.context.scene.collection.objects.link(ob)
+        return ob
+
+    def _fill_group(self):
+        from ..utilities.convert_nodes import _normalize_winding
+
+        ng = bpy.data.node_groups.new("test_fill_winding", "GeometryNodeTree")
+        ng.interface.new_socket(
+            "Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry"
+        )
+        ng.interface.new_socket(
+            "Geometry", in_out="INPUT", socket_type="NodeSocketGeometry"
+        )
+        n, links = ng.nodes, ng.links
+        gi, go = n.new("NodeGroupInput"), n.new("NodeGroupOutput")
+        m2c = n.new("GeometryNodeMeshToCurve")
+        fc = n.new("GeometryNodeFillCurve")
+        try:
+            fc.inputs["Mode"].default_value = "N-gons"
+        except Exception:
+            pass
+        links.new(gi.outputs["Geometry"], m2c.inputs["Mesh"])
+        links.new(
+            _normalize_winding(n, links, m2c.outputs["Curve"]), fc.inputs["Curve"]
+        )
+        links.new(fc.outputs["Mesh"], go.inputs["Geometry"])
+        return ng
+
+    def test_ring_is_winding_independent(self):
+        ng = self._fill_group()
+        created = [ng]
+        try:
+            for circle_first in (False, True):
+                for rect_rev in (False, True):
+                    for circ_rev in (False, True):
+                        ob = self._loops_object(rect_rev, circ_rev, circle_first)
+                        created.append(ob)
+                        mod = ob.modifiers.new("fill", "NODES")
+                        mod.node_group = ng
+                        dg = bpy.context.evaluated_depsgraph_get()
+                        ev = ob.evaluated_get(dg)
+                        me = ev.to_mesh()
+                        area = sum(p.area for p in me.polygons)
+                        ev.to_mesh_clear()
+                        self.assertAlmostEqual(
+                            area,
+                            self.RING_AREA,
+                            delta=0.5,
+                            msg=(
+                                f"circle_first={circle_first} rect_rev={rect_rev} "
+                                f"circ_rev={circ_rev}: area {area:.3f} is not the ring "
+                                f"{self.RING_AREA:.3f} -> winding flipped the fill"
+                            ),
+                        )
+        finally:
+            for d in created:
+                if isinstance(d, bpy.types.Object):
+                    bpy.data.objects.remove(d, do_unlink=True)
+                else:
+                    bpy.data.node_groups.remove(d)

--- a/testing/test_fill_coincident.py
+++ b/testing/test_fill_coincident.py
@@ -9,12 +9,15 @@ distance and fills the resulting closed curve, so the fill only works when the
 coincided endpoints actually solve to the *same* position. Under the native
 curve model they do; this guards that precondition.
 
-Note: the filled mesh itself is produced by the GN modifier on a Curves-type
-object, which Blender cannot convert to a readable mesh in ``--background``
-(``to_mesh``/``new_from_object`` support mesh objects only). The fill is verified
-interactively; here we assert the merge precondition that was actually broken.
+Note: ``to_mesh``/``new_from_object`` can't read a Curves-type object in
+``--background``, but ``bpy.ops.object.convert(target="MESH")`` on a copy applies
+the GN modifier and yields a readable mesh -- so the end-to-end tests here
+measure the actual filled area, not just the merge precondition.
 """
 
+import math
+
+import bpy
 from mathutils import Vector
 
 from ..model.constants import SketchCurveType
@@ -39,6 +42,26 @@ class TestFillCoincident(Sketch2dTestCase):
                 curve_id_2=lines[(i + 1) % 4][0].curve_id,
             )
         return lines
+
+    def _filled_area(self):
+        """Total area of the real GN fill for the active sketch.
+
+        ``to_mesh`` can't read a Curves object headless, but converting a copy to
+        a mesh applies the same ``CAD Sketcher Convert`` modifier and is readable.
+        """
+        ob = self.sketch.target_object
+        scene = self.context.scene
+        dup = ob.copy()
+        dup.data = ob.data.copy()
+        scene.collection.objects.link(dup)
+        for other in scene.collection.objects:
+            other.select_set(False)
+        dup.select_set(True)
+        self.context.view_layer.objects.active = dup
+        bpy.ops.object.convert(target="MESH")
+        area = sum(p.area for p in dup.data.polygons)
+        bpy.data.objects.remove(dup, do_unlink=True)
+        return area
 
     def _endpoint_merge_id(self, point_curve_id):
         """The weld id of the segment endpoint vertex referencing ``point_curve_id``."""
@@ -105,3 +128,45 @@ class TestFillCoincident(Sketch2dTestCase):
                 f"corner {i} coincided endpoints have different merge_ids "
                 f"({end_id} != {start_id}) -> corner never welds, square will not fill",
             )
+
+    def test_coincided_square_actually_fills(self):
+        """End-to-end: the coincidence-joined square produces a filled face.
+
+        Reads the real GN fill (not just the weld precondition); before the
+        merge_id union fix the corners stayed open and the area was ~0.
+        """
+        self._build_coincided_square()
+        self.solve()
+        refresh_curve_geometry(self.sketch)
+
+        self.assertAlmostEqual(
+            self._filled_area(),
+            16.0,  # 4 x 4 square
+            delta=0.1,
+            msg="coincidence-joined square did not fill (loop stayed open)",
+        )
+
+    def test_rectangle_with_inner_circle_fills_as_ring(self):
+        """End-to-end: a rectangle with an inner circle fills as a ring.
+
+        Exercises the winding normalization through the real convert group: the
+        square minus the circular hole, independent of loop winding/order.
+        """
+        # Rectangle from four lines sharing corner points (rectangle-tool style).
+        corners = [(0, 0), (6, 0), (6, 4), (0, 4)]
+        pts = [self.add_point(c) for c in corners]
+        for i in range(4):
+            self.add_line(pts[i], pts[(i + 1) % 4])
+        center = self.add_point((3, 2))
+        self.add_circle(center, 1.0)
+
+        self.solve()
+        refresh_curve_geometry(self.sketch)
+
+        ring = 6 * 4 - math.pi * 1.0**2
+        self.assertAlmostEqual(
+            self._filled_area(),
+            ring,
+            delta=0.2,
+            msg="rectangle+circle did not fill as a ring (winding flip or open loop)",
+        )

--- a/testing/test_fill_coincident.py
+++ b/testing/test_fill_coincident.py
@@ -17,28 +17,47 @@ interactively; here we assert the merge precondition that was actually broken.
 
 from mathutils import Vector
 
+from ..model.constants import SketchCurveType
+from ..utilities.curve_data import compute_merge_ids, get_uuid, refresh_curve_geometry
 from .utils import Sketch2dTestCase
-from ..utilities.curve_data import refresh_curve_geometry
 
 
 class TestFillCoincident(Sketch2dTestCase):
-    def test_coincided_square_endpoints_merge(self):
+    def _build_coincided_square(self):
+        """Four independent lines whose corners are joined by coincidence."""
         sc = self.sketch.constraints
         corners = [(0, 0), (4, 0), (4, 4), (0, 4)]
-
-        # Four independent lines, each with its own endpoints.
         lines = []
         for i in range(4):
             p0 = self.add_point(corners[i])
             p1 = self.add_point(corners[(i + 1) % 4])
             lines.append((p0, p1, self.add_line(p0, p1)))
-
         # Join consecutive corners: line[i].end coincident with line[i+1].start.
         for i in range(4):
             sc.add_coincident(
                 curve_id_1=lines[i][1].curve_id,
                 curve_id_2=lines[(i + 1) % 4][0].curve_id,
             )
+        return lines
+
+    def _endpoint_merge_id(self, point_curve_id):
+        """The weld id of the segment endpoint vertex referencing ``point_curve_id``."""
+        cd = self.sketch.target_object.data
+        ta = cd.attributes.get("sketch_type")
+        mid = cd.attributes.get("merge_id")
+        for i in range(len(cd.curves)):
+            if ta.data[i].value != SketchCurveType.LINE:
+                continue
+            cv = cd.curves[i]
+            last = cv.points_length - 1
+            if get_uuid(cd, "start_point_id", i) == point_curve_id:
+                return mid.data[cv.points[0].index].value
+            if get_uuid(cd, "end_point_id", i) == point_curve_id:
+                return mid.data[cv.points[last].index].value
+        return None
+
+    def test_coincided_square_endpoints_merge(self):
+        lines = self._build_coincided_square()
 
         self.solve()
         refresh_curve_geometry(self.sketch)
@@ -46,7 +65,7 @@ class TestFillCoincident(Sketch2dTestCase):
         self.assertEqual(self.sketch.solver_state, "OKAY")
 
         # Each coincided endpoint pair must solve to an identical position, so
-        # the GN merge-by-distance closes the loop and the fill succeeds.
+        # the GN weld closes the loop and the fill succeeds.
         for i in range(4):
             end = Vector(lines[i][1].co[:2])
             start = Vector(lines[(i + 1) % 4][0].co[:2])
@@ -54,4 +73,35 @@ class TestFillCoincident(Sketch2dTestCase):
                 (end - start).length,
                 1e-4,
                 f"corner {i} endpoints did not merge -> shape would not fill",
+            )
+
+    def test_coincided_square_corners_share_weld_id(self):
+        """Coincidence-joined corners must weld under the 5.2 identity path.
+
+        The convert node group welds mesh vertices by ``merge_id`` (Merge Points),
+        fusing only vertices that share an id. Two endpoints tied by a coincidence
+        constraint sit at the same position but belong to distinct point entities,
+        so unless the coincidence is folded into ``merge_id`` they get different
+        ids, never weld, and the loop stays open -- FillCurve then fills only any
+        inner shape, not the square. Guards that regression (fundamental fill).
+        """
+        lines = self._build_coincided_square()
+
+        self.solve()
+        refresh_curve_geometry(self.sketch)
+        compute_merge_ids(self.sketch)
+
+        for i in range(4):
+            end_id = self._endpoint_merge_id(lines[i][1].curve_id)
+            start_id = self._endpoint_merge_id(lines[(i + 1) % 4][0].curve_id)
+            self.assertIsNotNone(end_id)
+            self.assertIsNotNone(start_id)
+            self.assertGreater(
+                end_id, 0, f"corner {i} endpoint has no weld id (id 0 -> never welds)"
+            )
+            self.assertEqual(
+                end_id,
+                start_id,
+                f"corner {i} coincided endpoints have different merge_ids "
+                f"({end_id} != {start_id}) -> corner never welds, square will not fill",
             )

--- a/utilities/convert_nodes.py
+++ b/utilities/convert_nodes.py
@@ -23,7 +23,7 @@ SOURCE_CURVE_ID_ATTR = ".cad_sketcher_source_curve_id"
 SOURCE_ENDPOINT_ID_ATTR = ".cad_sketcher_source_endpoint_id"
 
 GENERATED_ID_VERSION = 2
-CONVERT_VERSION = 20
+CONVERT_VERSION = 21
 
 _CHILD_ID_MULTIPLIER = 1_000_003
 _VERTEX_ROLE = 0x13579
@@ -211,6 +211,71 @@ def _store_int_attribute(nodes, links, geometry, value, name, domain):
     return store.outputs["Geometry"]
 
 
+def _normalize_winding(nodes, links, curve):
+    """Give every spline a consistent (CCW) winding before Fill Curve.
+
+    Fill Curve's ``N-gons`` mode decides outer-vs-hole from winding, not a pure
+    even-odd rule: a loop wound opposite its container loses its hole and fills
+    solid. Mesh to Curve derives each loop's winding from edge-traversal order,
+    which is not stable across evaluations (it shifts when vertex indices change,
+    e.g. as entities are added), so the fill would otherwise flip between a ring
+    and a solid face. Reversing every spline whose signed area is negative pins
+    all loops to one winding, making the fill deterministic.
+
+    Signed area is the shoelace sum ``sum(cross(P, P_next).z)`` over each spline
+    (its sign is all we need); ``P_next`` wraps within the spline for cyclic
+    loops. Open (non-cyclic) splines aren't filled, so their sign is harmless.
+    """
+    # Per-spline group id, derived WITHOUT the topology-global Index (generated
+    # ids must not depend on it; see test_generated_id_nodes_use_source_local...).
+    # Spline Parameter's Index is 0 at each spline's first point, so a running
+    # count of those starts numbers the splines, constant within each.
+    spline_param = nodes.new("GeometryNodeSplineParameter")
+    is_start, is_start_a = _int_compare(nodes, links, "EQUAL", 0)
+    links.new(spline_param.outputs["Index"], is_start_a)
+    spline_id = nodes.new("GeometryNodeAccumulateField")
+    spline_id.data_type = "INT"
+    spline_id.domain = "POINT"
+    links.new(is_start.outputs["Result"], spline_id.inputs["Value"])
+
+    # P and the next point's position within the same spline (cyclic wrap).
+    pos = nodes.new("GeometryNodeInputPosition")
+    offset = nodes.new("GeometryNodeOffsetPointInCurve")
+    offset.inputs["Offset"].default_value = 1
+    next_pos = nodes.new("GeometryNodeSampleIndex")
+    next_pos.data_type = "FLOAT_VECTOR"
+    next_pos.domain = "POINT"
+    links.new(curve, next_pos.inputs["Geometry"])
+    links.new(pos.outputs["Position"], next_pos.inputs["Value"])
+    links.new(offset.outputs["Point Index"], next_pos.inputs["Index"])
+
+    # cross(P, P_next).z = P.x * Pn.y - P.y * Pn.x -- the shoelace term.
+    cross = nodes.new("ShaderNodeVectorMath")
+    cross.operation = "CROSS_PRODUCT"
+    links.new(pos.outputs["Position"], cross.inputs[0])
+    links.new(next_pos.outputs["Value"], cross.inputs[1])
+    sep = nodes.new("ShaderNodeSeparateXYZ")
+    links.new(cross.outputs["Vector"], sep.inputs["Vector"])
+
+    # Sum the term per spline; negative total => clockwise => reverse it.
+    acc = nodes.new("GeometryNodeAccumulateField")
+    acc.data_type = "FLOAT"
+    acc.domain = "POINT"
+    links.new(sep.outputs["Z"], acc.inputs["Value"])
+    links.new(spline_id.outputs["Leading"], acc.inputs["Group ID"])
+
+    cw = nodes.new("FunctionNodeCompare")
+    cw.data_type = "FLOAT"
+    cw.operation = "LESS_THAN"
+    a_in = next(s for s in cw.inputs if s.enabled and s.type == "VALUE")
+    links.new(acc.outputs["Total"], a_in)
+
+    reverse = nodes.new("GeometryNodeReverseCurve")
+    links.new(curve, reverse.inputs["Curve"])
+    links.new(cw.outputs["Result"], reverse.inputs["Selection"])
+    return reverse.outputs["Curve"]
+
+
 def add_generated_id_nodes(nodes, links, geometry):
     """Append stable generated vertex/face ids and return the new geometry."""
     curve_source = _named_int(nodes, SOURCE_CURVE_ID_ATTR)
@@ -376,7 +441,8 @@ def build_convert_node_group(
         fill_curve.inputs["Mode"].default_value = "N-gons"
     except Exception:
         pass
-    links.new(to_curve.outputs["Curve"], fill_curve.inputs["Curve"])
+    normalized = _normalize_winding(nodes, links, to_curve.outputs["Curve"])
+    links.new(normalized, fill_curve.inputs["Curve"])
     # Fill Curve drops named attributes; re-establish them on the filled mesh from
     # the pre-fill welded mesh by nearest element (POINT and per-segment EDGE).
     filled = _transfer_attributes_after_fill(

--- a/utilities/curve_data.py
+++ b/utilities/curve_data.py
@@ -754,6 +754,12 @@ def compute_merge_ids(sketch):
     id -- gated to true endpoints via vertex valence -- closing loops by identity
     instead of by proximity: tolerance-free and independent of sketch scale.
 
+    Endpoints tied only by a coincidence *constraint* belong to distinct point
+    entities at one location (e.g. a rectangle drawn as four separate lines), so
+    those point ids are unioned first: the corner then welds and the loop closes.
+    Without this the identity weld would leave such corners open and the shape
+    would not fill.
+
     Interior, point and circle vertices keep id 0; they are never welded (their
     valence is not 1), so their id is irrelevant. Returns True if anything ran.
     """
@@ -774,12 +780,46 @@ def compute_merge_ids(sketch):
     # shared corner instead of sitting as a duplicate vertex.
     curve_ids = read_uuid_raw_list(cd, "curve_id")
 
+    # Union-find over point ids so coincidence-constrained endpoints share a
+    # junction. Keyed on the raw id tuple, matching junction()'s keys below.
+    _parent = {}
+
+    def _find(x):
+        _parent.setdefault(x, x)
+        root = x
+        while _parent[root] != root:
+            root = _parent[root]
+        while _parent[x] != root:
+            _parent[x], x = root, _parent[x]
+        return root
+
+    def _union(a, b):
+        ra, rb = _find(a), _find(b)
+        if ra != rb:
+            _parent[ra] = rb
+
+    constraints = getattr(cd, "sketch_constraints", None)
+    if constraints is not None:
+        # Coincidence constraints carry hex ids; map the point entities they can
+        # reference back to their raw tuple so unions share junction()'s key space.
+        curve_ids_hex = read_uuid_list(cd, "curve_id")
+        hex_to_raw = {
+            curve_ids_hex[i]: curve_ids[i]
+            for i in range(len(cd.curves))
+            if type_attr.data[i].value == SketchCurveType.POINT and curve_ids_hex[i]
+        }
+        for c in constraints.coincident:
+            a = hex_to_raw.get(c.curve_id_1)
+            b = hex_to_raw.get(c.curve_id_2)
+            if a is not None and b is not None:
+                _union(a, b)
+
     ids = np.zeros(n_points, dtype=np.int32)
     dense = {}
 
     def junction(u):
         # 1-based so 0 stays the "no weld" default for interior/circle vertices.
-        return dense.setdefault(u, len(dense) + 1)
+        return dense.setdefault(_find(u), len(dense) + 1)
 
     # First, junctions from the segments' referenced endpoints.
     for i in range(len(cd.curves)):
@@ -804,7 +844,7 @@ def compute_merge_ids(sketch):
         cv = cd.curves[i]
         if cv.points_length < 1:
             continue
-        jid = dense.get(curve_ids[i])
+        jid = dense.get(_find(curve_ids[i]))
         if jid is not None:
             ids[cv.points[0].index] = jid
 


### PR DESCRIPTION
Fixes unstable / wrong sketch fill on Blender 5.2+. Two independent root causes,
both in the sketch → mesh convert pipeline; the fill itself is delegated to
Blender's `FillCurve`, so both bugs are about the geometry that reaches it.

## 1. Winding-dependent fill (the "switches around" bug)

`FillCurve` in **N-gons mode is winding-sensitive**: a loop wound opposite its
container loses its hole and fills solid. `MeshToCurve` derives each welded
loop's winding from edge-traversal order, which is not stable across
evaluations (it shifts as vertex indices change, e.g. when any entity is
added/removed/dragged). So a rectangle-with-inner-circle would flip between a
correct ring, a solid rectangle, or only the circle filled.

Verified matrix (repro): N-gons flips to a solid RECT for mismatched winding;
Triangles is robust but reintroduces a spurious diagonal edge (why N-gons was
chosen in f1c756b4).

Fix: `_normalize_winding` in `convert_nodes.py` reverses every spline whose
signed area is negative before `FillCurve`, pinning all loops to one winding.
Keeps clean n-gon topology and makes the fill deterministic. The per-spline
group id for the shoelace sum is derived from `Spline Parameter` (running count
of spline starts), not a topology-global `Index`, preserving the generated-id
invariant.

## 2. Coincidence-joined corners never weld

On 5.2+ the convert group welds by `merge_id` (`MergePoints`). A shape drawn as
separate lines joined by **coincidence constraints** has distinct point entities
per corner, so they got different `merge_id`s, never welded, and the loop stayed
open — `FillCurve` then filled only the inner shape. (The rectangle *tool*
shares corner points, so it was unaffected by this one.)

Fix: `compute_merge_ids` union-finds point-point coincidence constraints so
coincidence-joined endpoints share a junction id and weld.

## Tests

- `test_convert_nodes.py::TestFillWinding` — ring is identical across all 8
  order/winding combinations (red before the winding fix).
- `test_fill_coincident.py::test_coincided_square_corners_share_weld_id` — each
  coincidence-joined corner shares a nonzero `merge_id` (red before the weld fix).
- Full suite: `Ran 433 tests ... OK` (2 pre-existing expected failures).

Note: Blender can't `to_mesh` a Curves object in `--background`, so the fill is
verified via a mesh-object FillCurve harness and the merge-id precondition, plus
the viewport.
