### PR TITLE
release CI: auto-submit tagged versions to extensions.blender.org

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,6 +131,42 @@ jobs:
           generate_release_notes: true
           body_path: ${{ github.workspace }}/notes.md
 
+      # Submit the same version to the official extensions.blender.org platform.
+      # This only queues it: a human moderator still approves it before it goes
+      # live, so this can't publish on its own. The self-hosted stable/latest
+      # channels above are independent and unaffected. Runs after the GitHub
+      # release is out, so a platform hiccup never blocks the release. Inert
+      # until the repo variable EXTENSIONS_BLENDER_ID (the extension slug) is set;
+      # the token lives in the EXTENSIONS_BLENDER_TOKEN secret.
+      - name: Submit to extensions.blender.org
+        if: ${{ vars.EXTENSIONS_BLENDER_ID != '' }}
+        working-directory: ./CAD_Sketcher
+        env:
+          TOKEN: ${{ secrets.EXTENSIONS_BLENDER_TOKEN }}
+          EXTENSION: ${{ vars.EXTENSIONS_BLENDER_ID }}
+          NOTES: ${{ github.workspace }}/notes.md
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "$TOKEN" ]; then
+            echo "::error::EXTENSIONS_BLENDER_TOKEN secret is not set"; exit 1
+          fi
+          # One combined package (all platform wheels): the platform serves the
+          # right wheel per OS. Separate from the split-platform zips used for
+          # the self-hosted GitHub-release listing.
+          out="${{ github.workspace }}/blender_ext"
+          mkdir -p "$out"
+          blender --background --command extension build --output-dir "$out"
+          zip=$(ls "$out"/*.zip | head -1)
+          notes=$(cat "$NOTES")
+          [ -n "$notes" ] || notes="CAD Sketcher ${TAG_NAME#v}"
+          echo "Submitting $(basename "$zip") to extensions.blender.org/$EXTENSION"
+          curl --fail-with-body -X POST \
+            "https://extensions.blender.org/api/v1/extensions/${EXTENSION}/versions/upload/" \
+            -H "Authorization: bearer ${TOKEN}" \
+            -F "version_file=@${zip}" \
+            -F "release_notes=${notes}"
+
   # Rebuild stable/index.json from the tagged (non-pre-release) releases.
   publish-stable:
     needs: release


### PR DESCRIPTION
Automates submitting a tagged release to the official **extensions.blender.org**
platform, so no more manual upload.

## What it does
Adds a `Submit to extensions.blender.org` step to the `release` job (runs on any
`v*` tag). It builds a single combined package (all platform wheels, the
platform serves the right one per OS) and POSTs it plus the `CHANGELOG.md`
section for that version to:

`POST https://extensions.blender.org/api/v1/extensions/<id>/versions/upload/`
(`Authorization: bearer <token>`, fields `version_file` + `release_notes`).

## Important: upload, not publish
The platform **queues** the version for a human moderator to approve; there is
no automatic go-live. So this removes the manual upload but the version still
waits on review. The self-hosted `stable`/`latest` channels are independent and
still publish instantly. The step runs *after* the GitHub release is out, so a
platform hiccup never blocks the release.

## Setup required before it does anything (inert until then)
- Repo **variable** `EXTENSIONS_BLENDER_ID` = the extension's slug on
  extensions.blender.org.
- Repo **secret** `EXTENSIONS_BLENDER_TOKEN` = an API token from your Blender ID
  profile on the platform.

Without the variable the step is skipped, so merging this changes nothing until
you add them.

## Notes
- Fires for every tag, including rc prereleases (matches the manual rc.1/rc.2
  submissions). To restrict to stable, add `&& !contains(github.ref_name, '-')`
  to the step's `if`.
- I verified the workflow YAML parses and the step is placed/gated correctly. I
  could not exercise the live API from here (no token, and I shouldn't upload),
  and the Blender docs domain is blocked from my environment, so please sanity-
  check the first real run's logs.
