### PR TITLE
Add Create Mesh Output: live, exportable mesh mirror of a sketch

### DIFF
--- a/declarations.py
+++ b/declarations.py
@@ -65,6 +65,7 @@ class Operators(str, Enum):
     DeleteConstraint = "view3d.slvs_delete_constraint"
     DeleteEntity = "view3d.slvs_delete_entity"
     DeleteSketch = "view3d.slvs_delete_sketch"
+    CreateMeshOutput = "view3d.slvs_create_mesh_output"
     MergePoints = "view3d.slvs_merge_points"
     Paste = "view3d.slvs_paste"
     Move = "view3d.slvs_move"

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -26,6 +26,7 @@ modules = [
     "bevel",
     "offset",
     "project_geometry",
+    "mesh_output",
     "set_sketch",
     "delete_entity",
     "delete_sketch",

--- a/operators/mesh_output.py
+++ b/operators/mesh_output.py
@@ -1,0 +1,62 @@
+"""Operator: create a live mesh mirror of the active sketch.
+
+The sketch object is Curves-typed, so its filled/wire output is not usable as a
+real mesh (export, mesh tools). This spawns a companion mesh object carrying the
+``CAD Sketcher To Mesh`` group, which reads the sketch's evaluated geometry, so
+the mesh follows the sketch live and can be exported or applied to bake it.
+"""
+
+import bpy
+from bpy.types import Context, Operator
+from bpy.utils import register_classes_factory
+
+from ..declarations import Operators
+from ..model.sketch_ref import get_active_sketch
+from ..utilities.mesh_output_nodes import (
+    build_mesh_output_node_group,
+    mesh_output_input_ids,
+)
+from .modifiers import set_modifier_input
+
+
+class View3D_OT_slvs_create_mesh_output(Operator):
+    """Create a mesh object that mirrors the active sketch's output, live"""
+
+    bl_idname = Operators.CreateMeshOutput
+    bl_label = "Create Mesh Output"
+    bl_options = {"REGISTER", "UNDO"}
+
+    @classmethod
+    def poll(cls, context: Context) -> bool:
+        sketch = get_active_sketch(context)
+        return sketch is not None and sketch.target_object is not None
+
+    def execute(self, context: Context):
+        sketch = get_active_sketch(context)
+        source = sketch.target_object
+
+        name = f"{sketch.name} Mesh"
+        mesh = bpy.data.meshes.new(name)
+        ob = bpy.data.objects.new(name, mesh)
+        # Match the sketch's transform: Object Info RELATIVE then yields geometry
+        # planar in this object's local space (pleasant to edit) but world-correct.
+        ob.matrix_world = source.matrix_world.copy()
+
+        for collection in source.users_collection or (context.scene.collection,):
+            collection.objects.link(ob)
+
+        group = build_mesh_output_node_group()
+        modifier = ob.modifiers.new("CAD Sketcher Mesh", "NODES")
+        modifier.node_group = group
+        set_modifier_input(modifier, mesh_output_input_ids(group)["Sketch"], source)
+
+        for selected in context.selected_objects:
+            selected.select_set(False)
+        ob.select_set(True)
+        context.view_layer.objects.active = ob
+
+        self.report({"INFO"}, f"Created mesh output '{name}'")
+        return {"FINISHED"}
+
+
+register, unregister = register_classes_factory((View3D_OT_slvs_create_mesh_output,))

--- a/operators/mesh_output.py
+++ b/operators/mesh_output.py
@@ -42,8 +42,10 @@ class View3D_OT_slvs_create_mesh_output(Operator):
         # planar in this object's local space (pleasant to edit) but world-correct.
         ob.matrix_world = source.matrix_world.copy()
 
-        for collection in source.users_collection or (context.scene.collection,):
-            collection.objects.link(ob)
+        # Group the mesh output with its source sketch's collection.
+        from ..utilities.collections import place_with_sketch
+
+        place_with_sketch(ob, source)
 
         group = build_mesh_output_node_group()
         modifier = ob.modifiers.new("CAD Sketcher Mesh", "NODES")

--- a/testing/test_mesh_output.py
+++ b/testing/test_mesh_output.py
@@ -62,6 +62,24 @@ class TestMeshOutput(Sketch2dTestCase):
         # Sketch is on the XY origin plane -> world centroid at (3, 2, 0).
         self.assertLess((centroid - LOCAL_CENTROID).length, 0.2)
 
+    def test_mesh_output_lands_in_the_sketch_collection(self):
+        """The companion groups with its source sketch's collection, not the root."""
+        from ..utilities.collections import sketch_collection
+
+        self._build_rectangle_with_hole()
+        self.solve()
+        refresh_curve_geometry(self.sketch)
+
+        sub = sketch_collection(self.sketch.target_object)
+        self.assertIsNotNone(sub, "sketch is not in a managed collection")
+        ob = self._create_output()
+        self.assertIn(ob.name, sub.objects, "mesh output not grouped with its sketch")
+        self.assertNotIn(
+            ob.name,
+            self.context.scene.collection.objects,
+            "mesh output should not sit loose in the scene root",
+        )
+
     def test_mesh_output_follows_a_transformed_sketch(self):
         """On a non-XY-placed sketch the mesh lands at the correct world position.
 

--- a/testing/test_mesh_output.py
+++ b/testing/test_mesh_output.py
@@ -1,0 +1,93 @@
+"""Mesh output: a companion mesh object mirrors the active sketch's fill.
+
+The sketch is a Curves object; its filled/wire output can't be read as a mesh.
+``Create Mesh Output`` spawns a mesh object with the ``CAD Sketcher To Mesh``
+group (Object Info -> Realize), which surfaces the sketch's evaluated geometry as
+a real, readable, world-correct mesh -- including when the sketch sits on a
+non-XY workplane (the transform must be handled by Object Info's RELATIVE space).
+"""
+
+import math
+
+import bpy
+from mathutils import Matrix, Vector
+
+from ..utilities.curve_data import refresh_curve_geometry
+from .utils import Sketch2dTestCase
+
+RING_AREA = 6 * 4 - math.pi * 1.0**2
+LOCAL_CENTROID = Vector((3.0, 2.0, 0.0))  # rectangle 0..6 x 0..4 centre
+
+
+class TestMeshOutput(Sketch2dTestCase):
+    def _build_rectangle_with_hole(self):
+        corners = [(0, 0), (6, 0), (6, 4), (0, 4)]
+        pts = [self.add_point(c) for c in corners]
+        for i in range(4):
+            self.add_line(pts[i], pts[(i + 1) % 4])
+        self.add_circle(self.add_point((3, 2)), 1.0)
+
+    def _create_output(self):
+        before = set(self.context.scene.objects)
+        result = bpy.ops.view3d.slvs_create_mesh_output()
+        self.assertIn("FINISHED", result)
+        new = [o for o in self.context.scene.objects if o not in before]
+        self.assertEqual(len(new), 1, "operator must create exactly one object")
+        return new[0]
+
+    def _eval_mesh(self, ob):
+        dg = self.context.evaluated_depsgraph_get()
+        ev = ob.evaluated_get(dg)
+        me = ev.to_mesh()
+        area = sum(p.area for p in me.polygons)
+        nfaces = len(me.polygons)
+        world_centroid = ob.matrix_world @ (
+            sum((v.co for v in me.vertices), Vector()) / max(1, len(me.vertices))
+        )
+        ev.to_mesh_clear()
+        return nfaces, area, world_centroid
+
+    def test_mesh_output_is_a_readable_ring(self):
+        """The companion object is a real mesh carrying the ring (to_mesh works)."""
+        self._build_rectangle_with_hole()
+        self.solve()
+        refresh_curve_geometry(self.sketch)
+
+        ob = self._create_output()
+        self.assertEqual(ob.type, "MESH")
+        nfaces, area, centroid = self._eval_mesh(ob)
+
+        self.assertGreater(nfaces, 0, "mesh output has no faces (fill not surfaced)")
+        self.assertAlmostEqual(area, RING_AREA, delta=0.2)
+        # Sketch is on the XY origin plane -> world centroid at (3, 2, 0).
+        self.assertLess((centroid - LOCAL_CENTROID).length, 0.2)
+
+    def test_mesh_output_follows_a_transformed_sketch(self):
+        """On a non-XY-placed sketch the mesh lands at the correct world position.
+
+        Object Info RELATIVE plus matching the object transform must reproduce the
+        sketch's world placement, not leave the geometry at the origin or rotated.
+        """
+        self._build_rectangle_with_hole()
+        self.solve()
+        refresh_curve_geometry(self.sketch)
+
+        # Tilt + offset the sketch as if drawn on an arbitrary workplane.
+        transform = Matrix.Translation((10, -5, 3)) @ Matrix.Rotation(
+            math.radians(45), 4, "X"
+        )
+        self.sketch.target_object.matrix_world = transform
+
+        ob = self._create_output()
+        nfaces, area, centroid = self._eval_mesh(ob)
+
+        self.assertGreater(nfaces, 0)
+        # Rotation preserves area.
+        self.assertAlmostEqual(area, RING_AREA, delta=0.2)
+        # The fill centroid must map through the sketch's transform.
+        expected = transform @ LOCAL_CENTROID
+        self.assertLess(
+            (centroid - expected).length,
+            0.2,
+            f"mesh output at {centroid[:]}, expected {expected[:]}",
+        )

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -38,6 +38,9 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
 
         layout.operator(declarations.Operators.MergePoints)
         layout.operator(declarations.Operators.ProjectGeometry, icon="MOD_SHRINKWRAP")
+        layout.operator(
+            declarations.Operators.CreateMeshOutput, icon="OUTLINER_OB_MESH"
+        )
 
         layout.separator()
         prefs = preferences.get_prefs()

--- a/utilities/collections.py
+++ b/utilities/collections.py
@@ -85,6 +85,24 @@ def nest_workplane(workplane, sketch_obj):
     return sub
 
 
+def sketch_collection(sketch_obj):
+    """The per-sketch collection ``sketch_obj`` lives in, or None."""
+    return next((c for c in sketch_obj.users_collection if c.get(_SKETCH_MARKER)), None)
+
+
+def place_with_sketch(obj, sketch_obj):
+    """Group a companion object (e.g. a mesh output) with its source sketch.
+
+    Links ``obj`` into the sketch's own collection so it stays with the part;
+    falls back to the scene collection if the sketch isn't in a managed
+    collection (e.g. a legacy file). Returns the collection it linked into.
+    """
+    target = sketch_collection(sketch_obj) or bpy.context.scene.collection
+    _clear_object_collections(obj)
+    target.objects.link(obj)
+    return target
+
+
 def link_sketch_object(obj, scene):
     """Put a sketch's curve object in its own scene-level collection.
 

--- a/utilities/mesh_output_nodes.py
+++ b/utilities/mesh_output_nodes.py
@@ -1,0 +1,69 @@
+"""Geometry Nodes group that surfaces a sketch's evaluated mesh on a mesh object.
+
+A sketch lives on a Curves-type object whose ``CAD Sketcher Convert`` modifier
+already outputs a mesh (wire, or a filled n-gon surface). But a Curves object
+cannot be read as a mesh -- ``to_mesh`` / exporters / mesh edit tools all refuse
+it regardless of what its modifier emits. Placed on a companion *mesh* object,
+this group pulls the sketch's evaluated geometry through an ``Object Info`` node,
+giving a real, non-destructive mesh that follows the sketch live, exports
+normally, and can be applied to bake a static editable mesh.
+"""
+
+import bpy
+
+MESH_OUTPUT_NODE_GROUP = "CAD Sketcher To Mesh"
+MESH_OUTPUT_VERSION = 1
+
+
+def build_mesh_output_node_group(name: str = MESH_OUTPUT_NODE_GROUP):
+    """Build the sketch-to-mesh group (idempotent, version-gated).
+
+    Reuses an existing group of the same name, rebuilding it in place when the
+    stored version is stale so bound modifiers upgrade without rebinding.
+    """
+    ng = bpy.data.node_groups.get(name)
+    if ng is None:
+        ng = bpy.data.node_groups.new(name, "GeometryNodeTree")
+
+    # Offer it in the Add Modifier > Geometry Nodes picker (off by default for
+    # API-created groups).
+    ng.is_modifier = True
+
+    if ng.get("cad_mesh_output_version") == MESH_OUTPUT_VERSION:
+        return ng
+    ng.nodes.clear()
+    ng.links.clear()
+    ng.interface.clear()
+
+    iface = ng.interface
+    iface.new_socket("Sketch", in_out="INPUT", socket_type="NodeSocketObject")
+    iface.new_socket("Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry")
+
+    nodes, links = ng.nodes, ng.links
+    gi = nodes.new("NodeGroupInput")
+    go = nodes.new("NodeGroupOutput")
+
+    # Pull the sketch's *evaluated* geometry (its convert modifier's mesh output)
+    # in this object's local space. Matching the mesh object's transform to the
+    # sketch's keeps the geometry planar in local coordinates yet world-correct.
+    info = nodes.new("GeometryNodeObjectInfo")
+    info.transform_space = "RELATIVE"
+    links.new(gi.outputs["Sketch"], info.inputs["Object"])
+
+    # A mesh target yields realized geometry already; realize regardless so an
+    # instanced source still resolves to real mesh data downstream.
+    realize = nodes.new("GeometryNodeRealizeInstances")
+    links.new(info.outputs["Geometry"], realize.inputs["Geometry"])
+    links.new(realize.outputs["Geometry"], go.inputs["Geometry"])
+
+    ng["cad_mesh_output_version"] = MESH_OUTPUT_VERSION
+    return ng
+
+
+def mesh_output_input_ids(node_group) -> dict:
+    """Map ``{socket name: identifier}`` for the group's inputs."""
+    return {
+        s.name: s.identifier
+        for s in node_group.interface.items_tree
+        if getattr(s, "in_out", "") == "INPUT"
+    }


### PR DESCRIPTION
A **Create Mesh Output** tool that spawns a companion **mesh** object mirroring
the active sketch live — giving a real, exportable, `to_mesh`-able mesh that a
Curves-typed sketch object can't provide on its own.

## What

- `CAD Sketcher To Mesh` group: `Object Info(sketch, Relative) → Realize → Output`.
- The object's transform is matched to the sketch, so the pulled geometry is
  planar in local space yet lands in the correct world position.
- The sketch is bound through the modifier's Object input (version-aware
  `set_modifier_input`).

Result: a live, exportable mesh that follows the sketch, respects its Fill/wire
setting, carries the generated vertex/face ids through, and can be **Applied** to
bake a static editable mesh.

## Integrates with managed collections (#685)

Rebased on the merged collection work. The companion is grouped into its **source
sketch's collection** via `place_with_sketch`, so the consumable stays with its
part (falls back to the scene collection for a legacy/unmanaged sketch).

## Tests

- `test_mesh_output_is_a_readable_ring` — companion is a `MESH`, `to_mesh()`
  works, carries the correct ring.
- `test_mesh_output_lands_in_the_sketch_collection` — grouped with its sketch,
  not loose in the scene root.
- `test_mesh_output_follows_a_transformed_sketch` — correct world position on a
  non-XY workplane.
- Full suite: `Ran 456 tests ... OK` (2 pre-existing expected failures).

## Follow-ups (not in this PR)

- Rename the mesh when the sketch is renamed.
- Deleting the sketch leaves the modifier's Object input empty (empty mesh, no
  crash) — no active cleanup.
