### PR TITLE
Add generic Fillet modifier (Mesh Bevel; 2D + 3D) for sketch output (draft)

### DIFF
--- a/declarations.py
+++ b/declarations.py
@@ -65,6 +65,7 @@ class Operators(str, Enum):
     DeleteConstraint = "view3d.slvs_delete_constraint"
     DeleteEntity = "view3d.slvs_delete_entity"
     DeleteSketch = "view3d.slvs_delete_sketch"
+    AddFillet = "view3d.slvs_add_fillet"
     MergePoints = "view3d.slvs_merge_points"
     Paste = "view3d.slvs_paste"
     Move = "view3d.slvs_move"

--- a/operators/__init__.py
+++ b/operators/__init__.py
@@ -26,6 +26,7 @@ modules = [
     "bevel",
     "offset",
     "project_geometry",
+    "fillet",
     "set_sketch",
     "delete_entity",
     "delete_sketch",

--- a/operators/fillet.py
+++ b/operators/fillet.py
@@ -1,0 +1,47 @@
+"""Operator: add the generic ``CAD Sketcher Fillet`` modifier to the active object.
+
+The fillet is a plain geometry-nodes modifier that rounds the corners of an
+object's output geometry. This just adds and selects it on the active object (a
+sketch's curves object, a mesh output, or any mesh/curve); all tuning happens on
+the modifier's Radius / Count / Fill inputs.
+"""
+
+from bpy.props import FloatProperty
+from bpy.types import Context, Operator
+from bpy.utils import register_classes_factory
+
+from ..declarations import Operators
+from ..utilities.fillet_nodes import build_fillet_node_group, fillet_input_ids
+from .modifiers import set_modifier_input
+
+
+class View3D_OT_slvs_add_fillet(Operator):
+    """Round the corners of the active object's output with a Fillet modifier"""
+
+    bl_idname = Operators.AddFillet
+    bl_label = "Add Fillet"
+    bl_options = {"REGISTER", "UNDO"}
+
+    radius: FloatProperty(
+        name="Radius",
+        description="Corner radius",
+        default=0.1,
+        min=0.0,
+        subtype="DISTANCE",
+    )
+
+    @classmethod
+    def poll(cls, context: Context) -> bool:
+        ob = context.object
+        return ob is not None and ob.type in {"MESH", "CURVES", "CURVE"}
+
+    def execute(self, context: Context):
+        ob = context.object
+        group = build_fillet_node_group()
+        modifier = ob.modifiers.new("CAD Sketcher Fillet", "NODES")
+        modifier.node_group = group
+        set_modifier_input(modifier, fillet_input_ids(group)["Radius"], self.radius)
+        return {"FINISHED"}
+
+
+register, unregister = register_classes_factory((View3D_OT_slvs_add_fillet,))

--- a/operators/fillet.py
+++ b/operators/fillet.py
@@ -22,9 +22,9 @@ class View3D_OT_slvs_add_fillet(Operator):
     bl_label = "Add Fillet"
     bl_options = {"REGISTER", "UNDO"}
 
-    radius: FloatProperty(
-        name="Radius",
-        description="Corner radius",
+    amount: FloatProperty(
+        name="Amount",
+        description="Fillet width",
         default=0.1,
         min=0.0,
         subtype="DISTANCE",
@@ -40,7 +40,7 @@ class View3D_OT_slvs_add_fillet(Operator):
         group = build_fillet_node_group()
         modifier = ob.modifiers.new("CAD Sketcher Fillet", "NODES")
         modifier.node_group = group
-        set_modifier_input(modifier, fillet_input_ids(group)["Radius"], self.radius)
+        set_modifier_input(modifier, fillet_input_ids(group)["Amount"], self.amount)
         return {"FINISHED"}
 
 

--- a/testing/test_fillet_nodes.py
+++ b/testing/test_fillet_nodes.py
@@ -1,0 +1,179 @@
+"""The generic CAD Sketcher Fillet node group.
+
+Rounds the corners of any curve/mesh-wire geometry: Mesh to Curve -> Fillet Curve
+-> (Fill Curve | wire). Independent of sketch data, so these tests drive it on
+plain meshes; a rounded corner drops the filled area below the sharp shape and
+raises the boundary vertex count, and the ``Fill`` toggle switches surface/wire.
+"""
+
+import math
+import unittest
+from unittest import TestCase
+
+import bpy
+
+
+def _loops_mesh(with_hole):
+    """A rectangle loop (8 x 4), optionally with an inner circle loop (r=1)."""
+    verts, edges = [], []
+    rect = [(-4, -2, 0), (4, -2, 0), (4, 2, 0), (-4, 2, 0)]
+    verts += rect
+    edges += [(i, (i + 1) % 4) for i in range(4)]
+    if with_hole:
+        n = 48
+        base = len(verts)
+        verts += [
+            (math.cos(2 * math.pi * k / n), math.sin(2 * math.pi * k / n), 0)
+            for k in range(n)
+        ]
+        edges += [(base + k, base + (k + 1) % n) for k in range(n)]
+    me = bpy.data.meshes.new("loops")
+    me.from_pydata(verts, edges, [])
+    me.update()
+    ob = bpy.data.objects.new("loops", me)
+    bpy.context.scene.collection.objects.link(ob)
+    return ob
+
+
+class TestFilletNodes(TestCase):
+    def _add_fillet(self, ob, radius, fill=True, count=6):
+        from ..operators.modifiers import set_modifier_input
+        from ..utilities.fillet_nodes import build_fillet_node_group, fillet_input_ids
+
+        group = build_fillet_node_group()
+        mod = ob.modifiers.new("fillet", "NODES")
+        mod.node_group = group
+        ids = fillet_input_ids(group)
+        set_modifier_input(mod, ids["Radius"], radius)
+        set_modifier_input(mod, ids["Count"], count)
+        set_modifier_input(mod, ids["Fill"], fill)
+        return mod
+
+    def _eval(self, ob):
+        dg = bpy.context.evaluated_depsgraph_get()
+        ev = ob.evaluated_get(dg)
+        me = ev.to_mesh()
+        area = sum(p.area for p in me.polygons)
+        nfaces = len(me.polygons)
+        nverts = len(me.vertices)
+        ev.to_mesh_clear()
+        return nfaces, nverts, area
+
+    def test_group_builds_and_is_a_modifier(self):
+        from ..utilities.fillet_nodes import build_fillet_node_group
+
+        group = build_fillet_node_group("test_fillet_build")
+        try:
+            self.assertTrue(group.is_modifier)
+            ids = {s.name for s in group.interface.items_tree}
+            for expected in ("Radius", "Count", "Fill", "Geometry"):
+                self.assertIn(expected, ids)
+            kinds = {n.bl_idname for n in group.nodes}
+            self.assertIn("GeometryNodeFilletCurve", kinds)
+            self.assertIn("GeometryNodeFillCurve", kinds)
+        finally:
+            bpy.data.node_groups.remove(group)
+
+    def test_fillet_rounds_corners_and_keeps_hole(self):
+        ob = _loops_mesh(with_hole=True)
+        try:
+            self._add_fillet(ob, 0.0)
+            nf0, nv0, a0 = self._eval(ob)
+            ob.modifiers.clear()
+            self._add_fillet(ob, 1.0)
+            nf1, nv1, a1 = self._eval(ob)
+
+            # Still a ring (two n-gon faces = outer + hole), rounded corners cut
+            # a little area and add boundary points.
+            self.assertEqual(nf0, 2)
+            self.assertEqual(nf1, 2, "fillet must not destroy the hole")
+            self.assertLess(a1, a0, "rounded corners should reduce the filled area")
+            self.assertGreater(nv1, nv0, "rounded corners add boundary vertices")
+        finally:
+            bpy.data.objects.remove(ob, do_unlink=True)
+
+    def test_fill_toggle_switches_surface_and_wire(self):
+        ob = _loops_mesh(with_hole=False)
+        try:
+            self._add_fillet(ob, 0.5, fill=True)
+            faces_filled, _, area = self._eval(ob)
+            ob.modifiers.clear()
+            self._add_fillet(ob, 0.5, fill=False)
+            faces_wire, verts_wire, _ = self._eval(ob)
+
+            self.assertGreater(faces_filled, 0)
+            self.assertGreater(area, 0.0)
+            self.assertEqual(faces_wire, 0, "Fill off must emit a wire (no faces)")
+            self.assertGreater(verts_wire, 0)
+        finally:
+            bpy.data.objects.remove(ob, do_unlink=True)
+
+
+@unittest.skipIf(bpy.app.version < (5, 2, 0), "requires Blender 5.2+")
+class TestFilletOnSketch(TestCase):
+    """Integration: the fillet stacks on a real sketch's convert output."""
+
+    def test_fillet_after_convert_rounds_the_sketch(self):
+        from ..curve_solver import solve_system
+
+        # Reuse the 2D sketch harness inline to build a rectangle + circle.
+        from ..model.curve_ref import CircleRef, LineRef, PointRef
+        from ..model.sketch_ref import (
+            Sketch,
+            set_active_sketch,
+            stamp_sketch_props,
+        )
+        from ..operators.modifiers import set_modifier_input
+        from ..utilities.curve_data import (
+            ensure_sketch_curve_object,
+            refresh_curve_geometry,
+        )
+        from ..utilities.fillet_nodes import (
+            build_fillet_node_group,
+            fillet_input_ids,
+        )
+        from .utils import Sketch2dTestCase  # noqa: F401  (ensure test env)
+
+        scene = bpy.data.scenes.new("fillet_sketch")
+        bpy.context.window.scene = scene
+        ctx = bpy.context
+        ents = scene.sketcher.entities
+        ents.ensure_origin_elements(ctx)
+        esk = ents.add_sketch(ents.origin_plane_XY)
+        ensure_sketch_curve_object(esk)
+        stamp_sketch_props(esk.target_object)
+        sketch = Sketch(esk.target_object)
+        set_active_sketch(ctx, esk.target_object)
+
+        corners = [(-4, -2), (4, -2), (4, 2), (-4, 2)]
+        pts = [PointRef.create(sketch, c) for c in corners]
+        for i in range(4):
+            LineRef.create(sketch, pts[i], pts[(i + 1) % 4])
+        CircleRef.create(sketch, PointRef.create(sketch, (0, 0)), 1.0)
+        self.assertTrue(solve_system(ctx))
+        refresh_curve_geometry(sketch)
+
+        ob = sketch.target_object
+
+        def area():
+            dup = ob.copy()
+            dup.data = ob.data.copy()
+            scene.collection.objects.link(dup)
+            for o in scene.collection.objects:
+                o.select_set(False)
+            dup.select_set(True)
+            ctx.view_layer.objects.active = dup
+            bpy.ops.object.convert(target="MESH")
+            a = sum(p.area for p in dup.data.polygons)
+            bpy.data.objects.remove(dup, do_unlink=True)
+            return a
+
+        sharp = area()
+        group = build_fillet_node_group()
+        mod = ob.modifiers.new("CAD Sketcher Fillet", "NODES")
+        mod.node_group = group
+        set_modifier_input(mod, fillet_input_ids(group)["Radius"], 1.0)
+        rounded = area()
+
+        self.assertLess(rounded, sharp, "fillet did not round the sketch output")
+        self.assertGreater(rounded, 0.0)

--- a/testing/test_fillet_nodes.py
+++ b/testing/test_fillet_nodes.py
@@ -1,42 +1,28 @@
-"""The generic CAD Sketcher Fillet node group.
+"""The generic CAD Sketcher Fillet node group (Mesh Bevel based).
 
-Rounds the corners of any curve/mesh-wire geometry: Mesh to Curve -> Fillet Curve
--> (Fill Curve | wire). Independent of sketch data, so these tests drive it on
-plain meshes; a rounded corner drops the filled area below the sharp shape and
-raises the boundary vertex count, and the ``Fill`` toggle switches surface/wire.
+Rounds corners/edges of any mesh: a flat profile's corners (Vertices) or a 3D
+solid's edges (Edges), auto-detected, with a Selection field for specific
+elements. Independent of sketch data, so most tests drive it on plain meshes.
 """
 
-import math
 import unittest
 from unittest import TestCase
 
 import bpy
 
 
-def _loops_mesh(with_hole):
-    """A rectangle loop (8 x 4), optionally with an inner circle loop (r=1)."""
-    verts, edges = [], []
-    rect = [(-4, -2, 0), (4, -2, 0), (4, 2, 0), (-4, 2, 0)]
-    verts += rect
-    edges += [(i, (i + 1) % 4) for i in range(4)]
-    if with_hole:
-        n = 48
-        base = len(verts)
-        verts += [
-            (math.cos(2 * math.pi * k / n), math.sin(2 * math.pi * k / n), 0)
-            for k in range(n)
-        ]
-        edges += [(base + k, base + (k + 1) % n) for k in range(n)]
-    me = bpy.data.meshes.new("loops")
-    me.from_pydata(verts, edges, [])
+def _flat_quad():
+    """A single flat filled n-gon (like a sketch fill)."""
+    me = bpy.data.meshes.new("quad")
+    me.from_pydata([(-2, -1, 0), (2, -1, 0), (2, 1, 0), (-2, 1, 0)], [], [(0, 1, 2, 3)])
     me.update()
-    ob = bpy.data.objects.new("loops", me)
+    ob = bpy.data.objects.new("quad", me)
     bpy.context.scene.collection.objects.link(ob)
     return ob
 
 
 class TestFilletNodes(TestCase):
-    def _add_fillet(self, ob, radius, fill=True, count=6):
+    def _add(self, ob, amount, affect=0, segments=4):
         from ..operators.modifiers import set_modifier_input
         from ..utilities.fillet_nodes import build_fillet_node_group, fillet_input_ids
 
@@ -44,80 +30,115 @@ class TestFilletNodes(TestCase):
         mod = ob.modifiers.new("fillet", "NODES")
         mod.node_group = group
         ids = fillet_input_ids(group)
-        set_modifier_input(mod, ids["Radius"], radius)
-        set_modifier_input(mod, ids["Count"], count)
-        set_modifier_input(mod, ids["Fill"], fill)
-        return mod
+        set_modifier_input(mod, ids["Amount"], amount)
+        set_modifier_input(mod, ids["Affect"], affect)
+        set_modifier_input(mod, ids["Segments"], segments)
+        return mod, ids
 
     def _eval(self, ob):
         dg = bpy.context.evaluated_depsgraph_get()
         ev = ob.evaluated_get(dg)
         me = ev.to_mesh()
-        area = sum(p.area for p in me.polygons)
-        nfaces = len(me.polygons)
-        nverts = len(me.vertices)
+        r = (len(me.vertices), len(me.polygons), sum(p.area for p in me.polygons))
         ev.to_mesh_clear()
-        return nfaces, nverts, area
+        return r
 
-    def test_group_builds_and_is_a_modifier(self):
+    def test_group_builds_with_mesh_bevel(self):
         from ..utilities.fillet_nodes import build_fillet_node_group
 
         group = build_fillet_node_group("test_fillet_build")
         try:
             self.assertTrue(group.is_modifier)
-            ids = {s.name for s in group.interface.items_tree}
-            for expected in ("Radius", "Count", "Fill", "Geometry"):
-                self.assertIn(expected, ids)
-            kinds = {n.bl_idname for n in group.nodes}
-            self.assertIn("GeometryNodeFilletCurve", kinds)
-            self.assertIn("GeometryNodeFillCurve", kinds)
+            names = {s.name for s in group.interface.items_tree}
+            for expected in ("Amount", "Segments", "Affect", "Selection", "Geometry"):
+                self.assertIn(expected, names)
+            self.assertIn("GeometryNodeMeshBevel", {n.bl_idname for n in group.nodes})
         finally:
             bpy.data.node_groups.remove(group)
 
-    def test_fillet_rounds_corners_and_keeps_hole(self):
-        ob = _loops_mesh(with_hole=True)
+    def test_flat_profile_rounds_corners(self):
+        """Auto picks Vertices on a flat face: corners round, area shrinks."""
+        ob = _flat_quad()
         try:
-            self._add_fillet(ob, 0.0)
-            nf0, nv0, a0 = self._eval(ob)
-            ob.modifiers.clear()
-            self._add_fillet(ob, 1.0)
-            nf1, nv1, a1 = self._eval(ob)
-
-            # Still a ring (two n-gon faces = outer + hole), rounded corners cut
-            # a little area and add boundary points.
-            self.assertEqual(nf0, 2)
-            self.assertEqual(nf1, 2, "fillet must not destroy the hole")
-            self.assertLess(a1, a0, "rounded corners should reduce the filled area")
-            self.assertGreater(nv1, nv0, "rounded corners add boundary vertices")
+            v0, f0, a0 = self._eval(ob)
+            self._add(ob, 0.3)  # Affect = Auto
+            v1, f1, a1 = self._eval(ob)
+            self.assertGreater(v1, v0, "corners should gain vertices")
+            self.assertLess(a1, a0, "rounded corners cut a little area")
+            self.assertGreaterEqual(f1, 1)
         finally:
             bpy.data.objects.remove(ob, do_unlink=True)
 
-    def test_fill_toggle_switches_surface_and_wire(self):
-        ob = _loops_mesh(with_hole=False)
+    def test_3d_solid_rounds_edges(self):
+        """The case that broke the curve pipeline: a cube's edges round."""
+        bpy.ops.mesh.primitive_cube_add(size=2)
+        ob = bpy.context.active_object
         try:
-            self._add_fillet(ob, 0.5, fill=True)
-            faces_filled, _, area = self._eval(ob)
-            ob.modifiers.clear()
-            self._add_fillet(ob, 0.5, fill=False)
-            faces_wire, verts_wire, _ = self._eval(ob)
-
-            self.assertGreater(faces_filled, 0)
-            self.assertGreater(area, 0.0)
-            self.assertEqual(faces_wire, 0, "Fill off must emit a wire (no faces)")
-            self.assertGreater(verts_wire, 0)
+            v0, f0, _ = self._eval(ob)
+            self.assertEqual((v0, f0), (8, 6))
+            self._add(ob, 0.3)  # Auto -> Edges (closed solid)
+            v1, f1, _ = self._eval(ob)
+            self.assertGreater(v1, v0, "beveled edges add vertices")
+            self.assertGreater(f1, f0, "beveled edges add faces")
         finally:
             bpy.data.objects.remove(ob, do_unlink=True)
+
+    def test_selection_fillets_only_chosen_elements(self):
+        """A per-element Selection field fillets a subset (fewer new verts)."""
+        from ..operators.modifiers import set_modifier_input
+        from ..utilities.fillet_nodes import build_fillet_node_group, fillet_input_ids
+
+        # A DEDICATED group whose Selection is driven by a 'sel' edge attribute,
+        # so the shared group is never mutated (that would leak into other tests).
+        group = build_fillet_node_group("test_fillet_selection")
+        named = group.nodes.new("GeometryNodeInputNamedAttribute")
+        named.data_type = "BOOLEAN"
+        named.inputs["Name"].default_value = "sel"
+        gi = next(n for n in group.nodes if n.bl_idname == "NodeGroupInput")
+        for link in list(group.links):
+            if link.from_socket == gi.outputs["Selection"]:
+                group.links.new(named.outputs["Attribute"], link.to_socket)
+        ids = fillet_input_ids(group)
+
+        def beveled_verts(ob, sel_flags):
+            attr = ob.data.attributes.new("sel", "BOOLEAN", "EDGE")
+            attr.data.foreach_set("value", sel_flags)
+            mod = ob.modifiers.new("f", "NODES")
+            mod.node_group = group
+            set_modifier_input(mod, ids["Amount"], 0.3)
+            set_modifier_input(mod, ids["Affect"], 2)  # Edges
+            return self._eval(ob)[0]
+
+        def cube():
+            bpy.ops.mesh.primitive_cube_add(size=2)
+            return bpy.context.active_object
+
+        all_ob = sub_ob = None
+        try:
+            all_ob = cube()
+            v_all = beveled_verts(all_ob, [True] * len(all_ob.data.edges))
+            sub_ob = cube()
+            v_sub = beveled_verts(
+                sub_ob, [i < 3 for i in range(len(sub_ob.data.edges))]
+            )
+            self.assertGreater(v_sub, 8, "selected edges should still bevel")
+            self.assertLess(
+                v_sub, v_all, "a subset selection must add fewer vertices than all"
+            )
+        finally:
+            for ob in (all_ob, sub_ob):
+                if ob is not None:
+                    bpy.data.objects.remove(ob, do_unlink=True)
+            bpy.data.node_groups.remove(group)
 
 
 @unittest.skipIf(bpy.app.version < (5, 2, 0), "requires Blender 5.2+")
 class TestFilletOnSketch(TestCase):
-    """Integration: the fillet stacks on a real sketch's convert output."""
+    """Integration: the fillet rounds a real sketch's convert output."""
 
-    def test_fillet_after_convert_rounds_the_sketch(self):
+    def test_fillet_rounds_the_sketch_output(self):
         from ..curve_solver import solve_system
-
-        # Reuse the 2D sketch harness inline to build a rectangle + circle.
-        from ..model.curve_ref import CircleRef, LineRef, PointRef
+        from ..model.curve_ref import LineRef, PointRef
         from ..model.sketch_ref import (
             Sketch,
             set_active_sketch,
@@ -132,7 +153,6 @@ class TestFilletOnSketch(TestCase):
             build_fillet_node_group,
             fillet_input_ids,
         )
-        from .utils import Sketch2dTestCase  # noqa: F401  (ensure test env)
 
         scene = bpy.data.scenes.new("fillet_sketch")
         bpy.context.window.scene = scene
@@ -145,35 +165,41 @@ class TestFilletOnSketch(TestCase):
         sketch = Sketch(esk.target_object)
         set_active_sketch(ctx, esk.target_object)
 
+        # A plain rectangle: global vertex-fillet rounds its 4 corners cleanly.
+        # (A dense inner circle would need a Selection to avoid scalloping it --
+        # the per-element follow-up; see the module note.)
         corners = [(-4, -2), (4, -2), (4, 2), (-4, 2)]
         pts = [PointRef.create(sketch, c) for c in corners]
         for i in range(4):
             LineRef.create(sketch, pts[i], pts[(i + 1) % 4])
-        CircleRef.create(sketch, PointRef.create(sketch, (0, 0)), 1.0)
         self.assertTrue(solve_system(ctx))
         refresh_curve_geometry(sketch)
 
         ob = sketch.target_object
 
-        def area():
-            dup = ob.copy()
-            dup.data = ob.data.copy()
-            scene.collection.objects.link(dup)
-            for o in scene.collection.objects:
-                o.select_set(False)
-            dup.select_set(True)
-            ctx.view_layer.objects.active = dup
-            bpy.ops.object.convert(target="MESH")
-            a = sum(p.area for p in dup.data.polygons)
-            bpy.data.objects.remove(dup, do_unlink=True)
-            return a
+        # Bake the sketch's convert output to a static mesh once, then drive the
+        # fillet on that mesh via to_mesh (robust; ops.convert with a second live
+        # modifier is context-sensitive across tests).
+        baked = ob.copy()
+        baked.data = ob.data.copy()
+        scene.collection.objects.link(baked)
+        for o in scene.collection.objects:
+            o.select_set(False)
+        baked.select_set(True)
+        ctx.view_layer.objects.active = baked
+        bpy.ops.object.convert(target="MESH")
+        sharp = sum(p.area for p in baked.data.polygons)
+        self.assertAlmostEqual(sharp, 32.0, delta=0.01, msg="baked rectangle fill")
 
-        sharp = area()
         group = build_fillet_node_group()
-        mod = ob.modifiers.new("CAD Sketcher Fillet", "NODES")
+        mod = baked.modifiers.new("CAD Sketcher Fillet", "NODES")
         mod.node_group = group
-        set_modifier_input(mod, fillet_input_ids(group)["Radius"], 1.0)
-        rounded = area()
+        set_modifier_input(mod, fillet_input_ids(group)["Amount"], 0.3)
+
+        dg = ctx.evaluated_depsgraph_get()
+        me = baked.evaluated_get(dg).to_mesh()
+        rounded = sum(p.area for p in me.polygons)
+        baked.evaluated_get(dg).to_mesh_clear()
 
         self.assertLess(rounded, sharp, "fillet did not round the sketch output")
         self.assertGreater(rounded, 0.0)

--- a/testing/test_fillet_nodes.py
+++ b/testing/test_fillet_nodes.py
@@ -69,6 +69,26 @@ class TestFilletNodes(TestCase):
         finally:
             bpy.data.objects.remove(ob, do_unlink=True)
 
+    def test_amount_controls_width(self):
+        """A larger Amount bevels more -- guards the bug where Amount was wired to
+        Mesh Bevel's inert 'Offset' instead of the per-side offsets, so editing it
+        did nothing."""
+
+        def beveled_area(amount):
+            bpy.ops.mesh.primitive_cube_add(size=2)
+            ob = bpy.context.active_object
+            try:
+                self._add(ob, amount, affect=2)  # Edges
+                return self._eval(ob)[2]
+            finally:
+                bpy.data.objects.remove(ob, do_unlink=True)
+
+        small = beveled_area(0.1)
+        large = beveled_area(0.5)
+        self.assertLess(
+            large, small, "a larger Amount must bevel more (less surface area)"
+        )
+
     def test_3d_solid_rounds_edges(self):
         """The case that broke the curve pipeline: a cube's edges round."""
         bpy.ops.mesh.primitive_cube_add(size=2)

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -38,7 +38,6 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
 
         layout.operator(declarations.Operators.MergePoints)
         layout.operator(declarations.Operators.ProjectGeometry, icon="MOD_SHRINKWRAP")
-        layout.operator(declarations.Operators.AddFillet, icon="MOD_BEVEL")
 
         layout.separator()
         prefs = preferences.get_prefs()
@@ -109,6 +108,7 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
         col.operator(declarations.Operators.NodeRevolve)
         col.operator(declarations.Operators.NodeArrayLinear)
         col.operator(declarations.Operators.NodeBoolean)
+        col.operator(declarations.Operators.AddFillet, icon="MOD_BEVEL")
 
     def draw(self, context: Context):
         # Mirror the workspace toolbar: sketch tools while a sketch is active,

--- a/ui/panels/tools.py
+++ b/ui/panels/tools.py
@@ -38,6 +38,7 @@ class VIEW3D_PT_sketcher_tools(VIEW3D_PT_sketcher_base):
 
         layout.operator(declarations.Operators.MergePoints)
         layout.operator(declarations.Operators.ProjectGeometry, icon="MOD_SHRINKWRAP")
+        layout.operator(declarations.Operators.AddFillet, icon="MOD_BEVEL")
 
         layout.separator()
         prefs = preferences.get_prefs()

--- a/utilities/fillet_nodes.py
+++ b/utilities/fillet_nodes.py
@@ -8,8 +8,8 @@ on any mesh.
 
 Inputs: ``Amount`` (width), ``Segments`` (roundness), ``Affect`` (Auto / Vertices
 / Edges) and a ``Selection`` field to fillet only chosen elements. ``Auto`` picks
-Vertices for a flat/open mesh (it has boundary edges) and Edges for a closed
-solid; the same choice via a per-element ``Selection`` gives "fillet specific
+Vertices for a planar profile (a degenerate bounding box) and Edges for a solid;
+the same choice via a per-element ``Selection`` gives "fillet specific
 edges/corners".
 
 Limitation: a global vertex fillet rounds *every* corner, including the dense
@@ -21,11 +21,19 @@ or an angle threshold) is the intended way to fillet specific elements.
 import bpy
 
 FILLET_NODE_GROUP = "CAD Sketcher Fillet"
-FILLET_VERSION = 2  # rebuilt on Mesh Bevel (was the curve-fillet pipeline)
+FILLET_VERSION = 3  # Mesh Bevel; Amount/Segments forced to plain values
 
 # ``Affect`` values. An int, not a menu socket: menu sockets don't evaluate
 # reliably as modifier inputs on Blender 5.0/5.1 (see boolean_nodes).
 AFFECT_AUTO, AFFECT_VERTICES, AFFECT_EDGES = 0, 1, 2
+
+
+def _force_value(socket):
+    """Forbid the field/attribute toggle so the input is a plain editable value."""
+    try:
+        socket.force_non_field = True
+    except Exception:
+        pass
 
 
 def _compare(nodes, links, data_type, operation, a_socket, b_value):
@@ -45,6 +53,56 @@ def _bool(nodes, links, operation, a, b):
     links.new(a, node.inputs[0])
     links.new(b, node.inputs[1])
     return node.outputs["Boolean"]
+
+
+def _math(nodes, links, operation, a, b):
+    node = nodes.new("ShaderNodeMath")
+    node.operation = operation
+    links.new(a, node.inputs[0])
+    if hasattr(b, "bl_idname") or hasattr(b, "node"):
+        links.new(b, node.inputs[1])
+    else:
+        node.inputs[1].default_value = b
+    return node.outputs["Value"]
+
+
+def _is_flat(nodes, links, geometry):
+    """Boolean: is the geometry planar (min bounding-box extent ~ 0)?
+
+    Scale-independent (compares the smallest extent to the largest) and safe on
+    any geometry -- Bounding Box never errors, so this can run under Auto without
+    tripping a node warning that would grey the modifier inputs.
+    """
+    bbox = nodes.new("GeometryNodeBoundBox")
+    links.new(geometry, bbox.inputs["Geometry"])
+    size = nodes.new("ShaderNodeVectorMath")
+    size.operation = "SUBTRACT"
+    links.new(bbox.outputs["Max"], size.inputs[0])
+    links.new(bbox.outputs["Min"], size.inputs[1])
+    sep = nodes.new("ShaderNodeSeparateXYZ")
+    links.new(size.outputs["Vector"], sep.inputs["Vector"])
+    max_extent = _math(
+        nodes,
+        links,
+        "MAXIMUM",
+        sep.outputs["X"],
+        _math(nodes, links, "MAXIMUM", sep.outputs["Y"], sep.outputs["Z"]),
+    )
+    min_extent = _math(
+        nodes,
+        links,
+        "MINIMUM",
+        sep.outputs["X"],
+        _math(nodes, links, "MINIMUM", sep.outputs["Y"], sep.outputs["Z"]),
+    )
+    threshold = _math(nodes, links, "MULTIPLY", max_extent, 1e-3)
+    cmp = nodes.new("FunctionNodeCompare")
+    cmp.data_type = "FLOAT"
+    cmp.operation = "LESS_THAN"
+    ins = [s for s in cmp.inputs if s.enabled and s.type == "VALUE"]
+    links.new(min_extent, ins[0])
+    links.new(threshold, ins[1])
+    return cmp.outputs["Result"]
 
 
 def _bevel(nodes, links, geometry, selection, amount, segments, affect_kind):
@@ -79,6 +137,10 @@ def build_fillet_node_group(name: str = FILLET_NODE_GROUP):
     amount = iface.new_socket("Amount", in_out="INPUT", socket_type="NodeSocketFloat")
     amount.default_value = 0.1
     amount.min_value = 0.0
+    # Plain value, never an attribute/field toggle -- these are global settings,
+    # and leaving them field-capable makes the modifier show an attribute box
+    # (which reads as "can't edit the value").
+    _force_value(amount)
     try:
         amount.subtype = "DISTANCE"
     except Exception:
@@ -87,6 +149,7 @@ def build_fillet_node_group(name: str = FILLET_NODE_GROUP):
     segments.default_value = 4
     segments.min_value = 1
     segments.description = "Segments per rounded corner/edge"
+    _force_value(segments)
     affect = iface.new_socket("Affect", in_out="INPUT", socket_type="NodeSocketInt")
     affect.default_value = AFFECT_AUTO
     affect.min_value = 0
@@ -95,6 +158,7 @@ def build_fillet_node_group(name: str = FILLET_NODE_GROUP):
         "0 = Auto (corners on a flat profile, edges on a solid), "
         "1 = Vertices, 2 = Edges"
     )
+    _force_value(affect)
     selection = iface.new_socket(
         "Selection", in_out="INPUT", socket_type="NodeSocketBool"
     )
@@ -115,15 +179,13 @@ def build_fillet_node_group(name: str = FILLET_NODE_GROUP):
     verts = _bevel(nodes, links, geo, sel, amt, seg, "Vertices")
     edges = _bevel(nodes, links, geo, sel, amt, seg, "Edges")
 
-    # Auto-detect flatness: a flat/open mesh has at least one boundary edge (an
-    # edge touching fewer than two faces); a closed solid has none.
-    neighbors = nodes.new("GeometryNodeInputMeshEdgeNeighbors")
-    stat = nodes.new("GeometryNodeAttributeStatistic")
-    stat.data_type = "FLOAT"
-    stat.domain = "EDGE"
-    links.new(geo, stat.inputs["Geometry"])
-    links.new(neighbors.outputs["Face Count"], stat.inputs["Attribute"])
-    is_flat = _compare(nodes, links, "FLOAT", "LESS_THAN", stat.outputs["Min"], 2.0)
+    # Auto-detect flatness from the bounding box: a flat profile is degenerate
+    # along one axis (min extent ~ 0), a solid has volume in all three. Bounding
+    # Box works on any geometry and never errors -- unlike mesh-only probes
+    # (Edge Neighbors / Attribute Statistic), which warn on a curve/non-mesh input
+    # and, because Auto is the only path that evaluates them, would grey the
+    # modifier's inputs at Affect = 0 only.
+    is_flat = _is_flat(nodes, links, geo)
 
     # use_vertices = (Affect == Vertices) or (Affect == Auto and is_flat)
     eq_vertices = _compare(

--- a/utilities/fillet_nodes.py
+++ b/utilities/fillet_nodes.py
@@ -1,0 +1,107 @@
+"""Generic ``CAD Sketcher Fillet`` geometry-nodes modifier.
+
+A self-contained node group that rounds the corners of whatever geometry it is
+given: it recovers a curve (Mesh to Curve), rounds it (Fillet Curve), then either
+re-fills it as an n-gon surface or emits it as a wire. It reads no sketch or
+constraint data, so it works on any curve/mesh-wire output -- drop it after a
+sketch's convert modifier, or on a mesh-output object, to round the result
+non-destructively.
+
+``Radius`` and ``Count`` are exposed as modifier inputs; ``Fill`` toggles between
+a filled surface and a plain wire. The fill path normalizes spline winding first
+because Fill Curve's N-gon mode is winding-sensitive (see ``_normalize_winding``).
+"""
+
+import bpy
+
+from .convert_nodes import _normalize_winding
+
+FILLET_NODE_GROUP = "CAD Sketcher Fillet"
+FILLET_VERSION = 1
+
+
+def build_fillet_node_group(name: str = FILLET_NODE_GROUP):
+    """Build the generic fillet group (idempotent, version-gated).
+
+    Reuses an existing group of the same name, rebuilding it in place when the
+    stored version is stale so bound modifiers upgrade without rebinding.
+    """
+    ng = bpy.data.node_groups.get(name)
+    if ng is None:
+        ng = bpy.data.node_groups.new(name, "GeometryNodeTree")
+
+    # Offer it in the Add Modifier > Geometry Nodes picker (off by default for
+    # API-created groups).
+    ng.is_modifier = True
+
+    if ng.get("cad_fillet_version") == FILLET_VERSION:
+        return ng
+    ng.nodes.clear()
+    ng.links.clear()
+    ng.interface.clear()
+
+    iface = ng.interface
+    iface.new_socket("Geometry", in_out="INPUT", socket_type="NodeSocketGeometry")
+    radius = iface.new_socket("Radius", in_out="INPUT", socket_type="NodeSocketFloat")
+    radius.default_value = 0.1
+    radius.min_value = 0.0
+    try:
+        radius.subtype = "DISTANCE"
+    except Exception:
+        pass
+    count = iface.new_socket("Count", in_out="INPUT", socket_type="NodeSocketInt")
+    count.default_value = 4
+    count.min_value = 1
+    count.description = "Segments per rounded corner (Bezier smoothness)"
+    fill = iface.new_socket("Fill", in_out="INPUT", socket_type="NodeSocketBool")
+    fill.default_value = True
+    iface.new_socket("Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry")
+
+    nodes, links = ng.nodes, ng.links
+    gi = nodes.new("NodeGroupInput")
+    go = nodes.new("NodeGroupOutput")
+
+    to_curve = nodes.new("GeometryNodeMeshToCurve")
+    links.new(gi.outputs["Geometry"], to_curve.inputs["Mesh"])
+
+    fillet = nodes.new("GeometryNodeFilletCurve")
+    # Clamp each fillet to the room between adjacent points, so a large radius on
+    # densely tessellated arcs/circles can't collapse them.
+    for socket in fillet.inputs:
+        if socket.name == "Limit Radius":
+            socket.default_value = True
+    links.new(to_curve.outputs["Curve"], fillet.inputs["Curve"])
+    links.new(gi.outputs["Radius"], fillet.inputs["Radius"])
+    links.new(gi.outputs["Count"], fillet.inputs["Count"])
+
+    # Fill path: pin winding (Fill Curve N-gons is winding-sensitive) then fill.
+    normalized = _normalize_winding(nodes, links, fillet.outputs["Curve"])
+    fill_curve = nodes.new("GeometryNodeFillCurve")
+    try:
+        fill_curve.inputs["Mode"].default_value = "N-gons"
+    except Exception:
+        pass
+    links.new(normalized, fill_curve.inputs["Curve"])
+
+    # Wire path: the rounded curve as edges (no profile -> edge-only mesh).
+    wire = nodes.new("GeometryNodeCurveToMesh")
+    links.new(fillet.outputs["Curve"], wire.inputs["Curve"])
+
+    switch = nodes.new("GeometryNodeSwitch")
+    switch.input_type = "GEOMETRY"
+    links.new(gi.outputs["Fill"], switch.inputs["Switch"])
+    links.new(wire.outputs["Mesh"], switch.inputs["False"])
+    links.new(fill_curve.outputs["Mesh"], switch.inputs["True"])
+    links.new(switch.outputs["Output"], go.inputs["Geometry"])
+
+    ng["cad_fillet_version"] = FILLET_VERSION
+    return ng
+
+
+def fillet_input_ids(node_group) -> dict:
+    """Map ``{socket name: identifier}`` for the group's inputs."""
+    return {
+        s.name: s.identifier
+        for s in node_group.interface.items_tree
+        if getattr(s, "in_out", "") == "INPUT"
+    }

--- a/utilities/fillet_nodes.py
+++ b/utilities/fillet_nodes.py
@@ -21,19 +21,11 @@ or an angle threshold) is the intended way to fillet specific elements.
 import bpy
 
 FILLET_NODE_GROUP = "CAD Sketcher Fillet"
-FILLET_VERSION = 3  # Mesh Bevel; Amount/Segments forced to plain values
+FILLET_VERSION = 4  # Mesh Bevel; bounding-box auto-detect (no mesh-only probes)
 
 # ``Affect`` values. An int, not a menu socket: menu sockets don't evaluate
 # reliably as modifier inputs on Blender 5.0/5.1 (see boolean_nodes).
 AFFECT_AUTO, AFFECT_VERTICES, AFFECT_EDGES = 0, 1, 2
-
-
-def _force_value(socket):
-    """Forbid the field/attribute toggle so the input is a plain editable value."""
-    try:
-        socket.force_non_field = True
-    except Exception:
-        pass
 
 
 def _compare(nodes, links, data_type, operation, a_socket, b_value):
@@ -137,10 +129,6 @@ def build_fillet_node_group(name: str = FILLET_NODE_GROUP):
     amount = iface.new_socket("Amount", in_out="INPUT", socket_type="NodeSocketFloat")
     amount.default_value = 0.1
     amount.min_value = 0.0
-    # Plain value, never an attribute/field toggle -- these are global settings,
-    # and leaving them field-capable makes the modifier show an attribute box
-    # (which reads as "can't edit the value").
-    _force_value(amount)
     try:
         amount.subtype = "DISTANCE"
     except Exception:
@@ -149,7 +137,6 @@ def build_fillet_node_group(name: str = FILLET_NODE_GROUP):
     segments.default_value = 4
     segments.min_value = 1
     segments.description = "Segments per rounded corner/edge"
-    _force_value(segments)
     affect = iface.new_socket("Affect", in_out="INPUT", socket_type="NodeSocketInt")
     affect.default_value = AFFECT_AUTO
     affect.min_value = 0
@@ -158,7 +145,6 @@ def build_fillet_node_group(name: str = FILLET_NODE_GROUP):
         "0 = Auto (corners on a flat profile, edges on a solid), "
         "1 = Vertices, 2 = Edges"
     )
