### PR TITLE
Don't submit reference dimensions to the solver (#674)

### DIFF
--- a/curve_solver.py
+++ b/curve_solver.py
@@ -281,6 +281,14 @@ class CurveSolver:
             group = self.group_sketch
             c.failed = False
 
+            # Reference ("measure only") dimensions report a measurement; they must
+            # never drive the solver. Submitting them consumes a DOF and, when the
+            # quantity is already implied, forces REDUNDANT_OK and flags the group
+            # failed (issue #674). The pre-native-curves solver gated these in
+            # DimensionalConstraint.py_data(); restore the gate on the curve path.
+            if getattr(c, "is_reference", False):
+                continue
+
             if getattr(sketch, "is_3d", False) and getattr(c, "type", "") != "DISTANCE":
                 # Free-3D sketches only support distance today. Flag anything else
                 # as failed so the UI marks it unsatisfied instead of silently

--- a/testing/test_reference_dimension.py
+++ b/testing/test_reference_dimension.py
@@ -1,0 +1,52 @@
+"""Issue #674: reference ("measure only") dimensions must not reach the solver.
+
+A reference dimension only reports a measurement; it must not act as a driving
+constraint. If it does, it consumes a degree of freedom and, when the measured
+quantity is already implied by other constraints, pushes the system into
+REDUNDANT_OK -- flagging the redundant group (and unrelated constraints) failed.
+"""
+
+from .utils import Sketch2dTestCase
+
+
+class TestReferenceDimension(Sketch2dTestCase):
+    def test_reference_distance_does_not_consume_dof(self):
+        # A free segment; a driving distance would remove one DOF, a reference one
+        # must not.
+        self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((1, 0))
+        p2 = self.add_point((1, 1))
+        self.add_line(p1, p2)
+        self.solve()
+        dof_free = self.sketch.dof
+
+        c = self.sketch.constraints.add_distance(
+            init=True, curve_id_1=p1.curve_id, curve_id_2=p2.curve_id
+        )
+        c.is_reference = True
+        self.solve()
+        self.assertEqual(self.sketch.dof, dof_free, "reference distance consumed a DOF")
+
+    def test_reference_distance_does_not_overconstrain(self):
+        # Fully constrain a segment's length with a driving distance, then add a
+        # second, reference, distance on the same pair. The reference one is a
+        # pure measurement, so the sketch must stay OKAY with nothing failed.
+        origin = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((3, 0))
+        self.add_line(origin, p1)
+        sc = self.sketch.constraints
+        driving = sc.add_distance(
+            init=True, curve_id_1=origin.curve_id, curve_id_2=p1.curve_id
+        )
+        driving.value = 3.0
+        self.solve()
+
+        ref = sc.add_distance(
+            init=True, curve_id_1=origin.curve_id, curve_id_2=p1.curve_id
+        )
+        ref.is_reference = True
+        self.solve()
+
+        self.assertEqual(self.sketch.get_solver_state().identifier, "OKAY")
+        failed = [c.type for c in sc.all if getattr(c, "failed", False)]
+        self.assertEqual(failed, [], f"reference dim over-constrained: {failed} failed")


### PR DESCRIPTION
Fixes #674.

## Problem
Reference ("measure only", `is_reference`) dimensions are still submitted to solvespace as real driving constraints. They consume a degree of freedom, and when the measured quantity is already implied by other constraints they push the system into `REDUNDANT_OK` — which marks the redundant group `failed`, so the dimensions and unrelated constraints turn red.

## Root cause
Pre-rework, `DimensionalConstraint.py_data()` returned `[]` for reference dims. The native-curves refactor moved constraint submission to `create_slvs_data_from_curves()`, driven from `CurveSolver._init_constraints()` (`curve_solver.py`), and that loop never re-implemented the gate. `grep -rn is_reference curve_solver.py` returned nothing.

## Fix
Skip reference constraints in `_init_constraints`, before submission — once, so it covers every dimensional type (distance/angle/diameter/ratio) rather than re-implementing per constraint. Measurement read-back is unaffected: a reference dim's value comes from `init_props()` (measures geometry directly), independent of the solver.

## Tests
Adds `testing/test_reference_dimension.py`, which reproduces both symptoms and now passes:
- a reference distance on a free segment must not change DOF (was 4→3),
- a reference distance duplicating a driving one must stay `OKAY` with nothing failed (was `REDUNDANT_OK`).

**Why existing tests missed it:** the reference-dimension tests (`test_distance_ref` etc.) only assert the measured *value* reads back correctly — a path (`_get_value` → `init_props()`) that reads geometry directly and never touches the solver. None called `solve()` or checked DOF / solver state / `failed`, so the "must not reach the solver" half of the contract was untested.

Full suite passes (434 tests).