### PR TITLE
Project-centric managed collections for CAD Sketcher objects

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -105,6 +105,12 @@ def on_depsgraph_update(scene, depsgraph):
 
         repair_origin_workplanes(bpy.context)
 
+        # Sketches rename through a plain name field; keep their collections in
+        # step (drift-reconcile, settles in one pass like the workplane repair).
+        from .utilities.collections import sync_sketch_collection_names
+
+        sync_sketch_collection_names(scene)
+
     if depsgraph.id_type_updated("SCENE"):
         global_data.needs_solve = True
 

--- a/model/native_3d.py
+++ b/model/native_3d.py
@@ -159,7 +159,7 @@ def create_3d_sketch(context, name="3D Sketch", matrix=None):
     remains free in XYZ and the Empty provides the stable origin required by
     placement/editing helpers.
     """
-    from ..utilities.collections import link_object
+    from ..utilities.collections import link_object, link_sketch_object
 
     origin = bpy.data.objects.new(f"{name} Origin", None)
     origin.empty_display_type = "PLAIN_AXES"
@@ -170,7 +170,7 @@ def create_3d_sketch(context, name="3D Sketch", matrix=None):
 
     curve = bpy.data.hair_curves.new(name)
     obj = bpy.data.objects.new(name, curve)
-    link_object(obj, context.scene)
+    link_sketch_object(obj, context.scene)
     stamp_sketch_props(obj)
     obj[SKETCH_3D_TAG] = True
 

--- a/model/native_3d.py
+++ b/model/native_3d.py
@@ -159,16 +159,18 @@ def create_3d_sketch(context, name="3D Sketch", matrix=None):
     remains free in XYZ and the Empty provides the stable origin required by
     placement/editing helpers.
     """
+    from ..utilities.collections import link_object
+
     origin = bpy.data.objects.new(f"{name} Origin", None)
     origin.empty_display_type = "PLAIN_AXES"
     origin.empty_display_size = 0.5
-    context.scene.collection.objects.link(origin)
+    link_object(origin, context.scene)
     origin.matrix_world = matrix.copy() if matrix is not None else Matrix.Identity(4)
     origin[SKETCH_3D_ORIGIN_TAG] = True
 
     curve = bpy.data.hair_curves.new(name)
     obj = bpy.data.objects.new(name, curve)
-    context.scene.collection.objects.link(obj)
+    link_object(obj, context.scene)
     stamp_sketch_props(obj)
     obj[SKETCH_3D_TAG] = True
 