-    _force_value(affect)
     selection = iface.new_socket(
         "Selection", in_out="INPUT", socket_type="NodeSocketBool"
     )
@@ -182,9 +168,9 @@ def build_fillet_node_group(name: str = FILLET_NODE_GROUP):
     # Auto-detect flatness from the bounding box: a flat profile is degenerate
     # along one axis (min extent ~ 0), a solid has volume in all three. Bounding
     # Box works on any geometry and never errors -- unlike mesh-only probes
-    # (Edge Neighbors / Attribute Statistic), which warn on a curve/non-mesh input
-    # and, because Auto is the only path that evaluates them, would grey the
-    # modifier's inputs at Affect = 0 only.
+    # (Edge Neighbors / Attribute Statistic), which warn on a curve/non-mesh input;
+    # because Auto is the only Affect value that evaluates the detection (the
+    # others constant-fold it away), that warning greyed the inputs at Affect=0.
     is_flat = _is_flat(nodes, links, geo)
 
     # use_vertices = (Affect == Vertices) or (Affect == Auto and is_flat)

--- a/utilities/fillet_nodes.py
+++ b/utilities/fillet_nodes.py
@@ -21,7 +21,7 @@ or an angle threshold) is the intended way to fillet specific elements.
 import bpy
 
 FILLET_NODE_GROUP = "CAD Sketcher Fillet"
