### PR TITLE
Release 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ prepended to that version's GitHub release notes, and it is shown in the in-app
 `## X.Y.Z` section (matching the manifest version) with a short summary — CI
 rejects a stable release that has no matching entry.
 
+## 0.31.0
+This release adds a unified Dimension tool, native 3D sketches, nondestructive Boolean modeling and custom sketch attributes, organizes a project's objects into clean collections, and refines the Extrude, Revolve and Projection tools.
+
+New
+- Dimension tool: a single tool that adds the right dimensional constraint for what you select — line length, distance, angle, diameter, or edge-to-edge — then drag to place the label or type a value
+- Native 3D sketches: draw points and lines freely in 3D space, anchored to an origin instead of a workplane
+- Nondestructive Boolean modeling: Extrude and Revolve can cut, union or intersect their result into overlapping bodies, with automatic target detection
+- Custom sketch attributes
+- Live Snapping: pick existing curve and mesh elements as references while drawing, they will be implicitly projected and update after future geometry changes
+- Project-centric collections: a project's sketches, workplanes and results are organized into a clean per-part collection layout instead of cluttering the scene root
+
+Improved
+- Constraints are shown as an icon grid in the sidebar, split into dimensional and geometric, with theme-aware icons
+- Revolve can now build from a source object, with automatic boolean detection
+- Project Geometry is now a dedicated tool, and can project individual elements and sketch sources
+- Node tools (Extrude, Revolve, Array) return to the Select tool after finishing
+- The tools panel now shows the tools relevant to the current sketch mode
+- Auto-constraints while drawing are validated so they no longer over-constrain the sketch
+- Legacy files are migrated on demand via a button in the Sketcher panel, instead of automatically on file load
+
+Fixed
+- Orthogonal sketch planes no longer collapse onto the XY plane
+- Add Sketch can target the faces of extruded and filled sketches again
+- Crash when a boolean cutter referenced itself
+- Extrude of unfilled profiles now builds open walls instead of nothing
+- Revolve of profiles with holes
+- Copy/paste of constraints
+- Merging of coincident self-referencing points
+- Sketch-conversion topology, and node weld on Blender 5.0
+
 ## 0.30.0
 The data model of the extension has been fundamentally reworked for a closer integration
 into Blender, better stability and performance.

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "CAD_Sketcher"
-version = "0.31.0-rc.2"
+version = "0.31.0"
 name = "CAD Sketcher"
 tagline = "Parametric, constraint-based geometry sketcher"
 maintainer = "hlorus <dave19924@gmail.com>"


### PR DESCRIPTION
Cuts the stable **0.31.0** release now that rc.2 passed the extensions.blender.org review.

- Bumps the manifest `0.31.0-rc.2` → `0.31.0`.
- Adds the `## 0.31.0` CHANGELOG section (supersedes #662, its content is folded
  in here), plus the two user-visible changes that landed after rc.2:
  Project-centric collections (#685) under New, and the orthogonal-plane-collapse
  and Add-Sketch-on-curve-face fixes under Fixed.

Verified locally: `changelog_notes.py 0.31.0` extracts the section (the stable
release gate), `extension validate` passes, all four split-platform zips build,
and the changelog/whats-new/migration tests pass.

After merge, tag `v0.31.0` on the merge commit to trigger the stable release
(GitHub release + stable/index.json + auto-bump of main to 0.31.1). Closes #662.