--- a/model/native_3d.py
+++ b/model/native_3d.py
@@ -159,12 +159,12 @@ def create_3d_sketch(context, name="3D Sketch", matrix=None):
     remains free in XYZ and the Empty provides the stable origin required by
     placement/editing helpers.
     """
-    from ..utilities.collections import link_object, link_sketch_object
+    from ..utilities.collections import link_loose_workplane, link_sketch_object
 
     origin = bpy.data.objects.new(f"{name} Origin", None)
     origin.empty_display_type = "PLAIN_AXES"
     origin.empty_display_size = 0.5
-    link_object(origin, context.scene)
+    link_loose_workplane(origin, context.scene)
     origin.matrix_world = matrix.copy() if matrix is not None else Matrix.Identity(4)
     origin[SKETCH_3D_ORIGIN_TAG] = True
 
@@ -188,6 +188,11 @@ def create_3d_sketch(context, name="3D Sketch", matrix=None):
     obj.lock_location = (True, True, True)
     obj.lock_rotation = (True, True, True)
     obj.lock_scale = (True, True, True)
+
+    # The origin empty is dedicated to this sketch; group it with the sketch.
+    from ..utilities.collections import nest_workplane
+
+    nest_workplane(origin, obj)
     return Sketch(obj)
 
 

--- a/operators/add_sketch.py
+++ b/operators/add_sketch.py
@@ -124,9 +124,9 @@ class View3D_OT_slvs_add_sketch(Operator, Operator3d):
         empty = bpy.data.objects.new("Workplane", None)
         empty.empty_display_type = "PLAIN_AXES"
         empty.empty_display_size = 0.5
-        from ..utilities.collections import link_object
+        from ..utilities.collections import link_loose_workplane
 
-        link_object(empty, context.scene)
+        link_loose_workplane(empty, context.scene)
 
         empty.matrix_world = face_workplane_matrix(context, ob, face_index)
 

--- a/operators/add_sketch.py
+++ b/operators/add_sketch.py
@@ -30,9 +30,9 @@ def create_sketch_on_workplane(context: Context, wp_empty, operator: Operator):
     sketch_obj = bpy.data.objects.new("Sketch", curve)
 
     scene = context.scene
-    from ..utilities.collections import link_object
+    from ..utilities.collections import link_sketch_object
 
-    link_object(sketch_obj, scene)
+    link_sketch_object(sketch_obj, scene)
 
     stamp_sketch_props(sketch_obj)
     _ensure_convert_modifier(sketch_obj)

--- a/operators/add_sketch.py
+++ b/operators/add_sketch.py
@@ -44,6 +44,11 @@ def create_sketch_on_workplane(context: Context, wp_empty, operator: Operator):
     sketch_obj.lock_rotation = (True, True, True)
     sketch_obj.lock_scale = (True, True, True)
 
+    # Tuck a dedicated (face/custom) workplane in with its sketch, not at the root.
+    from ..utilities.collections import nest_workplane
+
+    nest_workplane(wp_orig, sketch_obj)
+
     sketch = Sketch(sketch_obj)
 
     origin = PointRef.create(sketch, (0.0, 0.0), fixed=True, is_origin=True)

--- a/operators/add_sketch.py
+++ b/operators/add_sketch.py
@@ -30,8 +30,9 @@ def create_sketch_on_workplane(context: Context, wp_empty, operator: Operator):
     sketch_obj = bpy.data.objects.new("Sketch", curve)
 
     scene = context.scene
-    if sketch_obj.name not in scene.collection.objects:
-        scene.collection.objects.link(sketch_obj)
+    from ..utilities.collections import link_object
+
+    link_object(sketch_obj, scene)
 
     stamp_sketch_props(sketch_obj)
     _ensure_convert_modifier(sketch_obj)
@@ -118,7 +119,9 @@ class View3D_OT_slvs_add_sketch(Operator, Operator3d):
         empty = bpy.data.objects.new("Workplane", None)
         empty.empty_display_type = "PLAIN_AXES"
         empty.empty_display_size = 0.5
-        context.scene.collection.objects.link(empty)
+        from ..utilities.collections import link_object
+
+        link_object(empty, context.scene)
 
         empty.matrix_world = face_workplane_matrix(context, ob, face_index)
 

--- a/operators/delete_sketch.py
+++ b/operators/delete_sketch.py
@@ -1,6 +1,6 @@
 import bpy
-from bpy.types import Operator, Context
 from bpy.props import StringProperty
+from bpy.types import Context, Operator
 from bpy.utils import register_classes_factory
 
 from ..declarations import Operators

--- a/operators/delete_sketch.py
+++ b/operators/delete_sketch.py
@@ -29,6 +29,11 @@ class View3D_OT_slvs_delete_sketch(Operator):
 
         # Remove the object (handler cleans up orphan constraints)
         bpy.data.objects.remove(ob)
+
+        # Drop the now-empty per-sketch collection.
+        from ..utilities.collections import cleanup_sketch_collections
+
+        cleanup_sketch_collections(context.scene)
         return {"FINISHED"}
 
 

--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -246,6 +246,11 @@ class BooleanFromToolMixin:
 
         self._apply_boolean_targets(cutter)
 
+        # Nest the cutter's collection under the bodies it now feeds.
+        from ..utilities.collections import organize_part_nesting
+
+        organize_part_nesting(context.scene)
+
     def _apply_boolean_targets(self, cutter):
         name = boolean_modifier_name(cutter)
         enabled_bodies = set()

--- a/testing/test_collections.py
+++ b/testing/test_collections.py
@@ -65,6 +65,37 @@ class TestManagedCollection(Sketch2dTestCase):
             self.assertNotIn(ob.name, root.objects)
             self.assertNotIn(ob.name, self.context.scene.collection.objects)
 
+    def test_dedicated_workplane_nests_with_its_sketch(self):
+        from ..utilities.collections import link_object, nest_workplane
+
+        ob = self.sketch.target_object
+        sub = self._sketch_subcollection(ob)
+        root = self._cad_collection()
+
+        wp = bpy.data.objects.new("Workplane", None)
+        link_object(wp, self.context.scene)  # a face workplane starts at the root
+        self.assertIn(wp.name, root.objects)
+
+        ob.parent = wp
+        nest_workplane(wp, ob)
+        try:
+            self.assertIn(wp.name, sub.objects, "workplane should nest with its sketch")
+            self.assertNotIn(wp.name, root.objects, "and leave the root")
+        finally:
+            bpy.data.objects.remove(wp)
+
+    def test_origin_plane_is_not_stolen_into_a_sketch(self):
+        from ..utilities.collections import nest_workplane
+        from ..utilities.workplane import ensure_origin_workplane_empties
+
+        ensure_origin_workplane_empties(self.context)
+        origin = next(
+            c for c in self._cad_collection().children if c.get("cad_origin_collection")
+        )
+        wp_xy = next(iter(origin.objects))
+        nest_workplane(wp_xy, self.sketch.target_object)
+        self.assertIn(wp_xy.name, origin.objects, "origin plane must stay in Origin")
+
     def test_cutter_nests_under_the_body_it_feeds(self):
         from ..operators.modifiers import apply_boolean, boolean_cutters
         from ..utilities.collections import organize_part_nesting

--- a/testing/test_collections.py
+++ b/testing/test_collections.py
@@ -8,7 +8,7 @@ object is both source and consumable).
 
 import bpy
 
-from ..utilities.collections import CAD_COLLECTION_NAME, ensure_cad_collection
+from ..utilities.collections import ensure_cad_collection
 from ..utilities.curve_data import refresh_curve_geometry
 from .utils import Sketch2dTestCase
 
@@ -26,19 +26,19 @@ class TestManagedCollection(Sketch2dTestCase):
                 return coll
         return None
 
-    def test_sketch_object_lands_in_its_own_subcollection(self):
+    def test_part_collection_is_at_the_scene_level(self):
         ob = self.sketch.target_object
-        root = self._cad_collection()
-        self.assertIsNotNone(root, "CAD Sketcher collection was not created")
-        self.assertEqual(root.name.split(".")[0], CAD_COLLECTION_NAME)
-
         sub = self._sketch_subcollection(ob)
-        self.assertIsNotNone(sub, "sketch object not in a per-sketch sub-collection")
-        self.assertIn(sub.name, root.children, "sub-collection not under the CAD root")
+        self.assertIsNotNone(sub, "sketch object not in a per-sketch collection")
+        self.assertIn(
+            sub.name,
+            self.context.scene.collection.children,
+            "part collection should be at the scene level, not under a wrapper",
+        )
         self.assertNotIn(
             ob.name,
             self.context.scene.collection.objects,
-            "sketch object should not stay in the scene master collection",
+            "sketch object should not sit loose in the scene master collection",
         )
 
     def test_each_sketch_gets_a_distinct_subcollection(self):
@@ -70,10 +70,10 @@ class TestManagedCollection(Sketch2dTestCase):
 
         ob = self.sketch.target_object
         sub = self._sketch_subcollection(ob)
-        root = self._cad_collection()
 
         wp = bpy.data.objects.new("Workplane", None)
-        link_object(wp, self.context.scene)  # a face workplane starts at the root
+        link_object(wp, self.context.scene)  # a face workplane starts in internals
+        root = self._cad_collection()
         self.assertIn(wp.name, root.objects)
 
         ob.parent = wp
@@ -104,8 +104,8 @@ class TestManagedCollection(Sketch2dTestCase):
         cutter_obj = self.new_sketch().target_object
         body_coll = self._sketch_subcollection(body_obj)
         cutter_coll = self._sketch_subcollection(cutter_obj)
-        root = self._cad_collection()
-        self.assertIn(cutter_coll.name, root.children)
+        scene_children = self.context.scene.collection.children
+        self.assertIn(cutter_coll.name, scene_children)
 
         mod = apply_boolean(body_obj, cutter_obj)
         self.assertIsNotNone(mod, "boolean was refused (cycle?)")
@@ -113,12 +113,12 @@ class TestManagedCollection(Sketch2dTestCase):
 
         organize_part_nesting(self.context.scene)
         self.assertIn(cutter_coll.name, body_coll.children, "cutter did not nest")
-        self.assertNotIn(cutter_coll.name, root.children)
+        self.assertNotIn(cutter_coll.name, scene_children)
 
-        # Removing the boolean un-nests it back to the root.
+        # Removing the boolean un-nests it back to the scene level.
         body_obj.modifiers.remove(mod)
         organize_part_nesting(self.context.scene)
-        self.assertIn(cutter_coll.name, root.children, "cutter did not un-nest")
+        self.assertIn(cutter_coll.name, scene_children, "cutter did not un-nest")
         self.assertNotIn(cutter_coll.name, body_coll.children)
 
     def test_renaming_a_sketch_syncs_its_collection(self):
@@ -144,15 +144,17 @@ class TestManagedCollection(Sketch2dTestCase):
         name = sub.name
         bpy.data.objects.remove(extra.target_object)
         cleanup_sketch_collections(self.context.scene)
-        self.assertNotIn(name, {c.name for c in self._cad_collection().children})
+        self.assertNotIn(name, {c.name for c in self.context.scene.collection.children})
 
-    def test_collection_is_linked_but_not_excluded(self):
-        """The collection must stay in the view layer so its objects evaluate."""
-        coll = self._cad_collection()
+    def test_internals_collection_is_linked_but_not_excluded(self):
+        """The internals collection must stay in the view layer (never excluded)."""
+        coll = ensure_cad_collection(self.context.scene)
         self.assertIn(coll.name, self.context.scene.collection.children)
         layer_coll = self.context.view_layer.layer_collection.children.get(coll.name)
         self.assertIsNotNone(layer_coll)
-        self.assertFalse(layer_coll.exclude, "managed collection must not be excluded")
+        self.assertFalse(
+            layer_coll.exclude, "internals collection must not be excluded"
+        )
 
     def test_fill_still_evaluates_from_the_collection(self):
         corners = [(-2, -2), (2, -2), (2, 2), (-2, 2)]

--- a/testing/test_collections.py
+++ b/testing/test_collections.py
@@ -48,6 +48,23 @@ class TestManagedCollection(Sketch2dTestCase):
         self.assertIsNotNone(second)
         self.assertIsNot(first, second, "two sketches must not share a sub-collection")
 
+    def test_origin_planes_go_in_the_origin_collection(self):
+        from ..utilities.workplane import ensure_origin_workplane_empties
+
+        ensure_origin_workplane_empties(self.context)
+        root = self._cad_collection()
+        origin = next(
+            (c for c in root.children if c.get("cad_origin_collection")), None
+        )
+        self.assertIsNotNone(origin, "Origin sub-collection not created")
+        self.assertGreaterEqual(
+            len(origin.objects), 3, "the three origin planes should be grouped here"
+        )
+        # And not scattered in the CAD root or the scene master.
+        for ob in origin.objects:
+            self.assertNotIn(ob.name, root.objects)
+            self.assertNotIn(ob.name, self.context.scene.collection.objects)
+
     def test_cutter_nests_under_the_body_it_feeds(self):
         from ..operators.modifiers import apply_boolean, boolean_cutters
         from ..utilities.collections import organize_part_nesting

--- a/testing/test_collections.py
+++ b/testing/test_collections.py
@@ -48,6 +48,31 @@ class TestManagedCollection(Sketch2dTestCase):
         self.assertIsNotNone(second)
         self.assertIsNot(first, second, "two sketches must not share a sub-collection")
 
+    def test_cutter_nests_under_the_body_it_feeds(self):
+        from ..operators.modifiers import apply_boolean, boolean_cutters
+        from ..utilities.collections import organize_part_nesting
+
+        body_obj = self.sketch.target_object
+        cutter_obj = self.new_sketch().target_object
+        body_coll = self._sketch_subcollection(body_obj)
+        cutter_coll = self._sketch_subcollection(cutter_obj)
+        root = self._cad_collection()
+        self.assertIn(cutter_coll.name, root.children)
+
+        mod = apply_boolean(body_obj, cutter_obj)
+        self.assertIsNotNone(mod, "boolean was refused (cycle?)")
+        self.assertIn(cutter_obj, boolean_cutters(body_obj))
+
+        organize_part_nesting(self.context.scene)
+        self.assertIn(cutter_coll.name, body_coll.children, "cutter did not nest")
+        self.assertNotIn(cutter_coll.name, root.children)
+
+        # Removing the boolean un-nests it back to the root.
+        body_obj.modifiers.remove(mod)
+        organize_part_nesting(self.context.scene)
+        self.assertIn(cutter_coll.name, root.children, "cutter did not un-nest")
+        self.assertNotIn(cutter_coll.name, body_coll.children)
+
     def test_deleting_a_sketch_removes_its_empty_collection(self):
         from ..utilities.collections import cleanup_sketch_collections
 

--- a/testing/test_collections.py
+++ b/testing/test_collections.py
@@ -1,0 +1,79 @@
+"""CAD Sketcher objects live in a managed, still-evaluating collection.
+
+Guards P1: sketch curve objects and workplane empties go into a per-scene
+"CAD Sketcher" collection instead of the scene master collection, and that
+collection is never excluded -- excluding it would drop the fill (the curve
+object is both source and consumable).
+"""
+
+import bpy
+
+from ..utilities.collections import CAD_COLLECTION_NAME, ensure_cad_collection
+from ..utilities.curve_data import refresh_curve_geometry
+from .utils import Sketch2dTestCase
+
+
+class TestManagedCollection(Sketch2dTestCase):
+    def _cad_collection(self):
+        for child in self.context.scene.collection.children:
+            if child.get("is_cad_sketcher"):
+                return child
+        return None
+
+    def test_sketch_object_lands_in_managed_collection(self):
+        ob = self.sketch.target_object
+        coll = self._cad_collection()
+        self.assertIsNotNone(coll, "CAD Sketcher collection was not created")
+        self.assertEqual(coll.name.split(".")[0], CAD_COLLECTION_NAME)
+        self.assertIn(ob.name, coll.objects, "sketch object not in the collection")
+        self.assertNotIn(
+            ob.name,
+            self.context.scene.collection.objects,
+            "sketch object should not stay in the scene master collection",
+        )
+
+    def test_collection_is_linked_but_not_excluded(self):
+        """The collection must stay in the view layer so its objects evaluate."""
+        coll = self._cad_collection()
+        self.assertIn(coll.name, self.context.scene.collection.children)
+        layer_coll = self.context.view_layer.layer_collection.children.get(coll.name)
+        self.assertIsNotNone(layer_coll)
+        self.assertFalse(layer_coll.exclude, "managed collection must not be excluded")
+
+    def test_fill_still_evaluates_from_the_collection(self):
+        corners = [(-2, -2), (2, -2), (2, 2), (-2, 2)]
+        pts = [self.add_point(c) for c in corners]
+        for i in range(4):
+            self.add_line(pts[i], pts[(i + 1) % 4])
+        self.solve()
+        refresh_curve_geometry(self.sketch)
+
+        ob = self.sketch.target_object
+        scene = self.context.scene
+        dup = ob.copy()
+        dup.data = ob.data.copy()
+        scene.collection.objects.link(dup)
+        for o in scene.collection.all_objects:
+            o.select_set(False)
+        dup.select_set(True)
+        self.context.view_layer.objects.active = dup
+        bpy.ops.object.convert(target="MESH")
+        area = sum(p.area for p in dup.data.polygons)
+        bpy.data.objects.remove(dup, do_unlink=True)
+
+        self.assertAlmostEqual(
+            area, 16.0, delta=0.01, msg="fill did not evaluate -> collection excluded?"
+        )
+
+    def test_ensure_collection_is_idempotent_and_per_scene(self):
+        scene = self.context.scene
+        a = ensure_cad_collection(scene)
+        b = ensure_cad_collection(scene)
+        self.assertIs(a, b, "ensure_cad_collection must reuse the scene's collection")
+
+        other = bpy.data.scenes.new("other_scene")
+        try:
+            c = ensure_cad_collection(other)
+            self.assertIsNot(c, a, "each scene must own its own collection")
+        finally:
+            bpy.data.scenes.remove(other)

--- a/testing/test_collections.py
+++ b/testing/test_collections.py
@@ -121,6 +121,20 @@ class TestManagedCollection(Sketch2dTestCase):
         self.assertIn(cutter_coll.name, root.children, "cutter did not un-nest")
         self.assertNotIn(cutter_coll.name, body_coll.children)
 
+    def test_renaming_a_sketch_syncs_its_collection(self):
+        from ..utilities.collections import sync_sketch_collection_names
+
+        ob = self.sketch.target_object
+        sub = self._sketch_subcollection(ob)
+        ob.name = "Renamed Sketch"
+        sync_sketch_collection_names(self.context.scene)
+        self.assertEqual(sub.name, "Renamed Sketch", "collection did not follow rename")
+
+        # Runs again with no change: no rename loop.
+        prev = sub.name
+        sync_sketch_collection_names(self.context.scene)
+        self.assertEqual(sub.name, prev, "sync must be stable, not re-rename")
+
     def test_deleting_a_sketch_removes_its_empty_collection(self):
         from ..utilities.collections import cleanup_sketch_collections
 

--- a/testing/test_collections.py
+++ b/testing/test_collections.py
@@ -20,17 +20,44 @@ class TestManagedCollection(Sketch2dTestCase):
                 return child
         return None
 
-    def test_sketch_object_lands_in_managed_collection(self):
+    def _sketch_subcollection(self, ob):
+        for coll in ob.users_collection:
+            if coll.get("cad_sketch_collection"):
+                return coll
+        return None
+
+    def test_sketch_object_lands_in_its_own_subcollection(self):
         ob = self.sketch.target_object
-        coll = self._cad_collection()
-        self.assertIsNotNone(coll, "CAD Sketcher collection was not created")
-        self.assertEqual(coll.name.split(".")[0], CAD_COLLECTION_NAME)
-        self.assertIn(ob.name, coll.objects, "sketch object not in the collection")
+        root = self._cad_collection()
+        self.assertIsNotNone(root, "CAD Sketcher collection was not created")
+        self.assertEqual(root.name.split(".")[0], CAD_COLLECTION_NAME)
+
+        sub = self._sketch_subcollection(ob)
+        self.assertIsNotNone(sub, "sketch object not in a per-sketch sub-collection")
+        self.assertIn(sub.name, root.children, "sub-collection not under the CAD root")
         self.assertNotIn(
             ob.name,
             self.context.scene.collection.objects,
             "sketch object should not stay in the scene master collection",
         )
+
+    def test_each_sketch_gets_a_distinct_subcollection(self):
+        first = self._sketch_subcollection(self.sketch.target_object)
+        second_sketch = self.new_sketch()
+        second = self._sketch_subcollection(second_sketch.target_object)
+        self.assertIsNotNone(second)
+        self.assertIsNot(first, second, "two sketches must not share a sub-collection")
+
+    def test_deleting_a_sketch_removes_its_empty_collection(self):
+        from ..utilities.collections import cleanup_sketch_collections
+
+        extra = self.new_sketch()
+        sub = self._sketch_subcollection(extra.target_object)
+        self.assertIsNotNone(sub)
+        name = sub.name
+        bpy.data.objects.remove(extra.target_object)
+        cleanup_sketch_collections(self.context.scene)
+        self.assertNotIn(name, {c.name for c in self._cad_collection().children})
 
     def test_collection_is_linked_but_not_excluded(self):
         """The collection must stay in the view layer so its objects evaluate."""

--- a/testing/test_collections.py
+++ b/testing/test_collections.py
@@ -1,22 +1,21 @@
-"""CAD Sketcher objects live in a managed, still-evaluating collection.
+"""Project-centric managed collections for CAD Sketcher.
 
-Guards P1: sketch curve objects and workplane empties go into a per-scene
-"CAD Sketcher" collection instead of the scene master collection, and that
-collection is never excluded -- excluding it would drop the fill (the curve
-object is both source and consumable).
+Each sketch/part is its own scene-level collection (its workplane nested inside);
+cutters nest under the body they feed; only the shared origin planes live in a
+scene-level "Origin" collection. Nothing is excluded from the view layer --
+excluding would drop the fill (the curve object is both source and consumable).
 """
 
 import bpy
 