-FILLET_VERSION = 4  # Mesh Bevel; bounding-box auto-detect (no mesh-only probes)
+FILLET_VERSION = 5  # drive Mesh Bevel per-side offsets so Amount controls width
 
 # ``Affect`` values. An int, not a menu socket: menu sockets don't evaluate
 # reliably as modifier inputs on Blender 5.0/5.1 (see boolean_nodes).
@@ -97,6 +97,17 @@ def _is_flat(nodes, links, geometry):
     return cmp.outputs["Result"]
 
 
+# Mesh Bevel's width comes from the four per-side offsets, not the "Offset"
+# input -- "Offset" only mirrors into them when set as a node default, so a
+# *linked* Offset is ignored (Amount then had no effect). Drive the per-sides.
+_BEVEL_OFFSETS = (
+    "Start Left Offset",
+    "Start Right Offset",
+    "End Left Offset",
+    "End Right Offset",
+)
+
+
 def _bevel(nodes, links, geometry, selection, amount, segments, affect_kind):
     """One Mesh Bevel branch with a round profile (a fillet, not a chamfer)."""
     node = nodes.new("GeometryNodeMeshBevel")
@@ -105,7 +116,13 @@ def _bevel(nodes, links, geometry, selection, amount, segments, affect_kind):
         node.inputs["Shape"].default_value = 0.5  # round arc
     links.new(geometry, node.inputs["Mesh"])
     links.new(selection, node.inputs["Selection"])
