### PR TITLE
release CI: make the changelog entry optional (warn, don't fail)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,12 +115,11 @@ jobs:
           if PYTHONPATH=. python3 scripts/changelog_notes.py "$version" CHANGELOG.md > "$notes"; then
             echo "Prepending CHANGELOG.md entry for $version."
           else
+            # A missing entry is allowed (e.g. a packaging-only patch that
+            # shouldn't trigger the in-app "What's New"). Fall back to GitHub's
+            # auto-generated notes rather than failing the release.
             : > "$notes"
-            if [[ "$version" != *-* ]]; then
-              echo "::error::No CHANGELOG.md entry for stable release $version. Add a '## $version' section before tagging."
-              exit 1
-            fi
-            echo "No changelog entry for pre-release $version; using auto-generated notes only."
+            echo "::warning::No CHANGELOG.md entry for $version; using auto-generated notes only."
           fi
 
       - name: Publish Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 Notes here feed two places automatically: the entry matching a release is
 prepended to that version's GitHub release notes, and it is shown in the in-app
-"What's new" dialog after the add-on updates. Before tagging a release, add a
-`## X.Y.Z` section (matching the manifest version) with a short summary — CI
-rejects a stable release that has no matching entry.
+"What's new" dialog after the add-on updates. Add a `## X.Y.Z` section (matching
+the manifest version) with a short summary for anything user-facing. It is
+optional: a release with no matching entry just uses GitHub's auto-generated
+notes and shows no "What's new" (e.g. a packaging-only patch).
 
 ## 0.31.0
 This release adds a unified Dimension tool, native 3D sketches, nondestructive Boolean modeling and custom sketch attributes, organizes a project's objects into clean collections, and refines the Extrude, Revolve and Projection tools.


### PR DESCRIPTION
A stable release with no matching `## X.Y.Z` CHANGELOG section currently hard-fails the release job. That's wrong for a **packaging-only** patch (like 0.31.1, which only splits the extensions.blender.org build per-platform) that shouldn't trigger the in-app 'What's New'.

Relax it: a missing entry now logs a warning and falls back to GitHub's auto-generated release notes instead of `exit 1`. Also updated the CHANGELOG.md header note to match.

Clears the way to tag 0.31.1 with no changelog entry (manifest is already 0.31.1). Since the platform has no approval queue for new versions, that release goes live per-platform immediately.