### PR TITLE
release CI: upload per-platform builds to extensions.blender.org

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,12 +164,14 @@ jobs:
           if [ -z "$TOKEN" ]; then
             echo "::error::EXTENSIONS_BLENDER_TOKEN secret is not set"; exit 1
           fi
-          # One combined package (all platform wheels): the platform serves the
-          # right wheel per OS.
+          # One package per platform (matching the self-hosted channel), so users
+          # download only their OS's wheel instead of one combined all-wheels
+          # zip. Uploading each split zip to the same endpoint groups them under
+          # one version: the platform matches equal name+version with differing
+          # platform into a single version with per-OS downloads.
           out="${{ github.workspace }}/blender_ext"
           mkdir -p "$out"
-          blender --background --command extension build --output-dir "$out"
-          zip=$(ls "$out"/*.zip | head -1)
+          blender --background --command extension build --split-platforms --output-dir "$out"
 
           version="${TAG_NAME#v}"
           notes="$(PYTHONPATH=. python3 scripts/changelog_notes.py "$version" CHANGELOG.md || true)"
@@ -184,12 +186,17 @@ jobs:
             notes="$(printf '%s\n\n%s' "$trimmed" "$link")"
           fi
 
-          echo "Submitting $(basename "$zip") to extensions.blender.org/$EXTENSION"
-          curl --fail-with-body -X POST \
-            "https://extensions.blender.org/api/v1/extensions/${EXTENSION}/versions/upload/" \
-            -H "Authorization: bearer ${TOKEN}" \
-            -F "version_file=@${zip}" \
-            -F "release_notes=${notes}"
+          rc=0
+          for zip in "$out"/*.zip; do
+            echo "Submitting $(basename "$zip") to extensions.blender.org/$EXTENSION"
+            curl --fail-with-body -X POST \
+              "https://extensions.blender.org/api/v1/extensions/${EXTENSION}/versions/upload/" \
+              -H "Authorization: bearer ${TOKEN}" \
+              -F "version_file=@${zip}" \
+              -F "release_notes=${notes}" || rc=1
+            echo
+          done
+          exit "$rc"
 
   # Rebuild stable/index.json from the tagged (non-pre-release) releases.
   publish-stable:


### PR DESCRIPTION
**Problem:** 0.31.0 is live on extensions.blender.org as a **single combined 15 MB zip** bundling all four platforms' `slvs` wheels, so every user downloads every OS's wheel. Confirmed via the platform's feed:
```
id=CAD_Sketcher v=0.31.0 platforms=[windows-x64, macos-x64, macos-arm64, linux-x64] size=15445301
```

**Cause:** the `submit-blender` job built one combined package (no `--split-platforms`) and uploaded that single file.

**Fix:** build `--split-platforms` and upload each of the four zips. The platform groups equal name+version with differing platform into one version with per-OS downloads. This is the norm there (49 extensions do it, e.g. the wheel-based `step_importer` has one entry per platform); CAD_Sketcher was one of only 4 combined-all-platforms outliers. Now matches our self-hosted `stable` channel (already per-platform).

Recipe confirmed by a maintainer on the Blender forum: uploading each split zip to the same `versions/upload` endpoint "gets matched if the name and version numbers are the same but platform are different."

**Two things to watch on the first real run (0.31.1):**
- The step passes `release_notes` on each of the four uploads (same value). If the platform only wants it on the first, the 2nd upload would error, the job is isolated + loud, so it can't break publishing and we'd see it.
- It re-reads the corrected `EXTENSIONS_BLENDER_ID=CAD_Sketcher` variable.

**Current 0.31.0** stays combined; converting it retroactively would mean deleting the 0.31.0 version on the platform and re-submitting split (see below). This PR makes 0.31.1 onward per-platform.