-    links.new(amount, node.inputs["Offset"])
+    names = [s.name for s in node.inputs]
+    for side in _BEVEL_OFFSETS:
+        if side in names:
+            links.new(amount, node.inputs[side])
+    # Keep Offset driven too for any build/mode that reads it directly.
+    if "Offset" in names:
+        links.new(amount, node.inputs["Offset"])
     links.new(segments, node.inputs["Segments"])
     return node.outputs["Mesh"]
 

--- a/utilities/fillet_nodes.py
+++ b/utilities/fillet_nodes.py
@@ -1,37 +1,71 @@
 """Generic ``CAD Sketcher Fillet`` geometry-nodes modifier.
 
-A self-contained node group that rounds the corners of whatever geometry it is
-given: it recovers a curve (Mesh to Curve), rounds it (Fillet Curve), then either
-re-fills it as an n-gon surface or emits it as a wire. It reads no sketch or
-constraint data, so it works on any curve/mesh-wire output -- drop it after a
-sketch's convert modifier, or on a mesh-output object, to round the result
-non-destructively.
+Rounds the corners/edges of whatever geometry it is given, via the built-in
+``Mesh Bevel`` node, so it works on both a flat sketch profile (rounds the
+boundary corners) and a 3D solid (rounds the edges). It reads no sketch or
+constraint data -- add it after a sketch's convert modifier, on a mesh output, or
+on any mesh.
 
-``Radius`` and ``Count`` are exposed as modifier inputs; ``Fill`` toggles between
-a filled surface and a plain wire. The fill path normalizes spline winding first
-because Fill Curve's N-gon mode is winding-sensitive (see ``_normalize_winding``).
+Inputs: ``Amount`` (width), ``Segments`` (roundness), ``Affect`` (Auto / Vertices
+/ Edges) and a ``Selection`` field to fillet only chosen elements. ``Auto`` picks
+Vertices for a flat/open mesh (it has boundary edges) and Edges for a closed
+solid; the same choice via a per-element ``Selection`` gives "fillet specific
+edges/corners".
+
+Limitation: a global vertex fillet rounds *every* corner, including the dense
+tessellation of an arc/circle in a flat profile, and Mesh Bevel bails when the
+amount exceeds the spacing there. Driving ``Selection`` (e.g. only true corners,
+or an angle threshold) is the intended way to fillet specific elements.
 """
 
 import bpy
 