-from ..utilities.collections import ensure_cad_collection
 from ..utilities.curve_data import refresh_curve_geometry
 from .utils import Sketch2dTestCase
 
 
 class TestManagedCollection(Sketch2dTestCase):
-    def _cad_collection(self):
+    def _origin_collection(self):
         for child in self.context.scene.collection.children:
-            if child.get("is_cad_sketcher"):
+            if child.get("cad_origin_collection"):
                 return child
         return None
 
@@ -48,50 +47,65 @@ class TestManagedCollection(Sketch2dTestCase):
         self.assertIsNotNone(second)
         self.assertIsNot(first, second, "two sketches must not share a sub-collection")
 
-    def test_origin_planes_go_in_the_origin_collection(self):
+    def test_origin_planes_go_in_a_scene_level_origin_collection(self):
         from ..utilities.workplane import ensure_origin_workplane_empties
 
         ensure_origin_workplane_empties(self.context)
-        root = self._cad_collection()
-        origin = next(
-            (c for c in root.children if c.get("cad_origin_collection")), None
+        origin = self._origin_collection()
+        self.assertIsNotNone(origin, "Origin collection not created")
+        self.assertIn(
+            origin.name,
+            self.context.scene.collection.children,
+            "Origin should be a scene-level collection (no wrapper)",
         )
-        self.assertIsNotNone(origin, "Origin sub-collection not created")
         self.assertGreaterEqual(
             len(origin.objects), 3, "the three origin planes should be grouped here"
         )
-        # And not scattered in the CAD root or the scene master.
         for ob in origin.objects:
-            self.assertNotIn(ob.name, root.objects)
             self.assertNotIn(ob.name, self.context.scene.collection.objects)
 
     def test_dedicated_workplane_nests_with_its_sketch(self):
-        from ..utilities.collections import link_object, nest_workplane
+        from ..utilities.collections import link_loose_workplane, nest_workplane
 
         ob = self.sketch.target_object
         sub = self._sketch_subcollection(ob)
 
         wp = bpy.data.objects.new("Workplane", None)
-        link_object(wp, self.context.scene)  # a face workplane starts in internals
-        root = self._cad_collection()
-        self.assertIn(wp.name, root.objects)
+        link_loose_workplane(wp, self.context.scene)  # starts loose at scene level
+        self.assertIn(wp.name, self.context.scene.collection.objects)
 
         ob.parent = wp
         nest_workplane(wp, ob)
         try:
             self.assertIn(wp.name, sub.objects, "workplane should nest with its sketch")
-            self.assertNotIn(wp.name, root.objects, "and leave the root")
+            self.assertNotIn(
+                wp.name,
+                self.context.scene.collection.objects,
+                "and leave the scene root",
+            )
         finally:
             bpy.data.objects.remove(wp)
+
+    def test_free_3d_origin_nests_with_its_sketch(self):
+        from ..model.native_3d import create_3d_sketch
+
+        sketch = create_3d_sketch(self.context, "Free3D")
+        obj = sketch.target_object
+        origin = obj.parent
+        self.assertIsNotNone(origin, "free-3D sketch has no origin empty")
+        sub = self._sketch_subcollection(obj)
+        self.assertIsNotNone(sub)
+        self.assertIn(
+            origin.name, sub.objects, "free-3D origin should nest with its sketch"
+        )
+        self.assertNotIn(origin.name, self.context.scene.collection.objects)
 
     def test_origin_plane_is_not_stolen_into_a_sketch(self):
         from ..utilities.collections import nest_workplane
         from ..utilities.workplane import ensure_origin_workplane_empties
 
         ensure_origin_workplane_empties(self.context)
-        origin = next(
-            c for c in self._cad_collection().children if c.get("cad_origin_collection")
-        )
+        origin = self._origin_collection()
         wp_xy = next(iter(origin.objects))
         nest_workplane(wp_xy, self.sketch.target_object)
         self.assertIn(wp_xy.name, origin.objects, "origin plane must stay in Origin")
@@ -146,15 +160,15 @@ class TestManagedCollection(Sketch2dTestCase):
         cleanup_sketch_collections(self.context.scene)
         self.assertNotIn(name, {c.name for c in self.context.scene.collection.children})
 
-    def test_internals_collection_is_linked_but_not_excluded(self):
-        """The internals collection must stay in the view layer (never excluded)."""
-        coll = ensure_cad_collection(self.context.scene)
+    def test_origin_collection_is_linked_but_not_excluded(self):
+        """The Origin collection must stay in the view layer (never excluded)."""
+        from ..utilities.collections import origin_collection
+
+        coll = origin_collection(self.context.scene)
         self.assertIn(coll.name, self.context.scene.collection.children)
         layer_coll = self.context.view_layer.layer_collection.children.get(coll.name)
         self.assertIsNotNone(layer_coll)
-        self.assertFalse(
-            layer_coll.exclude, "internals collection must not be excluded"
-        )
+        self.assertFalse(layer_coll.exclude, "Origin collection must not be excluded")
 
     def test_fill_still_evaluates_from_the_collection(self):
         corners = [(-2, -2), (2, -2), (2, 2), (-2, 2)]
@@ -181,15 +195,17 @@ class TestManagedCollection(Sketch2dTestCase):
             area, 16.0, delta=0.01, msg="fill did not evaluate -> collection excluded?"
         )
 
