### PR TITLE
Add Sketch: pick faces on curve-object sketches again

### DIFF
--- a/stateful_operator/utilities/geometry.py
+++ b/stateful_operator/utilities/geometry.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from typing import Optional
 
 from bpy.types import Context, Object, RegionView3D
@@ -26,6 +27,53 @@ def get_scale_from_pos(co: Vector, rv3d: RegionView3D) -> Vector:
 
 def get_evaluated_obj(context: Context, object: Object):
     return object.evaluated_get(context.evaluated_depsgraph_get())
+
+
+def instance_origin(inst) -> Optional[Object]:
+    """Original object a depsgraph instance belongs to (its emitter, if instanced)."""
+    if inst.is_instance and inst.parent is not None:
+        return inst.parent.original
+    return inst.object.original
+
+
+@contextmanager
+def evaluated_surface_mesh(context: Context, ob: Object):
+    """Yield ``(mesh, matrix_world)`` for ``ob``'s evaluated surface, else ``(None, None)``.
+
+    A mesh object exposes its evaluated mesh directly on ``obj_eval.data``. A
+    Curves object whose geometry-nodes modifier outputs a mesh (an extruded or
+    filled CAD Sketcher sketch) exposes that mesh only as a depsgraph *instance*,
+    not on the evaluated object, and ``to_mesh`` on the evaluated object raises
+    "does not have geometry data". So fall back to scanning instances. Any
+    temporary mesh created for the instance case is freed on exit, so callers
+    must use the yielded mesh only inside the ``with`` block.
+    """
+    depsgraph = context.evaluated_depsgraph_get()
+    obj_eval = ob.evaluated_get(depsgraph)
+    data = obj_eval.data
+    if hasattr(data, "polygons"):
+        yield data, obj_eval.matrix_world
+        return
+
+    owner = None
+    try:
+        for inst in depsgraph.object_instances:
+            if instance_origin(inst) != ob.original:
+                continue
+            try:
+                mesh = inst.object.to_mesh()
+            except RuntimeError:
+                mesh = None
+            if mesh is not None and len(mesh.polygons):
+                owner = inst.object
+                yield mesh, inst.matrix_world.copy()
+                return
+            if mesh is not None:
+                inst.object.to_mesh_clear()
+        yield None, None
+    finally:
+        if owner is not None:
+            owner.to_mesh_clear()
 
 
 def get_mesh_element(
@@ -72,18 +120,6 @@ def get_mesh_element(
     if not (vertex or edge or face):
         return ob, Object, None
 
-    obj_eval = get_evaluated_obj(context, ob)
-
-    me = obj_eval.data
-    if not hasattr(me, "polygons"):
-        return None, None, None
-
-    closest_type = ""
-    closest_dist = None
-
-    loc = obj_eval.matrix_world.inverted() @ loc
-    polygon = me.polygons[face_index]
-
     def get_closest(deltas):
         index_min = min(range(len(deltas)), key=deltas.__getitem__)
         if deltas[index_min] > threshold:
@@ -97,34 +133,48 @@ def get_mesh_element(
             return True
         return False
 
-    if vertex:
-        i, dist = get_closest(
-            [(me.vertices[i].co - loc).length for i in polygon.vertices]
-        )
-        if i is not None:
-            closest_type = "VERTEX"
-            closest_index = polygon.vertices[i]
-            closest_dist = dist
+    # Read the evaluated surface mesh. For a Curves sketch (its extrude/fill
+    # modifier outputs a mesh) that mesh lives on a depsgraph instance rather
+    # than obj_eval.data, so go through the shared helper instead of reading
+    # .data directly -- otherwise curve-object faces can't be picked.
+    with evaluated_surface_mesh(context, ob) as (me, mw):
+        if me is None or face_index >= len(me.polygons):
+            return None, None, None
 
-    if edge:
-        face_edge_map = {ek: me.edges[i] for i, ek in enumerate(me.edge_keys)}
-        i, dist = get_closest(
-            [
-                (((me.vertices[start].co + me.vertices[end].co) / 2) - loc).length
-                for start, end in polygon.edge_keys
-            ]
-        )
-        if i is not None and is_closer(dist, closest_dist):
-            closest_type = "EDGE"
-            closest_index = face_edge_map[polygon.edge_keys[i]].index
-            closest_dist = dist
+        closest_type = ""
+        closest_dist = None
 
-    if face:
-        # Check if face midpoint is closest
-        if is_closer((polygon.center - loc).length, closest_dist):
-            closest_type = "FACE"
-            closest_index = face_index
+        loc_local = mw.inverted() @ loc
+        polygon = me.polygons[face_index]
 
-    if closest_type:
-        return ob, closest_type, closest_index
-    return ob, Object, None
+        if vertex:
+            i, dist = get_closest(
+                [(me.vertices[i].co - loc_local).length for i in polygon.vertices]
+            )
+            if i is not None:
+                closest_type = "VERTEX"
+                closest_index = polygon.vertices[i]
+                closest_dist = dist
+
+        if edge:
+            face_edge_map = {ek: me.edges[i] for i, ek in enumerate(me.edge_keys)}
+            i, dist = get_closest(
+                [
+                    (((me.vertices[s].co + me.vertices[e].co) / 2) - loc_local).length
+                    for s, e in polygon.edge_keys
+                ]
+            )
+            if i is not None and is_closer(dist, closest_dist):
+                closest_type = "EDGE"
+                closest_index = face_edge_map[polygon.edge_keys[i]].index
+                closest_dist = dist
+
+        if face:
+            # Check if face midpoint is closest
+            if is_closer((polygon.center - loc_local).length, closest_dist):
+                closest_type = "FACE"
+                closest_index = face_index
+
+        if closest_type:
+            return ob, closest_type, closest_index
+        return ob, Object, None

--- a/testing/test_curve_face_pick.py
+++ b/testing/test_curve_face_pick.py
@@ -1,0 +1,70 @@
+"""Add Sketch on a curve-object face.
+
+A CAD Sketcher sketch (and its extrude/fill result) is a Curves object whose
+geometry-nodes modifier outputs a mesh. That mesh surfaces only as a depsgraph
+instance, not on ``obj_eval.data``, so the face-picking path used to bail on it
+(curve-object faces became unpickable). These lock in that the shared
+``evaluated_surface_mesh`` helper and ``face_workplane_matrix`` read that mesh
+for a Curves object, and still work for a plain mesh object.
+"""
+
+import unittest
+
+import bpy
+
+from ..stateful_operator.utilities.geometry import evaluated_surface_mesh
+from ..utilities.geometry import face_bounds_in_plane, face_workplane_matrix
+
+
+def _curves_object_with_mesh_grid(z=1.0):
+    """A Curves object whose GN modifier outputs a 2x2 grid at height ``z``."""
+    cu = bpy.data.hair_curves.new("C")
+    ob = bpy.data.objects.new("CurveObj", cu)
+    bpy.context.scene.collection.objects.link(ob)
+
+    ng = bpy.data.node_groups.new("GN", "GeometryNodeTree")
+    ng.interface.new_socket(
+        "Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry"
+    )
+    out = ng.nodes.new("NodeGroupOutput")
+    grid = ng.nodes.new("GeometryNodeMeshGrid")
+    grid.inputs["Size X"].default_value = 2.0
+    grid.inputs["Size Y"].default_value = 2.0
+    tr = ng.nodes.new("GeometryNodeTransform")
+    tr.inputs["Translation"].default_value = (0.0, 0.0, z)
+    ng.links.new(grid.outputs["Mesh"], tr.inputs["Geometry"])
+    ng.links.new(tr.outputs["Geometry"], out.inputs[0])
+    ob.modifiers.new("GN", "NODES").node_group = ng
+    return ob
+
+
+class TestCurveFacePick(unittest.TestCase):
+    def tearDown(self):
+        bpy.ops.wm.read_homefile(use_empty=True)
+
+    def test_evaluated_surface_mesh_reads_curves_instance_mesh(self):
+        ob = _curves_object_with_mesh_grid()
+        with evaluated_surface_mesh(bpy.context, ob) as (mesh, mw):
+            self.assertIsNotNone(mesh, "no evaluated mesh for the Curves object")
+            self.assertEqual(len(mesh.polygons), 4)
+
+    def test_face_workplane_matrix_on_curve_face(self):
+        ob = _curves_object_with_mesh_grid(z=1.0)
+        mat = face_workplane_matrix(bpy.context, ob, 0)
+        # Grid lies in a plane at z=1 with a +Z normal.
+        normal = mat.col[2].to_3d()
+        self.assertAlmostEqual(abs(normal.z), 1.0, places=4)
+        self.assertAlmostEqual(mat.translation.z, 1.0, places=4)
+        # Bounds are finite (the face has real extent).
+        bounds = face_bounds_in_plane(bpy.context, ob, 0, mat)
+        self.assertLess(bounds[0], bounds[2])
+        self.assertLess(bounds[1], bounds[3])
+
+    def test_mesh_object_still_works(self):
+        bpy.ops.mesh.primitive_plane_add(location=(5.0, 0.0, 0.0))
+        plane = bpy.context.active_object
+        with evaluated_surface_mesh(bpy.context, plane) as (mesh, mw):
+            self.assertEqual(len(mesh.polygons), 1)
+        mat = face_workplane_matrix(bpy.context, plane, 0)
+        self.assertAlmostEqual(abs(mat.col[2].to_3d().z), 1.0, places=4)
+        self.assertAlmostEqual(mat.translation.x, 5.0, places=4)

--- a/utilities/boolean_targets.py
+++ b/utilities/boolean_targets.py
@@ -51,15 +51,13 @@ def _world_geometry_map(depsgraph, wanted):
     have geometry data" there). Objects yielding no faces (a flat, unextruded
     profile) are simply absent from the map.
     """
+    from ..stateful_operator.utilities.geometry import instance_origin
+
     wanted = set(wanted)
     accum = {}  # origin object -> ([world verts], [poly index tuples])
     for inst in depsgraph.object_instances:
         ob = inst.object
-        origin = (
-            inst.parent.original
-            if inst.is_instance and inst.parent is not None
-            else ob.original
-        )
+        origin = instance_origin(inst)
         if origin not in wanted:
             continue
         try:

--- a/utilities/geometry.py
+++ b/utilities/geometry.py
@@ -7,43 +7,39 @@ from mathutils import Matrix, Vector
 
 
 def face_workplane_matrix(context, ob, face_index):
-    """World matrix of the workplane a mesh face would produce.
+    """World matrix of the workplane a face would produce.
 
     Shared by the Add Sketch operator (creating the empty) and the workplane
-    gizmo (previewing it on hover) so both agree exactly.
+    gizmo (previewing it on hover) so both agree exactly. Works for mesh objects
+    and for Curves sketches (whose extrude/fill mesh is on a depsgraph instance).
     """
-    from ..stateful_operator.utilities.geometry import get_evaluated_obj
+    from ..stateful_operator.utilities.geometry import evaluated_surface_mesh
 
-    eval_ob = get_evaluated_obj(context, ob)
-    mesh = eval_ob.data
-    face = mesh.polygons[face_index]
-
-    quat = get_face_orientation(mesh, face)
-    quat.rotate(ob.matrix_world)
-    pos = ob.matrix_world @ face.center
-    return Matrix.LocRotScale(pos, quat, None)
+    with evaluated_surface_mesh(context, ob) as (mesh, mw):
+        face = mesh.polygons[face_index]
+        quat = get_face_orientation(mesh, face)
+        quat.rotate(mw)
+        pos = mw @ face.center
+        return Matrix.LocRotScale(pos, quat, None)
 
 
 def face_bounds_in_plane(context, ob, face_index, mat):
-    """2D bounding box of a mesh face in a workplane's local frame.
+    """2D bounding box of a face in a workplane's local frame.
 
     ``mat`` is the plane's world matrix (see :func:`face_workplane_matrix`).
     Returns (min_x, min_y, max_x, max_y).
     """
-    from ..stateful_operator.utilities.geometry import get_evaluated_obj
+    from ..stateful_operator.utilities.geometry import evaluated_surface_mesh
 
-    eval_ob = get_evaluated_obj(context, ob)
-    mesh = eval_ob.data
-    face = mesh.polygons[face_index]
-
-    inv = mat.inverted()
-    mw = ob.matrix_world
-    xs, ys = [], []
-    for vi in face.vertices:
-        local = inv @ (mw @ mesh.vertices[vi].co)
-        xs.append(local.x)
-        ys.append(local.y)
-    return min(xs), min(ys), max(xs), max(ys)
+    with evaluated_surface_mesh(context, ob) as (mesh, mw):
+        face = mesh.polygons[face_index]
+        inv = mat.inverted()
+        xs, ys = [], []
+        for vi in face.vertices:
+            local = inv @ (mw @ mesh.vertices[vi].co)
+            xs.append(local.x)
+            ys.append(local.y)
+        return min(xs), min(ys), max(xs), max(ys)
 
 
 def orientation_from_normal(normal):


### PR DESCRIPTION
## Problem

Add Sketch could not pick faces on a curve-object sketch (a filled/extruded
CAD Sketcher sketch). Those are Curves objects whose geometry-nodes modifier
outputs a mesh, and that mesh surfaces only as a **depsgraph instance**, not on
`obj_eval.data`. The face path read `obj_eval.data.polygons`, which a Curves
object doesn't have, so the pick returned nothing. Regular mesh objects still
worked.

`scene.ray_cast` does hit the generated faces (returns the object + a valid
`face_index`), it's the follow-up polygon lookup that failed. The correct source
was already known in the codebase: `boolean_targets._world_geometry_map` reads a
Curves object's evaluated mesh from `depsgraph.object_instances`.

## Fix

Add a shared `evaluated_surface_mesh(context, ob)` context manager
(`stateful_operator/utilities/geometry.py`) that yields `(mesh, matrix_world)`
for any object: `obj_eval.data` for a real mesh, or the depsgraph-instance mesh
for a Curves object (freeing the temporary mesh on exit). Route the three
pick/preview helpers through it:

- `get_mesh_element` (the pick)
- `face_workplane_matrix` (the empty the sketch is parented to)
- `face_bounds_in_plane` (the gizmo hover preview)

Generalization: extracted a small `instance_origin(inst)` resolver and pointed
`boolean_targets` at it too. I deliberately did **not** fold the boolean batch
map into the per-object helper, it's a single-pass scan over many targets, and a
per-object helper would turn one depsgraph traversal into N.

## Tests

New `testing/test_curve_face_pick.py`: the helper reads a Curves-GN object's
instance mesh, `face_workplane_matrix`/`face_bounds_in_plane` produce the right
plane on a curve face, and a plain mesh object still works.

Full suite passes (441; 2 pre-existing expected failures).

## Note

Face workplanes created on a curve face are plain fixed workplanes (not
anchored to a persistent face id the way mesh faces are, since a Curves object
has no original mesh face to stamp). Following the curve as it changes could be
a later enhancement.