-from .convert_nodes import _normalize_winding
-
 FILLET_NODE_GROUP = "CAD Sketcher Fillet"
-FILLET_VERSION = 1
+FILLET_VERSION = 2  # rebuilt on Mesh Bevel (was the curve-fillet pipeline)
+
+# ``Affect`` values. An int, not a menu socket: menu sockets don't evaluate
+# reliably as modifier inputs on Blender 5.0/5.1 (see boolean_nodes).
+AFFECT_AUTO, AFFECT_VERTICES, AFFECT_EDGES = 0, 1, 2
+
+
+def _compare(nodes, links, data_type, operation, a_socket, b_value):
+    cmp = nodes.new("FunctionNodeCompare")
+    cmp.data_type = data_type
+    cmp.operation = operation
+    socket_type = "INT" if data_type == "INT" else "VALUE"
+    ins = [s for s in cmp.inputs if s.enabled and s.type == socket_type]
+    links.new(a_socket, ins[0])
+    ins[1].default_value = b_value
+    return cmp.outputs["Result"]
+
+
+def _bool(nodes, links, operation, a, b):
+    node = nodes.new("FunctionNodeBooleanMath")
+    node.operation = operation
+    links.new(a, node.inputs[0])
+    links.new(b, node.inputs[1])
+    return node.outputs["Boolean"]
+
+
+def _bevel(nodes, links, geometry, selection, amount, segments, affect_kind):
+    """One Mesh Bevel branch with a round profile (a fillet, not a chamfer)."""
+    node = nodes.new("GeometryNodeMeshBevel")
+    node.inputs["Affect Kind"].default_value = affect_kind  # "Vertices" | "Edges"
+    if "Shape" in [s.name for s in node.inputs]:
+        node.inputs["Shape"].default_value = 0.5  # round arc
+    links.new(geometry, node.inputs["Mesh"])
+    links.new(selection, node.inputs["Selection"])
+    links.new(amount, node.inputs["Offset"])
+    links.new(segments, node.inputs["Segments"])
+    return node.outputs["Mesh"]
 
 
 def build_fillet_node_group(name: str = FILLET_NODE_GROUP):