-    def test_ensure_collection_is_idempotent_and_per_scene(self):
+    def test_origin_collection_is_idempotent_and_per_scene(self):
+        from ..utilities.collections import origin_collection
+
         scene = self.context.scene
-        a = ensure_cad_collection(scene)
-        b = ensure_cad_collection(scene)
-        self.assertIs(a, b, "ensure_cad_collection must reuse the scene's collection")
+        a = origin_collection(scene)
+        b = origin_collection(scene)
+        self.assertIs(a, b, "origin_collection must reuse the scene's collection")
 
         other = bpy.data.scenes.new("other_scene")
         try:
-            c = ensure_cad_collection(other)
-            self.assertIsNot(c, a, "each scene must own its own collection")
+            c = origin_collection(other)
+            self.assertIsNot(c, a, "each scene must own its own Origin collection")
         finally:
             bpy.data.scenes.remove(other)

--- a/utilities/collections.py
+++ b/utilities/collections.py
@@ -1,14 +1,15 @@
-"""Managed collection for CAD Sketcher's internal objects.
+"""Managed collections for CAD Sketcher.
 
-Groups the add-on's objects -- sketch curve objects and workplane empties --
-under one collection per scene instead of scattering them through the scene's
-master collection, so the outliner stays clean and the internals are easy to
-find or hide as a group.
+Layout is *project-centric*, not addon-centric: each part is its own collection
+at the **scene level** (where users expect their models), with cutter sketches
+nested under the body they feed. Only genuinely shared internals -- the three
+origin planes and any not-yet-claimed workplane empties -- live in a small
+``CAD Sketcher`` collection; parts are never nested inside it.
 
