### PR TITLE
Drop the unused 'files' permission and the dead disk-pickle save/load

### DIFF
--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -33,9 +33,6 @@ wheels = [
   "./wheels/slvs-3.2-cp313-cp313-win_amd64.whl",
 ]
 
-[permissions]
-files = "Used to load CAD Sketcher assets"
-
 [build]
 # Ship only the runtime add-on. Everything below is dev tooling, docs, tests,
 # or local build cruft that must not end up in the released extension.

--- a/serialize.py
+++ b/serialize.py
@@ -1,6 +1,4 @@
-import pickle
-from pathlib import Path
-from typing import Dict, Optional, Union
+from typing import Dict
 
 from bpy.types import Scene
 
@@ -133,36 +131,6 @@ def _get_indices(elements):
 
     [l.sort() for l in indices.values()]
     return indices
-
-
-def save(file: Union[str, Path], scene: Optional[Scene] = None):
-    """Saves CAD Sketcher data of scene into file"""
-    if not scene:
-        import bpy
-
-        scene = bpy.context.scene
-
-    with open(file, "wb") as picklefile:
-        pickler = pickle.Pickler(picklefile)
-
-        # Convert to dict to avoid pickling PropertyGroup instances
-        dict = scene_to_dict(scene)
-        pickler.dump(dict)
-        picklefile.close()
-
-
-def load(file: Union[str, Path], scene: Optional[Scene] = None):
-    """Overwrites scene with entities and constraints stored in file"""
-    if not scene:
-        import bpy
-
-        scene = bpy.context.scene
-
-    with open(file, "rb") as picklefile:
-        unpickler = pickle.Unpickler(picklefile)
-        load_dict = unpickler.load()
-
-        update_scene_from_dict(scene, load_dict)
 
 
 def paste(context, dictionary):


### PR DESCRIPTION
The manifest declared the Blender `files` permission ("Access to any file,
folder or drive on the system") with a description still referencing the
removed `assets.blend`. Audited every filesystem touch in the shipped add-on:

- `base/whats_new.py` — reads the bundled `CHANGELOG.md` (own package) and
  reads/writes a seen-version marker under `bpy.utils.extension_path_user` (the
  add-on's own sanctioned storage).
- `icon_manager.py` — loads `resources/icons/*.png` from its own package.
- `serialize.py save()/load()` — the only functions taking an arbitrary path
  (disk pickle).

Own-package files and `extension_path_user` don't need the `files` permission,
so it's removed (the whole `[permissions]` block).

While auditing, `serialize.save`/`load` turned out to be not just dead but
**broken**: they pickle `scene_to_dict(scene)`, and since the native-curves
refactor the scene dict embeds live `bpy.types.Object` pointers
(`workplane_object`, `wp_xy/xz/yz`, ...), so `pickle.dumps` raises `cannot
pickle 'Object' object` on any real sketch. Nothing called them (the snapshot
system uses the in-memory `scene_to_dict`/`scene_from_dict`; there is no
import/export operator). Removed them, so no `open(<arbitrary path>)` remains in
shipped code. A real "export sketch to file" feature, if wanted later, needs
Object-pointer resolution (name/uuid) and its own design + a deliberate
re-add of the permission.

Verified: `extension validate` succeeds and the add-on installs without the
permission; full test suite passes (432; 2 pre-existing expected failures).