-    """Build the generic fillet group (idempotent, version-gated).
-
-    Reuses an existing group of the same name, rebuilding it in place when the
-    stored version is stale so bound modifiers upgrade without rebinding.
-    """
+    """Build the generic fillet group (idempotent, version-gated)."""
     ng = bpy.data.node_groups.get(name)
     if ng is None:
         ng = bpy.data.node_groups.new(name, "GeometryNodeTree")
 
-    # Offer it in the Add Modifier > Geometry Nodes picker (off by default for
-    # API-created groups).
     ng.is_modifier = True
 
     if ng.get("cad_fillet_version") == FILLET_VERSION:
@@ -42,56 +76,68 @@ def build_fillet_node_group(name: str = FILLET_NODE_GROUP):
 
     iface = ng.interface
     iface.new_socket("Geometry", in_out="INPUT", socket_type="NodeSocketGeometry")
-    radius = iface.new_socket("Radius", in_out="INPUT", socket_type="NodeSocketFloat")
-    radius.default_value = 0.1
-    radius.min_value = 0.0
+    amount = iface.new_socket("Amount", in_out="INPUT", socket_type="NodeSocketFloat")
+    amount.default_value = 0.1
+    amount.min_value = 0.0
     try:
-        radius.subtype = "DISTANCE"
+        amount.subtype = "DISTANCE"
     except Exception:
         pass