-Critical invariant: the collection is **hidden, never excluded**. Excluding it
-from the view layer removes its objects from the depsgraph, which stops the
-convert modifier and drops the fill (the curve object is both source and
-consumable). Visibility is a display concern; evaluation must keep running.
+Critical invariant: nothing is **excluded** from the view layer. Excluding a
+collection removes its objects from the depsgraph, which stops the convert
+modifier and drops the fill (the curve object is both source and consumable).
+Visibility is a display concern; evaluation must keep running.
 """
 
 import bpy
@@ -29,11 +30,11 @@ def _find_cad_collection(scene):
 
 
 def ensure_cad_collection(scene):
-    """Return this scene's CAD Sketcher collection, creating+linking it once.
+    """Return this scene's shared-internals collection, creating+linking it once.
 
-    Found by a marker among the scene's own child collections (not by a global
-    name) so each scene owns its own collection -- shared datablocks would leak
-    one scene's sketches into another.
+    Holds only shared internals (origin planes, transient workplanes) -- parts
+    live at the scene level, not inside it. Found by a marker among the scene's
+    own child collections (not by a global name) so each scene owns its own.
     """
     coll = _find_cad_collection(scene)
     if coll is not None:
@@ -116,11 +117,11 @@ def link_sketch_object(obj, scene):
     for coll in obj.users_collection:
         if coll.get(_SKETCH_MARKER):
             return coll
-    root = ensure_cad_collection(scene)
     sub = bpy.data.collections.new(obj.name)
     sub[_SKETCH_MARKER] = True
     sub[_SYNCED_NAME] = obj.name
-    root.children.link(sub)
+    # Part collections live at the scene level, not inside the internals wrapper.
+    scene.collection.children.link(sub)
     _clear_object_collections(obj)
     sub.objects.link(obj)
     return sub
@@ -134,10 +135,7 @@ def sync_sketch_collection_names(scene):
     collision -- where Blender appends a numeric suffix -- can't spin a rename
     loop; only writes on an actual change, settling in one pass.
     """
-    root = _find_cad_collection(scene)
-    if root is None:
-        return
-    for sub in _walk_sketch_collections(root):
+    for sub in _walk_sketch_collections(scene.collection):
         obj = next((o for o in sub.objects if o.type == "CURVES"), None)
         if obj is None:
             continue
@@ -147,11 +145,8 @@ def sync_sketch_collection_names(scene):
 
 
 def cleanup_sketch_collections(scene):
-    """Remove empty per-sketch sub-collections (e.g. after a sketch is deleted)."""
-    root = _find_cad_collection(scene)
-    if root is None:
-        return
-    for sub in _walk_sketch_collections(root):
+    """Remove empty per-sketch collections (e.g. after a sketch is deleted)."""
+    for sub in _walk_sketch_collections(scene.collection):
         if not sub.objects and not sub.children:
             bpy.data.collections.remove(sub)
 
@@ -168,9 +163,12 @@ def _walk_sketch_collections(root):
 
 
 def _reparent_collection(coll, parent):
-    """Move ``coll`` to be a direct child of ``parent`` (single parent)."""
+    """Move ``coll`` to be the single direct child of ``parent``."""
     if coll.name in parent.children:
         return
+    for scene in bpy.data.scenes:
+        if coll.name in scene.collection.children:
+            scene.collection.children.unlink(coll)
     for other in bpy.data.collections:
         if coll.name in other.children:
             other.children.unlink(coll)
@@ -181,18 +179,17 @@ def organize_part_nesting(scene):
     """Nest each cutter sketch's collection under the body it feeds.
 
     Rebuilt from the boolean dependency graph, so it converges no matter the order
-    booleans were added or removed. The graph is a DAG (the boolean tool refuses
-    cycles), so the collection tree can't cycle either. A cutter feeding several
-    bodies nests under one of them -- Blender has no clean multi-parent tree; the
-    other bodies still reference it, which is harmless.
+    booleans were added or removed. Parts live at the scene level; a cutter's
+    collection moves under the body's. The graph is a DAG (the boolean tool
+    refuses cycles), so the tree can't cycle. A cutter feeding several bodies
+    nests under one -- Blender has no clean multi-parent tree; the others still
+    reference it, which is harmless.
     """
-    root = _find_cad_collection(scene)
-    if root is None:
-        return
     from ..operators.modifiers import boolean_cutters
 
+    container = scene.collection
     by_obj = {}
-    for coll in _walk_sketch_collections(root):
+    for coll in _walk_sketch_collections(container):
         for obj in coll.objects:
             by_obj[obj] = coll
 
@@ -203,10 +200,10 @@ def organize_part_nesting(scene):
             if cutter_coll is not None and cutter_coll is not body_coll:
                 parent_of[cutter_coll] = body_coll
 
-    # Flatten to root first so nesting can't transiently form a descendant cycle.
+    # Flatten to the scene root first so nesting can't transiently form a cycle.
     subs = set(by_obj.values())
     for coll in subs:
-        _reparent_collection(coll, root)
+        _reparent_collection(coll, container)
     for coll in subs:
         target = parent_of.get(coll)
         if target is not None:

--- a/utilities/collections.py
+++ b/utilities/collections.py
@@ -1,0 +1,48 @@
+"""Managed collection for CAD Sketcher's internal objects.
+
+Groups the add-on's objects -- sketch curve objects and workplane empties --
+under one collection per scene instead of scattering them through the scene's
+master collection, so the outliner stays clean and the internals are easy to
+find or hide as a group.
+
+Critical invariant: the collection is **hidden, never excluded**. Excluding it
+from the view layer removes its objects from the depsgraph, which stops the
+convert modifier and drops the fill (the curve object is both source and
+consumable). Visibility is a display concern; evaluation must keep running.
+"""
+
+import bpy
+
+CAD_COLLECTION_NAME = "CAD Sketcher"
+_MARKER = "is_cad_sketcher"
+
+
+def ensure_cad_collection(scene):
+    """Return this scene's CAD Sketcher collection, creating+linking it once.
+
+    Found by a marker among the scene's own child collections (not by a global
+    name) so each scene owns its own collection -- shared datablocks would leak
+    one scene's sketches into another.
+    """
+    for child in scene.collection.children:
+        if child.get(_MARKER):
+            return child
+    coll = bpy.data.collections.new(CAD_COLLECTION_NAME)
+    coll[_MARKER] = True
+    scene.collection.children.link(coll)
+    return coll
+
+
+def link_object(obj, scene):
+    """Link ``obj`` into the scene's CAD Sketcher collection, and nowhere else.
+
+    Safe to call on a freshly created (unlinked) object; also relocates one that
+    was linked into the scene master collection.
+    """
+    coll = ensure_cad_collection(scene)
+    if obj.name not in coll.objects:
+        coll.objects.link(obj)
+    master = scene.collection
+    if obj.name in master.objects:
+        master.objects.unlink(obj)
+    return coll

--- a/utilities/collections.py
+++ b/utilities/collections.py
@@ -2,9 +2,9 @@
 
 Layout is *project-centric*, not addon-centric: each part is its own collection
 at the **scene level** (where users expect their models), with cutter sketches
-nested under the body they feed. Only genuinely shared internals -- the three
-origin planes and any not-yet-claimed workplane empties -- live in a small
-``CAD Sketcher`` collection; parts are never nested inside it.
+nested under the body they feed and each sketch's own workplane grouped inside
+it. The only genuinely shared thing -- the three origin planes -- lives in a
+scene-level ``Origin`` collection. There is no addon wrapper collection.
 
 Critical invariant: nothing is **excluded** from the view layer. Excluding a
 collection removes its objects from the depsgraph, which stops the convert
@@ -14,35 +14,10 @@ Visibility is a display concern; evaluation must keep running.
 
 import bpy
 
-CAD_COLLECTION_NAME = "CAD Sketcher"
 ORIGIN_COLLECTION_NAME = "Origin"
-_MARKER = "is_cad_sketcher"
 _SKETCH_MARKER = "cad_sketch_collection"
 _ORIGIN_MARKER = "cad_origin_collection"
 _SYNCED_NAME = "cad_synced_name"
-
-
-def _find_cad_collection(scene):
-    for child in scene.collection.children:
-        if child.get(_MARKER):
-            return child
-    return None
-
-
-def ensure_cad_collection(scene):
-    """Return this scene's shared-internals collection, creating+linking it once.
-
-    Holds only shared internals (origin planes, transient workplanes) -- parts
-    live at the scene level, not inside it. Found by a marker among the scene's
-    own child collections (not by a global name) so each scene owns its own.
-    """
-    coll = _find_cad_collection(scene)
-    if coll is not None:
-        return coll
-    coll = bpy.data.collections.new(CAD_COLLECTION_NAME)
-    coll[_MARKER] = True
-    scene.collection.children.link(coll)
-    return coll
 
 
 def _clear_object_collections(obj):
@@ -50,35 +25,36 @@ def _clear_object_collections(obj):
         coll.objects.unlink(obj)
 
 
-def link_object(obj, scene):
-    """Link ``obj`` into the scene's CAD Sketcher root collection, and nowhere else.
+def link_loose_workplane(obj, scene):
+    """Link a not-yet-claimed workplane empty at the scene level (transient home).
 
-    Used for shared internals (workplane empties). Safe on a freshly created
-    object; also relocates one linked into the scene master collection.
+    Used for a workplane created before its sketch exists (e.g. a face pick);
+    ``nest_workplane`` moves it into the sketch's collection once that's created.
+    A workplane that never gets a sketch simply stays a scene-level object.
     """
