### PR TITLE
release CI: isolate + fix the extensions.blender.org submit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,22 +131,33 @@ jobs:
           generate_release_notes: true
           body_path: ${{ github.workspace }}/notes.md
 
-      # Submit the same version to the official extensions.blender.org platform.
-      # This only queues it: a human moderator still approves it before it goes
-      # live, so this can't publish on its own. The self-hosted stable/latest
-      # channels are independent and unaffected. continue-on-error keeps a
-      # platform hiccup from failing the release job (which would skip the
-      # publish-stable and bump-version jobs that depend on it). Inert until the
-      # repo variable EXTENSIONS_BLENDER_ID (the extension slug) is set; the
-      # token lives in the EXTENSIONS_BLENDER_TOKEN secret.
+  # Submit the tagged version to the official extensions.blender.org platform.
+  # Its own job (not a step in `release`) on purpose: a platform-side failure
+  # then shows up as a red run, but does NOT skip publish-stable / bump-version,
+  # which depend only on `release`. Submitting only queues the version; a human
+  # moderator still approves it before it goes live, and the self-hosted
+  # stable/latest channels are independent. Inert until the repo variable
+  # EXTENSIONS_BLENDER_ID (the extension slug) is set; the token is in the
+  # EXTENSIONS_BLENDER_TOKEN secret.
+  submit-blender:
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/') && vars.EXTENSIONS_BLENDER_ID != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Addon
+        uses: actions/checkout@v4
+        with:
+          path: CAD_Sketcher
+
+      - uses: moguri/setup-blender@v1
+        with:
+          blender-version: "5.0"
+
       - name: Submit to extensions.blender.org
-        if: ${{ vars.EXTENSIONS_BLENDER_ID != '' }}
-        continue-on-error: true
         working-directory: ./CAD_Sketcher
         env:
           TOKEN: ${{ secrets.EXTENSIONS_BLENDER_TOKEN }}
           EXTENSION: ${{ vars.EXTENSIONS_BLENDER_ID }}
-          NOTES: ${{ github.workspace }}/notes.md
           TAG_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
@@ -154,14 +165,15 @@ jobs:
             echo "::error::EXTENSIONS_BLENDER_TOKEN secret is not set"; exit 1
           fi
           # One combined package (all platform wheels): the platform serves the
-          # right wheel per OS. Separate from the split-platform zips used for
-          # the self-hosted GitHub-release listing.
+          # right wheel per OS.
           out="${{ github.workspace }}/blender_ext"
           mkdir -p "$out"
           blender --background --command extension build --output-dir "$out"
           zip=$(ls "$out"/*.zip | head -1)
-          notes=$(cat "$NOTES")
-          [ -n "$notes" ] || notes="CAD Sketcher ${TAG_NAME#v}"
+
+          version="${TAG_NAME#v}"
+          notes="$(PYTHONPATH=. python3 scripts/changelog_notes.py "$version" CHANGELOG.md || true)"
+          [ -n "$notes" ] || notes="CAD Sketcher ${version}"
           # The platform caps release_notes at 1024 characters. Our changelog
           # sections run longer, so trim to whole lines under a conservative
           # byte budget (bytes >= chars, so this stays under the char cap even
@@ -171,6 +183,7 @@ jobs:
             trimmed="$(printf '%s' "$notes" | head -c 850 | sed '$d')"
             notes="$(printf '%s\n\n%s' "$trimmed" "$link")"
           fi
+
           echo "Submitting $(basename "$zip") to extensions.blender.org/$EXTENSION"
           curl --fail-with-body -X POST \
             "https://extensions.blender.org/api/v1/extensions/${EXTENSION}/versions/upload/" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -160,6 +160,15 @@ jobs:
           zip=$(ls "$out"/*.zip | head -1)
           notes=$(cat "$NOTES")
           [ -n "$notes" ] || notes="CAD Sketcher ${TAG_NAME#v}"
+          # The platform caps release_notes at 1024 characters. Our changelog
+          # sections run longer, so trim to whole lines under a conservative
+          # byte budget (bytes >= chars, so this stays under the char cap even
+          # with multi-byte characters) and link to the full changelog.
+          if [ "$(printf '%s' "$notes" | wc -c)" -gt 1000 ]; then
+            link="Full changelog: https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md"
+            trimmed="$(printf '%s' "$notes" | head -c 850 | sed '$d')"
+            notes="$(printf '%s\n\n%s' "$trimmed" "$link")"
+          fi
           echo "Submitting $(basename "$zip") to extensions.blender.org/$EXTENSION"
           curl --fail-with-body -X POST \
             "https://extensions.blender.org/api/v1/extensions/${EXTENSION}/versions/upload/" \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,12 +134,14 @@ jobs:
       # Submit the same version to the official extensions.blender.org platform.
       # This only queues it: a human moderator still approves it before it goes
       # live, so this can't publish on its own. The self-hosted stable/latest
-      # channels above are independent and unaffected. Runs after the GitHub
-      # release is out, so a platform hiccup never blocks the release. Inert
-      # until the repo variable EXTENSIONS_BLENDER_ID (the extension slug) is set;
-      # the token lives in the EXTENSIONS_BLENDER_TOKEN secret.
+      # channels are independent and unaffected. continue-on-error keeps a
+      # platform hiccup from failing the release job (which would skip the
+      # publish-stable and bump-version jobs that depend on it). Inert until the
+      # repo variable EXTENSIONS_BLENDER_ID (the extension slug) is set; the
+      # token lives in the EXTENSIONS_BLENDER_TOKEN secret.
       - name: Submit to extensions.blender.org
         if: ${{ vars.EXTENSIONS_BLENDER_ID != '' }}
+        continue-on-error: true
         working-directory: ./CAD_Sketcher
         env:
           TOKEN: ${{ secrets.EXTENSIONS_BLENDER_TOKEN }}


### PR DESCRIPTION
The v0.31.0 auto-submit failed and, because it was a step inside the `release` job under `set -e`, it failed the whole job and **skipped `publish-stable` and `bump-version`** (the self-hosted stable listing never updated to 0.31.0; main was not bumped). Two problems, two fixes:

1. **1024-char `release_notes` cap** — the platform rejected the ~2150-char 0.31.0 changelog with `HTTP 400 {"release_notes":["...no more than 1024 characters"]}`. Trim to whole lines under a safe byte budget + a link to the full changelog (verified 2148 → 807).
2. **Isolate the submit into its own `submit-blender` job** (`needs: release`). A platform-side failure now surfaces as a red run but can't skip `publish-stable`/`bump-version`, which depend only on `release`. No `continue-on-error`, so failures stay visible.

The GitHub release + its zips did publish (that step ran first). After merge we re-run 0.31.0 to publish the stable listing and submit to the platform.