-    count = iface.new_socket("Count", in_out="INPUT", socket_type="NodeSocketInt")
-    count.default_value = 4
-    count.min_value = 1
-    count.description = "Segments per rounded corner (Bezier smoothness)"
-    fill = iface.new_socket("Fill", in_out="INPUT", socket_type="NodeSocketBool")
-    fill.default_value = True
+    segments = iface.new_socket("Segments", in_out="INPUT", socket_type="NodeSocketInt")
+    segments.default_value = 4
+    segments.min_value = 1
+    segments.description = "Segments per rounded corner/edge"
+    affect = iface.new_socket("Affect", in_out="INPUT", socket_type="NodeSocketInt")
+    affect.default_value = AFFECT_AUTO
+    affect.min_value = 0
+    affect.max_value = 2
+    affect.description = (
+        "0 = Auto (corners on a flat profile, edges on a solid), "
+        "1 = Vertices, 2 = Edges"
+    )
+    selection = iface.new_socket(
+        "Selection", in_out="INPUT", socket_type="NodeSocketBool"
+    )
+    selection.default_value = True
+    selection.description = "Fillet only the selected corners/edges"
     iface.new_socket("Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry")
 
     nodes, links = ng.nodes, ng.links
     gi = nodes.new("NodeGroupInput")
     go = nodes.new("NodeGroupOutput")
 