-    coll = ensure_cad_collection(scene)
-    if obj.name not in coll.objects:
-        coll.objects.link(obj)
-    master = scene.collection
-    if obj.name in master.objects:
-        master.objects.unlink(obj)
-    return coll
+    if obj.name not in scene.collection.objects:
+        _clear_object_collections(obj)
+        scene.collection.objects.link(obj)
+    return scene.collection
 
 
 def origin_collection(scene):
-    """Sub-collection under the CAD root that holds the three origin planes."""
-    root = ensure_cad_collection(scene)
-    for child in root.children:
+    """Scene-level ``Origin`` collection holding the three origin planes.
+
+    The only shared internals; found by a marker among the scene's own children
+    so each scene owns its own.
+    """
+    for child in scene.collection.children:
         if child.get(_ORIGIN_MARKER):
             return child
     coll = bpy.data.collections.new(ORIGIN_COLLECTION_NAME)
     coll[_ORIGIN_MARKER] = True
-    root.children.link(coll)
+    scene.collection.children.link(coll)
     return coll
 
 
 def link_origin_workplane(obj, scene):
-    """Group the XY/XZ/YZ origin empties in their own 'Origin' sub-collection."""
+    """Group the XY/XZ/YZ origin empties in the scene-level 'Origin' collection."""
     coll = origin_collection(scene)
     if obj.name in coll.objects:
         return coll
@@ -88,31 +64,33 @@ def link_origin_workplane(obj, scene):
 
 
 def nest_workplane(workplane, sketch_obj):
-    """Move a dedicated (face/custom) workplane empty into its sketch's collection.
+    """Move a dedicated workplane empty into its sketch's collection.
 
