### PR TITLE
Release 0.31.0-rc.2

### DIFF
--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "CAD_Sketcher"
-version = "0.31.0-rc.1"
+version = "0.31.0-rc.2"
 name = "CAD Sketcher"
 tagline = "Parametric, constraint-based geometry sketcher"
 maintainer = "hlorus <dave19924@gmail.com>"


### PR DESCRIPTION
Bumps the manifest to `0.31.0-rc.2` for the re-submission to
extensions.blender.org.

Since rc.1 (the version their reviewer looked at), main has landed every review
finding:
- `_bpy` replaced with public `bpy.ops` (#673)
- dead `operators/test.py` removed (#673)
- undefined names fixed + tree-wide `ruff -F` gate on release (#673, #676)
- `assets.blend` removed for code-built node groups (#675)
- unused `files` permission + dead disk-pickle `save`/`load` removed (#679)

Verified locally: `extension validate` passes and split-platform builds produce
all four zips.

After merge, tag `v0.31.0-rc.2` on the merge commit to trigger the prerelease
build.