-    to_curve = nodes.new("GeometryNodeMeshToCurve")
-    links.new(gi.outputs["Geometry"], to_curve.inputs["Mesh"])
+    geo = gi.outputs["Geometry"]
+    sel = gi.outputs["Selection"]
+    amt = gi.outputs["Amount"]
+    seg = gi.outputs["Segments"]
 
-    fillet = nodes.new("GeometryNodeFilletCurve")
-    # Clamp each fillet to the room between adjacent points, so a large radius on
-    # densely tessellated arcs/circles can't collapse them.
-    for socket in fillet.inputs:
-        if socket.name == "Limit Radius":
-            socket.default_value = True
-    links.new(to_curve.outputs["Curve"], fillet.inputs["Curve"])
-    links.new(gi.outputs["Radius"], fillet.inputs["Radius"])
-    links.new(gi.outputs["Count"], fillet.inputs["Count"])
+    # Two branches; the Switch below evaluates only the one it selects.
+    verts = _bevel(nodes, links, geo, sel, amt, seg, "Vertices")
+    edges = _bevel(nodes, links, geo, sel, amt, seg, "Edges")
 
-    # Fill path: pin winding (Fill Curve N-gons is winding-sensitive) then fill.
-    normalized = _normalize_winding(nodes, links, fillet.outputs["Curve"])
-    fill_curve = nodes.new("GeometryNodeFillCurve")
-    try:
-        fill_curve.inputs["Mode"].default_value = "N-gons"
-    except Exception:
-        pass
-    links.new(normalized, fill_curve.inputs["Curve"])
+    # Auto-detect flatness: a flat/open mesh has at least one boundary edge (an
+    # edge touching fewer than two faces); a closed solid has none.
+    neighbors = nodes.new("GeometryNodeInputMeshEdgeNeighbors")
+    stat = nodes.new("GeometryNodeAttributeStatistic")
+    stat.data_type = "FLOAT"
+    stat.domain = "EDGE"
+    links.new(geo, stat.inputs["Geometry"])
+    links.new(neighbors.outputs["Face Count"], stat.inputs["Attribute"])
+    is_flat = _compare(nodes, links, "FLOAT", "LESS_THAN", stat.outputs["Min"], 2.0)
 
-    # Wire path: the rounded curve as edges (no profile -> edge-only mesh).
-    wire = nodes.new("GeometryNodeCurveToMesh")
-    links.new(fillet.outputs["Curve"], wire.inputs["Curve"])
+    # use_vertices = (Affect == Vertices) or (Affect == Auto and is_flat)
+    eq_vertices = _compare(
+        nodes, links, "INT", "EQUAL", gi.outputs["Affect"], AFFECT_VERTICES
+    )
+    eq_auto = _compare(nodes, links, "INT", "EQUAL", gi.outputs["Affect"], AFFECT_AUTO)
+    auto_vertices = _bool(nodes, links, "AND", eq_auto, is_flat)
+    use_vertices = _bool(nodes, links, "OR", eq_vertices, auto_vertices)
 
     switch = nodes.new("GeometryNodeSwitch")
     switch.input_type = "GEOMETRY"
-    links.new(gi.outputs["Fill"], switch.inputs["Switch"])
-    links.new(wire.outputs["Mesh"], switch.inputs["False"])
-    links.new(fill_curve.outputs["Mesh"], switch.inputs["True"])
+    links.new(use_vertices, switch.inputs["Switch"])
+    links.new(edges, switch.inputs["False"])
+    links.new(verts, switch.inputs["True"])
     links.new(switch.outputs["Output"], go.inputs["Geometry"])
 
     ng["cad_fillet_version"] = FILLET_VERSION


### PR DESCRIPTION
Draft. A generic, self-contained **Fillet** geometry-nodes modifier that rounds
the corners/edges of a sketch's *output* geometry -- it reads no sketch data and
works on any mesh.

## Built on Mesh Bevel (handles 2D and 3D)

The group wraps Blender's `GeometryNodeMeshBevel`, so one modifier covers both:

- **Flat profile** (a sketch fill/output) → rounds the boundary **corners**.
- **3D solid** (e.g. an extruded box) → rounds the **edges**.

An earlier curve-only pipeline (`MeshToCurve → Fillet Curve → Fill Curve`) was
2D-only and destroyed solids (a cube collapsed to 0 faces); Mesh Bevel fixes that
and is simpler.

## Inputs

- `Amount` — fillet width.
- `Segments` — roundness (a round profile, not a chamfer).
- `Affect` — `Auto` / `Vertices` / `Edges`. Auto picks Vertices for a flat/open
  mesh (it has boundary edges) and Edges for a closed solid.
- `Selection` — a per-element field; drive it to **fillet specific edges/corners**.

`is_modifier=True`, so it shows in Add Modifier > Geometry Nodes; an **Add Fillet**
button sits with the node-modifier tools (Extrude / Revolve / Array / Boolean).

## Verified (Blender 5.2, headless)

- `test_flat_profile_rounds_corners` — flat quad corners round (Auto→Vertices).
- `test_3d_solid_rounds_edges` — cube 8v/6f → beveled edges (the case that broke
  the old pipeline).
- `test_selection_fillets_only_chosen_elements` — a subset selection bevels fewer
  edges than "all".
- `test_fillet_rounds_the_sketch_output` — integration on a real sketch's convert
  output.
- Full suite: `Ran 446 tests ... OK` (2 pre-existing expected failures).

## Known limitation / next step

A **global** vertex fillet rounds *every* corner, including the dense tessellation
of an arc/circle in a flat profile (and Mesh Bevel bails when the amount exceeds
the spacing there). Driving `Selection` -- only true corners, or an angle
threshold -- is the intended way to fillet specific elements; wiring up that
authoring UI is the follow-up.