-    A workplane created for one sketch otherwise clutters the root; grouping it
-    with the sketch it belongs to keeps the tree tidy. Skipped for origin planes
-    (shared, kept in the Origin collection) and for a workplane already grouped
-    with another sketch (don't steal a shared custom plane).
+    A workplane made for one sketch (face, entity, or free-3D origin) otherwise
+    clutters the scene root; grouping it with its sketch keeps the tree tidy.
+    Skipped for origin planes (shared) and for a workplane already grouped with a
+    sketch (don't steal a shared custom plane). Returns the collection, or None.
     """
     if workplane is None:
-        return
+        return None
     for coll in workplane.users_collection:
         if coll.get(_ORIGIN_MARKER) or coll.get(_SKETCH_MARKER):
-            return
+            return None
     sub = next((c for c in sketch_obj.users_collection if c.get(_SKETCH_MARKER)), None)
-    if sub is None or workplane.name in sub.objects:
-        return
-    _clear_object_collections(workplane)
-    sub.objects.link(workplane)
+    if sub is None:
+        return None
+    if workplane.name not in sub.objects:
+        _clear_object_collections(workplane)
+        sub.objects.link(workplane)
+    return sub
 
 
 def link_sketch_object(obj, scene):
-    """Put a sketch's curve object in its own sub-collection under the CAD root.
+    """Put a sketch's curve object in its own scene-level collection.
 
-    One collection per sketch keeps the outliner readable; workplanes stay in the
-    root (they're shared and hidden). Idempotent: an object already in a sketch
-    sub-collection is left where it is.
+    One collection per sketch keeps the outliner readable; the sketch's workplane
+    nests in here too. Idempotent: an object already in a sketch collection is
+    left where it is.
     """
     for coll in obj.users_collection:
         if coll.get(_SKETCH_MARKER):

--- a/utilities/collections.py
+++ b/utilities/collections.py
@@ -18,6 +18,7 @@ ORIGIN_COLLECTION_NAME = "Origin"
 _MARKER = "is_cad_sketcher"
 _SKETCH_MARKER = "cad_sketch_collection"
 _ORIGIN_MARKER = "cad_origin_collection"
+_SYNCED_NAME = "cad_synced_name"
 
 
 def _find_cad_collection(scene):
@@ -118,10 +119,31 @@ def link_sketch_object(obj, scene):
     root = ensure_cad_collection(scene)
     sub = bpy.data.collections.new(obj.name)
     sub[_SKETCH_MARKER] = True
+    sub[_SYNCED_NAME] = obj.name
     root.children.link(sub)
     _clear_object_collections(obj)
     sub.objects.link(obj)
     return sub
+
+
+def sync_sketch_collection_names(scene):
+    """Reconcile each per-sketch sub-collection's name with its sketch object.
+
+    Sketches rename through a plain name field (no callback), so drift is fixed
+    here (from the depsgraph handler). The last intended name is tracked so a
+    collision -- where Blender appends a numeric suffix -- can't spin a rename
+    loop; only writes on an actual change, settling in one pass.
+    """
+    root = _find_cad_collection(scene)
+    if root is None:
+        return
+    for sub in _walk_sketch_collections(root):
+        obj = next((o for o in sub.objects if o.type == "CURVES"), None)
+        if obj is None:
+            continue
+        if sub.get(_SYNCED_NAME) != obj.name:
+            sub.name = obj.name
+            sub[_SYNCED_NAME] = obj.name
 
 
 def cleanup_sketch_collections(scene):

--- a/utilities/collections.py
+++ b/utilities/collections.py
@@ -14,8 +14,10 @@ consumable). Visibility is a display concern; evaluation must keep running.
 import bpy
 
 CAD_COLLECTION_NAME = "CAD Sketcher"
+ORIGIN_COLLECTION_NAME = "Origin"
 _MARKER = "is_cad_sketcher"
 _SKETCH_MARKER = "cad_sketch_collection"
+_ORIGIN_MARKER = "cad_origin_collection"
 
 
 def _find_cad_collection(scene):
@@ -58,6 +60,28 @@ def link_object(obj, scene):
     master = scene.collection
     if obj.name in master.objects:
         master.objects.unlink(obj)
+    return coll
+
+
+def origin_collection(scene):
+    """Sub-collection under the CAD root that holds the three origin planes."""
+    root = ensure_cad_collection(scene)
+    for child in root.children:
+        if child.get(_ORIGIN_MARKER):
+            return child
+    coll = bpy.data.collections.new(ORIGIN_COLLECTION_NAME)
+    coll[_ORIGIN_MARKER] = True
+    root.children.link(coll)
+    return coll
+
+
+def link_origin_workplane(obj, scene):
+    """Group the XY/XZ/YZ origin empties in their own 'Origin' sub-collection."""
+    coll = origin_collection(scene)
+    if obj.name in coll.objects:
+        return coll
+    _clear_object_collections(obj)
+    coll.objects.link(obj)
     return coll
 
 

--- a/utilities/collections.py
+++ b/utilities/collections.py
@@ -85,6 +85,26 @@ def link_origin_workplane(obj, scene):
     return coll
 
 
+def nest_workplane(workplane, sketch_obj):
+    """Move a dedicated (face/custom) workplane empty into its sketch's collection.
+
+    A workplane created for one sketch otherwise clutters the root; grouping it
+    with the sketch it belongs to keeps the tree tidy. Skipped for origin planes
+    (shared, kept in the Origin collection) and for a workplane already grouped
+    with another sketch (don't steal a shared custom plane).
+    """
+    if workplane is None:
+        return
+    for coll in workplane.users_collection:
+        if coll.get(_ORIGIN_MARKER) or coll.get(_SKETCH_MARKER):
+            return
+    sub = next((c for c in sketch_obj.users_collection if c.get(_SKETCH_MARKER)), None)
+    if sub is None or workplane.name in sub.objects:
+        return
+    _clear_object_collections(workplane)
+    sub.objects.link(workplane)
+
+
 def link_sketch_object(obj, scene):
     """Put a sketch's curve object in its own sub-collection under the CAD root.
 

--- a/utilities/collections.py
+++ b/utilities/collections.py
@@ -15,6 +15,14 @@ import bpy
 
 CAD_COLLECTION_NAME = "CAD Sketcher"
 _MARKER = "is_cad_sketcher"
+_SKETCH_MARKER = "cad_sketch_collection"
+
+
+def _find_cad_collection(scene):
+    for child in scene.collection.children:
+        if child.get(_MARKER):
+            return child
+    return None
 
 
 def ensure_cad_collection(scene):
@@ -24,20 +32,25 @@ def ensure_cad_collection(scene):
     name) so each scene owns its own collection -- shared datablocks would leak
     one scene's sketches into another.
     """
-    for child in scene.collection.children:
-        if child.get(_MARKER):
-            return child
+    coll = _find_cad_collection(scene)
+    if coll is not None:
+        return coll
     coll = bpy.data.collections.new(CAD_COLLECTION_NAME)
     coll[_MARKER] = True
     scene.collection.children.link(coll)
     return coll
 
 
-def link_object(obj, scene):
-    """Link ``obj`` into the scene's CAD Sketcher collection, and nowhere else.
+def _clear_object_collections(obj):
+    for coll in list(obj.users_collection):
+        coll.objects.unlink(obj)
 
-    Safe to call on a freshly created (unlinked) object; also relocates one that
-    was linked into the scene master collection.
+
+def link_object(obj, scene):
+    """Link ``obj`` into the scene's CAD Sketcher root collection, and nowhere else.
+
+    Used for shared internals (workplane empties). Safe on a freshly created
+    object; also relocates one linked into the scene master collection.
     """
     coll = ensure_cad_collection(scene)
     if obj.name not in coll.objects:
@@ -46,3 +59,32 @@ def link_object(obj, scene):
     if obj.name in master.objects:
         master.objects.unlink(obj)
     return coll
+
+
+def link_sketch_object(obj, scene):
+    """Put a sketch's curve object in its own sub-collection under the CAD root.
+
+    One collection per sketch keeps the outliner readable; workplanes stay in the
+    root (they're shared and hidden). Idempotent: an object already in a sketch
+    sub-collection is left where it is.
+    """
+    for coll in obj.users_collection:
+        if coll.get(_SKETCH_MARKER):
+            return coll
+    root = ensure_cad_collection(scene)
+    sub = bpy.data.collections.new(obj.name)
+    sub[_SKETCH_MARKER] = True
+    root.children.link(sub)
+    _clear_object_collections(obj)
+    sub.objects.link(obj)
+    return sub
+
+
+def cleanup_sketch_collections(scene):
+    """Remove empty per-sketch sub-collections (e.g. after a sketch is deleted)."""
+    root = _find_cad_collection(scene)
+    if root is None:
+        return
+    for sub in list(root.children):
+        if sub.get(_SKETCH_MARKER) and not sub.objects:
+            bpy.data.collections.remove(sub)

--- a/utilities/collections.py
+++ b/utilities/collections.py
@@ -85,6 +85,63 @@ def cleanup_sketch_collections(scene):
     root = _find_cad_collection(scene)
     if root is None:
         return
-    for sub in list(root.children):
-        if sub.get(_SKETCH_MARKER) and not sub.objects:
+    for sub in _walk_sketch_collections(root):
+        if not sub.objects and not sub.children:
             bpy.data.collections.remove(sub)
+
+
+def _walk_sketch_collections(root):
+    """All per-sketch sub-collections anywhere under ``root``."""
+    found, stack = [], list(root.children)
+    while stack:
+        coll = stack.pop()
+        if coll.get(_SKETCH_MARKER):
+            found.append(coll)
+        stack.extend(coll.children)
+    return found
+
+
+def _reparent_collection(coll, parent):
+    """Move ``coll`` to be a direct child of ``parent`` (single parent)."""
+    if coll.name in parent.children:
+        return
+    for other in bpy.data.collections:
+        if coll.name in other.children:
+            other.children.unlink(coll)
+    parent.children.link(coll)
+
+
+def organize_part_nesting(scene):
+    """Nest each cutter sketch's collection under the body it feeds.
+
+    Rebuilt from the boolean dependency graph, so it converges no matter the order
+    booleans were added or removed. The graph is a DAG (the boolean tool refuses
+    cycles), so the collection tree can't cycle either. A cutter feeding several
+    bodies nests under one of them -- Blender has no clean multi-parent tree; the
+    other bodies still reference it, which is harmless.
+    """
+    root = _find_cad_collection(scene)
+    if root is None:
+        return
+    from ..operators.modifiers import boolean_cutters
+
+    by_obj = {}
+    for coll in _walk_sketch_collections(root):
+        for obj in coll.objects:
+            by_obj[obj] = coll
+
+    parent_of = {}
+    for body, body_coll in by_obj.items():
+        for cutter in boolean_cutters(body):
+            cutter_coll = by_obj.get(cutter)
+            if cutter_coll is not None and cutter_coll is not body_coll:
+                parent_of[cutter_coll] = body_coll
+
+    # Flatten to root first so nesting can't transiently form a descendant cycle.
+    subs = set(by_obj.values())
+    for coll in subs:
+        _reparent_collection(coll, root)
+    for coll in subs:
+        target = parent_of.get(coll)
+        if target is not None:
+            _reparent_collection(coll, target)

--- a/utilities/curve_data.py
+++ b/utilities/curve_data.py
@@ -511,8 +511,9 @@ def ensure_sketch_curve_object(sketch):
 
         scene = bpy.context.scene
         assert scene is not None, "No active scene"
-        if ob.name not in scene.collection.objects:
-            scene.collection.objects.link(ob)
+        from .collections import link_object
+
+        link_object(ob, scene)
 
         _ensure_convert_modifier(ob)
 

--- a/utilities/curve_data.py
+++ b/utilities/curve_data.py
@@ -511,9 +511,9 @@ def ensure_sketch_curve_object(sketch):
 
         scene = bpy.context.scene
         assert scene is not None, "No active scene"
-        from .collections import link_object
+        from .collections import link_sketch_object
 
-        link_object(ob, scene)
+        link_sketch_object(ob, scene)
 
         _ensure_convert_modifier(ob)
 

--- a/utilities/migrate.py
+++ b/utilities/migrate.py
@@ -48,7 +48,9 @@ def _create_workplane_empty(context, wp, name):
     empty.lock_location = (True, True, True)
     empty.lock_rotation = (True, True, True)
     empty.lock_scale = (True, True, True)
-    context.scene.collection.objects.link(empty)
+    from .collections import link_object
+
+    link_object(empty, context.scene)
     empty.matrix_world = wp.matrix_basis
     return empty
 
@@ -59,7 +61,9 @@ def _create_sketch_object(context, empty, name):
 
     curve = bpy.data.hair_curves.new(name)
     obj = bpy.data.objects.new(name, curve)
-    context.scene.collection.objects.link(obj)
+    from .collections import link_object
+
+    link_object(obj, context.scene)
     stamp_sketch_props(obj)
     _ensure_convert_modifier(obj)
     obj.parent = empty

--- a/utilities/migrate.py
+++ b/utilities/migrate.py
@@ -61,9 +61,9 @@ def _create_sketch_object(context, empty, name):
 
     curve = bpy.data.hair_curves.new(name)
     obj = bpy.data.objects.new(name, curve)
-    from .collections import link_object
+    from .collections import link_sketch_object
 
-    link_object(obj, context.scene)
+    link_sketch_object(obj, context.scene)
     stamp_sketch_props(obj)
     _ensure_convert_modifier(obj)
     obj.parent = empty

--- a/utilities/migrate.py
+++ b/utilities/migrate.py
@@ -48,9 +48,11 @@ def _create_workplane_empty(context, wp, name):
     empty.lock_location = (True, True, True)
     empty.lock_rotation = (True, True, True)
     empty.lock_scale = (True, True, True)
-    from .collections import link_object
+    # A legacy workplane can be shared by several sketches, so keep it at the
+    # scene level rather than nesting it under one sketch.
+    from .collections import link_loose_workplane
 
-    link_object(empty, context.scene)
+    link_loose_workplane(empty, context.scene)
     empty.matrix_world = wp.matrix_basis
     return empty
 

--- a/utilities/workplane.py
+++ b/utilities/workplane.py
@@ -333,9 +333,9 @@ def ensure_origin_workplane_empties(context):
         empty.lock_rotation = (True, True, True)
         empty.lock_scale = (True, True, True)
 
-        from .collections import link_object
+        from .collections import link_origin_workplane
 
-        link_object(empty, scene)
+        link_origin_workplane(empty, scene)
 
         # Hide only after linking: hide_set needs the object in the view layer.
         _hide_managed_empty(empty, scene)

--- a/utilities/workplane.py
+++ b/utilities/workplane.py
@@ -258,9 +258,13 @@ def ensure_workplane_empty(sketch):
     empty.matrix_world = sketch.wp.matrix_basis
 
     scene = bpy.context.scene
-    from .collections import link_object
+    from .collections import link_loose_workplane, nest_workplane
 
-    link_object(empty, scene)
+    # Group the workplane with its sketch when the sketch object exists; otherwise
+    # keep it at the scene level until a sketch claims it.
+    target = getattr(sketch, "target_object", None)
+    if target is None or nest_workplane(empty, target) is None:
+        link_loose_workplane(empty, scene)
 
     # Hide only after linking: hide_set needs the object in the view layer.
     _hide_managed_empty(empty, scene)

--- a/utilities/workplane.py
+++ b/utilities/workplane.py
@@ -258,8 +258,9 @@ def ensure_workplane_empty(sketch):
     empty.matrix_world = sketch.wp.matrix_basis
 
     scene = bpy.context.scene
-    if empty.name not in scene.collection.objects:
-        scene.collection.objects.link(empty)
+    from .collections import link_object
+
+    link_object(empty, scene)
 
     # Hide only after linking: hide_set needs the object in the view layer.
     _hide_managed_empty(empty, scene)
@@ -332,8 +333,9 @@ def ensure_origin_workplane_empties(context):
         empty.lock_rotation = (True, True, True)
         empty.lock_scale = (True, True, True)
 
-        if empty.name not in scene.collection.objects:
-            scene.collection.objects.link(empty)
+        from .collections import link_object
+
+        link_object(empty, scene)
 
         # Hide only after linking: hide_set needs the object in the view layer.
         _hide_managed_empty(empty, scene)


### PR DESCRIPTION
Moves CAD Sketcher's objects out of the scene root into a clean, **project-centric**
collection layout. No mesh consumable — the curve object stays both source of truth
and consumable; nothing about geometry evaluation changes.

## Structure

```
📁 Scene Collection
├─ 🔷 (the user's own objects, untouched)
├─ 📁 Bracket                 (a part — at the scene level)
│   ├─ 〰 Bracket
│   ├─ ⊹ Workplane           (its own workplane, nested in)
│   └─ 📁 Hole 1 → 〰 Hole 1  (cutter nested under the body it feeds)
├─ 📁 Cover
└─ 📁 Origin → XY / XZ / YZ   (the only genuinely shared objects)
```

- **One collection per sketch/part, at the scene level** — where users organize
  their models. No addon wrapper collection.
- **Each sketch's workplane nests inside its collection** — face, entity, and the
  free-3D origin empty. (Legacy migrated workplanes, which can be shared, stay at
  the scene level.)
- **Cutter sketches nest under the body they feed**, rebuilt from the boolean
  dependency graph (`boolean_cutters`) so it converges on add/remove; un-nests
  when the boolean is dropped.
- **Only the three origin planes are shared** → a scene-level `Origin` collection.
- **Rename-sync**: renaming a sketch renames its collection (reconciled from the
  depsgraph handler, loop-safe, settles in one pass).

## Load-bearing invariant

Collections are **hidden, never excluded**. Excluding drops the objects from the
depsgraph → convert stops → the fill vanishes. Tested via `exclude=False` and a
square still evaluating to area 16.

## Tests

`test_collections.py` (12): part at scene level, distinct per sketch, workplane
nesting, free-3D origin nesting, origin-not-stolen, cutter nest + un-nest, delete
cleanup, rename-sync, Origin scene-level + not-excluded, fill still evaluates,
per-scene idempotency. Save/reload round-trip verified. Full suite:
`Ran 453 tests ... OK` (2 pre-existing expected failures).

## Deliberately not included

- **Migration of pre-existing files** — old sketches keep working (everything is
  pointer-resolved; nothing depends on object location) and new sketches
  auto-organize. Automatic relocation-on-load was judged riskier than the
  cosmetic gain and would violate the `on_load_post` "don't pay per load" policy.
  Can be added later as an opt-in "Organize Collections" operator.
