### PR TITLE
Alt+D a sketch -> linked consumable (not a second sketch)

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -99,12 +99,12 @@ def on_depsgraph_update(scene, depsgraph):
             global_data.needs_solve = True
 
         # A linked duplicate (Alt+D) leaves two objects sharing one sketch
-        # datablock; demote the copy to a live consumable of the source instead
-        # of a second (churning) sketch. Deferred to a timer since it swaps the
-        # object's data and modifiers, which can't happen mid-evaluation.
-        from .utilities.consumable import schedule_linked_duplicate_demotions
+        # datablock; drop the copy's sketch role so it stops showing as a second
+        # sketch and churning the self-heal (it stays a plain linked object).
+        from .utilities.consumable import reconcile_linked_duplicates
 
-        schedule_linked_duplicate_demotions(scene)
+        if reconcile_linked_duplicates(scene):
+            global_data.needs_solve = True
 
         # Undo/redo can flatten the origin workplane empties to identity (they
         # then stack into a mushy overlap, #571); re-assert their transforms.

--- a/handlers.py
+++ b/handlers.py
@@ -98,6 +98,14 @@ def on_depsgraph_update(scene, depsgraph):
         if validate_all_sketches(scene):
             global_data.needs_solve = True
 
+        # A linked duplicate (Alt+D) leaves two objects sharing one sketch
+        # datablock; demote the copy to a live consumable of the source instead
+        # of a second (churning) sketch. Deferred to a timer since it swaps the
+        # object's data and modifiers, which can't happen mid-evaluation.
+        from .utilities.consumable import schedule_linked_duplicate_demotions
+
+        schedule_linked_duplicate_demotions(scene)
+
         # Undo/redo can flatten the origin workplane empties to identity (they
         # then stack into a mushy overlap, #571); re-assert their transforms.
         # Only rewrites when drifted, so this settles in one pass.

--- a/model/sketch_ref.py
+++ b/model/sketch_ref.py
@@ -14,6 +14,11 @@ _SOLVER_STATE = "solver_state"
 _DOF = "dof"
 _IS_3D = "is_3d_sketch"
 
+# Object name of a sketch datablock's owning object, stamped on the Curves *data*
+# so a linked duplicate (which shares the data) can be told from its source (see
+# utilities.consumable).
+_OWNER = "slvs:sketch_owner"
+
 
 class Sketch:
     """Lightweight accessor wrapping a Blender Curves Object as a sketch."""
@@ -175,6 +180,11 @@ def stamp_sketch_props(obj):
         obj[_SOLVER_STATE] = "OKAY"
     if _DOF not in obj:
         obj[_DOF] = 0
+    # Record the owning object on the *data*, so a later linked duplicate (which
+    # shares this data) can be recognised as a copy of ``obj``. Only claim it if
+    # unset, a copy stamped over shared data must not steal ownership.
+    if obj.data is not None and _OWNER not in obj.data:
+        obj.data[_OWNER] = obj.name
 
 
 def is_sketch_object(obj):

--- a/testing/test_linked_duplicate.py
+++ b/testing/test_linked_duplicate.py
@@ -1,0 +1,91 @@
+"""Alt+D (linked duplicate) of a sketch demotes the copy to a consumable.
+
+A linked duplicate shares the Curves datablock, which made the self-heal churn
+(re-minting a shared constraint uid forever, leaking scene keys). The copy is
+demoted to a dumb linked consumable of the source instead: own data, no sketch
+tag, driven by an Object Info node. A full duplicate (Shift+D) copies the data
+and stays an independent sketch.
+"""
+
+from ..model.sketch_ref import _TAG, is_sketch_object, stamp_sketch_props
+from ..utilities.consumable import (
+    _CONSUME_MODIFIER,
+    demote_to_consumable,
+    plan_linked_duplicates,
+)
+from ..utilities.validate import validate_all_sketches
+from .utils import Sketch2dTestCase
+
+
+class TestLinkedDuplicate(Sketch2dTestCase):
+    def _dimensioned_sketch(self):
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((2, 0))
+        line = self.add_line(p0, p1)
+        self.sketch.constraints.add_distance(
+            init=True, value=2.0, curve_id_1=line.curve_id
+        )
+        # The depsgraph handler continually refreshes datablock ownership while a
+        # sketch is single-user; simulate that so the owner is current (the test
+        # harness renames the object after creation).
+        plan_linked_duplicates(self.context.scene)
+
+    def _link_duplicate(self):
+        """Mimic Alt+D: copy the object, share its data."""
+        a = self.sketch.target_object
+        b = a.copy()  # shares a.data
+        self.context.scene.collection.objects.link(b)
+        stamp_sketch_props(b)  # Alt+D copies the tag; emulate that
+        return a, b
+
+    def test_linked_copy_is_planned_for_demotion(self):
+        self._dimensioned_sketch()
+        a, b = self._link_duplicate()
+        self.assertIs(a.data, b.data)
+
+        plan = plan_linked_duplicates(self.context.scene)
+        # The owner (a) is kept; the copy (b) is queued for demotion.
+        self.assertIn((b.name, a.name), plan)
+        self.assertNotIn((a.name, b.name), plan)
+
+    def test_demotion_stops_the_churn(self):
+        self._dimensioned_sketch()
+        a, b = self._link_duplicate()
+
+        def n_keys():
+            return len(
+                [k for k in self.context.scene.keys() if k.startswith("slvs:c:")]
+            )
+
+        # Shared data churns the self-heal and leaks a scene key per pass.
+        start = n_keys()
+        for _ in range(3):
+            validate_all_sketches(self.context.scene)
+        self.assertGreater(n_keys(), start, "linked-dup should churn before the fix")
+
+        demote_to_consumable(b, a)
+
+        # b is no longer a sketch and no longer shares a's data.
+        self.assertFalse(is_sketch_object(b))
+        self.assertNotIn(_TAG, b)
+        self.assertIsNot(a.data, b.data)
+        self.assertIn(_CONSUME_MODIFIER, [m.name for m in b.modifiers])
+
+        # The churn/leak is gone.
+        before = n_keys()
+        for _ in range(5):
+            validate_all_sketches(self.context.scene)
+        self.assertEqual(n_keys(), before, "demotion must stop the scene-key leak")
+
+    def test_full_duplicate_stays_a_sketch(self):
+        self._dimensioned_sketch()
+        a = self.sketch.target_object
+        c = a.copy()
+        c.data = a.data.copy()  # Shift+D: independent data
+        self.context.scene.collection.objects.link(c)
+        stamp_sketch_props(c)
+
+        # A full copy owns its own data, so it is never demoted.
+        plan = plan_linked_duplicates(self.context.scene)
+        self.assertNotIn(c.name, [copy for copy, _ in plan])
+        self.assertTrue(is_sketch_object(c))

--- a/testing/test_linked_duplicate.py
+++ b/testing/test_linked_duplicate.py
@@ -79,6 +79,12 @@ class TestLinkedDuplicate(Sketch2dTestCase):
         self.assertIsNotNone(info)
         self.assertEqual(info.transform_space, "ORIGINAL")
 
+        # ...and its transform must be unlocked (sketches lock theirs), so the
+        # usual Alt+D-then-move works.
+        self.assertEqual(tuple(b.lock_location), (False, False, False))
+        self.assertEqual(tuple(b.lock_rotation), (False, False, False))
+        self.assertEqual(tuple(b.lock_scale), (False, False, False))
+
         # The churn/leak is gone.
         before = n_keys()
         for _ in range(5):

--- a/testing/test_linked_duplicate.py
+++ b/testing/test_linked_duplicate.py
@@ -1,18 +1,15 @@
-"""Alt+D (linked duplicate) of a sketch demotes the copy to a consumable.
+"""Alt+D (linked duplicate) of a sketch drops the copy's sketch role.
 
 A linked duplicate shares the Curves datablock, which made the self-heal churn
-(re-minting a shared constraint uid forever, leaking scene keys). The copy is
-demoted to a dumb linked consumable of the source instead: own data, no sketch
-tag, driven by an Object Info node. A full duplicate (Shift+D) copies the data
+(re-minting a shared constraint uid forever, leaking scene keys) and showed a
+second sketch entry. The copy is untagged and unlocked so it stops being a
+sketch, while keeping the shared data + modifiers (still shows the result,
+native linked-duplicate behaviour). A full duplicate (Shift+D) copies the data
 and stays an independent sketch.
 """
 
 from ..model.sketch_ref import _TAG, is_sketch_object, stamp_sketch_props
-from ..utilities.consumable import (
-    _CONSUME_MODIFIER,
-    demote_to_consumable,
-    plan_linked_duplicates,
-)
+from ..utilities.consumable import reconcile_linked_duplicates
 from ..utilities.validate import validate_all_sketches
 from .utils import Sketch2dTestCase
 
@@ -25,10 +22,10 @@ class TestLinkedDuplicate(Sketch2dTestCase):
         self.sketch.constraints.add_distance(
             init=True, value=2.0, curve_id_1=line.curve_id
         )
-        # The depsgraph handler continually refreshes datablock ownership while a
-        # sketch is single-user; simulate that so the owner is current (the test
-        # harness renames the object after creation).
-        plan_linked_duplicates(self.context.scene)
+        # The handler continually refreshes datablock ownership while a sketch is
+        # single-user; run it once so the owner is current (the harness renames
+        # the object after creation).
+        reconcile_linked_duplicates(self.context.scene)
 
     def _link_duplicate(self):
         """Mimic Alt+D: copy the object, share its data."""
@@ -38,15 +35,23 @@ class TestLinkedDuplicate(Sketch2dTestCase):
         stamp_sketch_props(b)  # Alt+D copies the tag; emulate that
         return a, b
 
-    def test_linked_copy_is_planned_for_demotion(self):
+    def test_linked_copy_is_demoted(self):
         self._dimensioned_sketch()
         a, b = self._link_duplicate()
         self.assertIs(a.data, b.data)
+        self.assertTrue(is_sketch_object(b))
 
-        plan = plan_linked_duplicates(self.context.scene)
-        # The owner (a) is kept; the copy (b) is queued for demotion.
-        self.assertIn((b.name, a.name), plan)
-        self.assertNotIn((a.name, b.name), plan)
+        self.assertTrue(reconcile_linked_duplicates(self.context.scene))
+
+        # The copy is no longer a sketch, is unlocked, and still shares the data
+        # (native linked-duplicate: it keeps showing the source's result).
+        self.assertFalse(is_sketch_object(b))
+        self.assertNotIn(_TAG, b)
+        self.assertIs(a.data, b.data)
+        self.assertTrue(is_sketch_object(a), "the original stays a sketch")
+        self.assertEqual(tuple(b.lock_location), (False, False, False))
+        self.assertEqual(tuple(b.lock_rotation), (False, False, False))
+        self.assertEqual(tuple(b.lock_scale), (False, False, False))
 
     def test_demotion_stops_the_churn(self):
         self._dimensioned_sketch()
@@ -63,29 +68,8 @@ class TestLinkedDuplicate(Sketch2dTestCase):
             validate_all_sketches(self.context.scene)
         self.assertGreater(n_keys(), start, "linked-dup should churn before the fix")
 
-        demote_to_consumable(b, a)
+        reconcile_linked_duplicates(self.context.scene)
 
-        # b is no longer a sketch and no longer shares a's data.
-        self.assertFalse(is_sketch_object(b))
-        self.assertNotIn(_TAG, b)
-        self.assertIsNot(a.data, b.data)
-        self.assertIn(_CONSUME_MODIFIER, [m.name for m in b.modifiers])
-
-        # The consumable must be movable: its Object Info reads the source in
-        # ORIGINAL space so the object's own transform places it (RELATIVE would
-        # glue it to the source and make it impossible to move).
-        ng = b.modifiers[_CONSUME_MODIFIER].node_group
-        info = ng.nodes.get("source_info")
-        self.assertIsNotNone(info)
-        self.assertEqual(info.transform_space, "ORIGINAL")
-
-        # ...and its transform must be unlocked (sketches lock theirs), so the
-        # usual Alt+D-then-move works.
-        self.assertEqual(tuple(b.lock_location), (False, False, False))
-        self.assertEqual(tuple(b.lock_rotation), (False, False, False))
-        self.assertEqual(tuple(b.lock_scale), (False, False, False))
-
-        # The churn/leak is gone.
         before = n_keys()
         for _ in range(5):
             validate_all_sketches(self.context.scene)
@@ -100,6 +84,5 @@ class TestLinkedDuplicate(Sketch2dTestCase):
         stamp_sketch_props(c)
 
         # A full copy owns its own data, so it is never demoted.
-        plan = plan_linked_duplicates(self.context.scene)
-        self.assertNotIn(c.name, [copy for copy, _ in plan])
+        reconcile_linked_duplicates(self.context.scene)
         self.assertTrue(is_sketch_object(c))

--- a/testing/test_linked_duplicate.py
+++ b/testing/test_linked_duplicate.py
@@ -71,6 +71,14 @@ class TestLinkedDuplicate(Sketch2dTestCase):
         self.assertIsNot(a.data, b.data)
         self.assertIn(_CONSUME_MODIFIER, [m.name for m in b.modifiers])
 
+        # The consumable must be movable: its Object Info reads the source in
+        # ORIGINAL space so the object's own transform places it (RELATIVE would
+        # glue it to the source and make it impossible to move).
+        ng = b.modifiers[_CONSUME_MODIFIER].node_group
+        info = ng.nodes.get("source_info")
+        self.assertIsNotNone(info)
+        self.assertEqual(info.transform_space, "ORIGINAL")
+
         # The churn/leak is gone.
         before = n_keys()
         for _ in range(5):

--- a/utilities/consumable.py
+++ b/utilities/consumable.py
@@ -76,6 +76,13 @@ def demote_to_consumable(copy: bpy.types.Object, source: bpy.types.Object) -> No
         if key in copy:
             del copy[key]
 
+    # Sketches lock their transform (placement comes from the parent workplane),
+    # and Alt+D copies that lock. A consumable is a free-standing object, so
+    # unlock it, otherwise it can't be grabbed and moved after the duplicate.
+    copy.lock_location = (False, False, False)
+    copy.lock_rotation = (False, False, False)
+    copy.lock_scale = (False, False, False)
+
     # Own, empty data: stops sharing the source's sketch datablock (which is what
     # made the self-heal churn) while keeping ``copy`` a Curves object.
     copy.data = bpy.data.hair_curves.new(copy.name)

--- a/utilities/consumable.py
+++ b/utilities/consumable.py
@@ -50,7 +50,12 @@ def _consume_node_group(source: bpy.types.Object) -> bpy.types.NodeTree:
         gout = ng.nodes.new("NodeGroupOutput")
         info = ng.nodes.new("GeometryNodeObjectInfo")
         info.name = "source_info"
-        info.transform_space = "RELATIVE"
+        # ORIGINAL (not RELATIVE): emit the source's geometry in its local space
+        # so the *consumable's own* object transform places it. The Alt+D copy
+        # inherits the source's matrix, so it starts overlapping the source and
+        # can then be grabbed and moved like any object. RELATIVE would glue it
+        # to the source's world position, making it impossible to move.
+        info.transform_space = "ORIGINAL"
         realize = ng.nodes.new("GeometryNodeRealizeInstances")
         ng.links.new(info.outputs["Geometry"], realize.inputs[0])
         ng.links.new(realize.outputs[0], gout.inputs[0])

--- a/utilities/consumable.py
+++ b/utilities/consumable.py
@@ -1,113 +1,50 @@
-"""Demote a linked-duplicated sketch (Alt+D) into a dumb linked consumable.
+"""Reconcile a linked-duplicated sketch (Alt+D) so it stops behaving as a sketch.
 
 Blender's *linked* duplicate shares the sketch's Curves datablock between two
-objects. Two objects driving one sketch is meaningless and makes the self-heal
-churn (it can't separate the shared constraint uids, see utilities.validate), so
-instead the copy is demoted: it gets its own empty data, loses its sketch role,
-and shows the *source* sketch's evaluated result through an Object Info node. The
-result is a live, linked consumable, no second sketch and no separate companion
-object to keep in sync (the depsgraph tracks the dependency).
+objects. Two objects driving one sketch is meaningless: it shows as a second
+sketch entry and makes the self-heal churn (it re-mints a shared constraint uid
+it can never separate, leaking a scene key per pass, see utilities.validate).
+
+The minimal fix is to drop the copy's sketch role: remove its sketch tag (so it
+leaves ``get_sketches`` and the self-heal) and unlock its transform (sketches
+lock theirs, placed by their workplane). The copy keeps the shared data and its
+copied modifiers, so it still displays the source's result and moves with its own
+transform, exactly the native linked-duplicate behaviour, just no longer a
+second sketch.
 
 A *full* duplicate (Shift+D) copies the data, so each object owns its own sketch
-and is left alone; only the ``_OWNER`` bookkeeping distinguishes the two (a copy
-that shares the owner's datablock is a linked duplicate; a copy with its own
-datablock just claims ownership).
-
-The object transform must run outside the depsgraph handler (it swaps ``data``
-and rebuilds the modifier stack), so the handler only *plans* the demotions and
-a one-shot timer performs them.
+and is left alone; the ``_OWNER`` stamp on the data distinguishes the two.
 """
-
-import logging
 
 import bpy
 
 from ..model.sketch_ref import _DOF, _OWNER, _SOLVER_STATE, _TAG, is_sketch_object
 
-logger = logging.getLogger(__name__)
 
-_CONSUME_GROUP = "CAD Sketcher Consumable"
-_CONSUME_MODIFIER = "CAD Sketcher Consumable"
-
-# Demotions queued by the depsgraph handler, performed by the timer below.
-_pending: list[tuple[str, str]] = []
-
-
-def _consume_node_group(source: bpy.types.Object) -> bpy.types.NodeTree:
-    """Node group surfacing ``source``'s evaluated geometry, realized to real mesh.
-
-    The source is baked into the Object Info node as an object pointer (stable
-    across renames, and GN modifier object inputs can't be set by subscript in
-    Blender 5.x). One group per source, reused across its consumables.
-    """
-    name = f"{_CONSUME_GROUP}: {source.name}"
-    ng = bpy.data.node_groups.get(name)
-    if ng is None:
-        ng = bpy.data.node_groups.new(name, "GeometryNodeTree")
-        ng.interface.new_socket(
-            "Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry"
-        )
-        gout = ng.nodes.new("NodeGroupOutput")
-        info = ng.nodes.new("GeometryNodeObjectInfo")
-        info.name = "source_info"
-        # ORIGINAL (not RELATIVE): emit the source's geometry in its local space
-        # so the *consumable's own* object transform places it. The Alt+D copy
-        # inherits the source's matrix, so it starts overlapping the source and
-        # can then be grabbed and moved like any object. RELATIVE would glue it
-        # to the source's world position, making it impossible to move.
-        info.transform_space = "ORIGINAL"
-        realize = ng.nodes.new("GeometryNodeRealizeInstances")
-        ng.links.new(info.outputs["Geometry"], realize.inputs[0])
-        ng.links.new(realize.outputs[0], gout.inputs[0])
-    info = ng.nodes.get("source_info")
-    if info is not None:
-        info.inputs["Object"].default_value = source
-    return ng
-
-
-def demote_to_consumable(copy: bpy.types.Object, source: bpy.types.Object) -> None:
-    """Turn a linked-dup sketch ``copy`` into a live consumable of ``source``.
-
-    Gives ``copy`` its own empty data (so it stops sharing the source sketch),
-    strips its sketch identity, and drives it from an Object Info node reading the
-    source's evaluated result.
-    """
+def _demote(copy: bpy.types.Object) -> None:
+    """Drop a linked-duplicate copy's sketch role: untag and unlock its transform."""
     for key in (_TAG, _SOLVER_STATE, _DOF):
         if key in copy:
             del copy[key]
-
-    # Sketches lock their transform (placement comes from the parent workplane),
-    # and Alt+D copies that lock. A consumable is a free-standing object, so
-    # unlock it, otherwise it can't be grabbed and moved after the duplicate.
     copy.lock_location = (False, False, False)
     copy.lock_rotation = (False, False, False)
     copy.lock_scale = (False, False, False)
 
-    # Own, empty data: stops sharing the source's sketch datablock (which is what
-    # made the self-heal churn) while keeping ``copy`` a Curves object.
-    copy.data = bpy.data.hair_curves.new(copy.name)
 
-    for modifier in list(copy.modifiers):
-        copy.modifiers.remove(modifier)
+def reconcile_linked_duplicates(scene: bpy.types.Scene) -> bool:
+    """Demote the copy of any linked-duplicated sketch. Returns True if changed.
 
-    modifier = copy.modifiers.new(_CONSUME_MODIFIER, "NODES")
-    modifier.node_group = _consume_node_group(source)
-
-
-def plan_linked_duplicates(scene: bpy.types.Scene) -> list[tuple[str, str]]:
-    """Claim datablock ownership and return ``(copy_name, source_name)`` to demote.
-
-    Sketch objects are grouped by their Curves datablock. A datablock used by a
-    single sketch object is that object's own (claim it). A datablock shared by
-    several is a linked duplicate: keep the owner, list the rest for demotion.
-    Only stamps ownership when it changes, so this is quiet on the common path.
+    Sketch objects are grouped by their Curves datablock. A datablock with one
+    sketch object is that object's own (claim ownership). A datablock shared by
+    several is a linked duplicate: keep the owner and demote the rest. Only
+    stamps ownership when it changes, so this is quiet on the common path.
     """
     by_data: dict[str, tuple[bpy.types.ID, list[bpy.types.Object]]] = {}
     for obj in scene.objects:
         if is_sketch_object(obj) and obj.data is not None:
             by_data.setdefault(obj.data.name, (obj.data, []))[1].append(obj)
 
-    demote: list[tuple[str, str]] = []
+    changed = False
     for data, objs in by_data.values():
         if len(objs) == 1:
             owner = objs[0]
@@ -121,41 +58,9 @@ def plan_linked_duplicates(scene: bpy.types.Scene) -> list[tuple[str, str]]:
         keep = next((o for o in objs if o.name == owner_name), None) or objs[0]
         if data.get(_OWNER) != keep.name:
             data[_OWNER] = keep.name
-        demote.extend((o.name, keep.name) for o in objs if o is not keep)
+        for obj in objs:
+            if obj is not keep:
+                _demote(obj)
+                changed = True
 
-    return demote
-
-
-def _run_demotions() -> None:
-    """Timer: perform queued demotions (safe outside the depsgraph handler)."""
-    pending, _pending[:] = list(_pending), []
-    seen = set()
-    for copy_name, source_name in pending:
-        if (copy_name, source_name) in seen:
-            continue
-        seen.add((copy_name, source_name))
-        copy = bpy.data.objects.get(copy_name)
-        source = bpy.data.objects.get(source_name)
-        # Only demote if still a linked duplicate (guards against undo/edits
-        # between planning and this timer firing).
-        if copy and source and copy is not source and copy.data is source.data:
-            try:
-                demote_to_consumable(copy, source)
-            except Exception:
-                logger.exception("Failed to demote linked sketch '%s'", copy_name)
-    return None
-
-
-def schedule_linked_duplicate_demotions(scene: bpy.types.Scene) -> None:
-    """Plan linked-duplicate demotions and defer the object transforms to a timer.
-
-    Called from the depsgraph handler. Planning only writes a data custom
-    property; the heavier object mutation (data swap + modifier rebuild) can't run
-    mid-evaluation, so it's deferred.
-    """
-    plan = plan_linked_duplicates(scene)
-    if not plan:
-        return
-    _pending.extend(plan)
-    if not bpy.app.timers.is_registered(_run_demotions):
-        bpy.app.timers.register(_run_demotions)
+    return changed

--- a/utilities/consumable.py
+++ b/utilities/consumable.py
@@ -1,0 +1,149 @@
+"""Demote a linked-duplicated sketch (Alt+D) into a dumb linked consumable.
+
+Blender's *linked* duplicate shares the sketch's Curves datablock between two
+objects. Two objects driving one sketch is meaningless and makes the self-heal
+churn (it can't separate the shared constraint uids, see utilities.validate), so
+instead the copy is demoted: it gets its own empty data, loses its sketch role,
+and shows the *source* sketch's evaluated result through an Object Info node. The
+result is a live, linked consumable, no second sketch and no separate companion
+object to keep in sync (the depsgraph tracks the dependency).
+
+A *full* duplicate (Shift+D) copies the data, so each object owns its own sketch
+and is left alone; only the ``_OWNER`` bookkeeping distinguishes the two (a copy
+that shares the owner's datablock is a linked duplicate; a copy with its own
+datablock just claims ownership).
+
+The object transform must run outside the depsgraph handler (it swaps ``data``
+and rebuilds the modifier stack), so the handler only *plans* the demotions and
+a one-shot timer performs them.
+"""
+
+import logging
+
+import bpy
+
+from ..model.sketch_ref import _DOF, _OWNER, _SOLVER_STATE, _TAG, is_sketch_object
+
+logger = logging.getLogger(__name__)
+
+_CONSUME_GROUP = "CAD Sketcher Consumable"
+_CONSUME_MODIFIER = "CAD Sketcher Consumable"
+
+# Demotions queued by the depsgraph handler, performed by the timer below.
+_pending: list[tuple[str, str]] = []
+
+
+def _consume_node_group(source: bpy.types.Object) -> bpy.types.NodeTree:
+    """Node group surfacing ``source``'s evaluated geometry, realized to real mesh.
+
+    The source is baked into the Object Info node as an object pointer (stable
+    across renames, and GN modifier object inputs can't be set by subscript in
+    Blender 5.x). One group per source, reused across its consumables.
+    """
+    name = f"{_CONSUME_GROUP}: {source.name}"
+    ng = bpy.data.node_groups.get(name)
+    if ng is None:
+        ng = bpy.data.node_groups.new(name, "GeometryNodeTree")
+        ng.interface.new_socket(
+            "Geometry", in_out="OUTPUT", socket_type="NodeSocketGeometry"
+        )
+        gout = ng.nodes.new("NodeGroupOutput")
+        info = ng.nodes.new("GeometryNodeObjectInfo")
+        info.name = "source_info"
+        info.transform_space = "RELATIVE"
+        realize = ng.nodes.new("GeometryNodeRealizeInstances")
+        ng.links.new(info.outputs["Geometry"], realize.inputs[0])
+        ng.links.new(realize.outputs[0], gout.inputs[0])
+    info = ng.nodes.get("source_info")
+    if info is not None:
+        info.inputs["Object"].default_value = source
+    return ng
+
+
+def demote_to_consumable(copy: bpy.types.Object, source: bpy.types.Object) -> None:
+    """Turn a linked-dup sketch ``copy`` into a live consumable of ``source``.
+
+    Gives ``copy`` its own empty data (so it stops sharing the source sketch),
+    strips its sketch identity, and drives it from an Object Info node reading the
+    source's evaluated result.
+    """
+    for key in (_TAG, _SOLVER_STATE, _DOF):
+        if key in copy:
+            del copy[key]
+
+    # Own, empty data: stops sharing the source's sketch datablock (which is what
+    # made the self-heal churn) while keeping ``copy`` a Curves object.
+    copy.data = bpy.data.hair_curves.new(copy.name)
+
+    for modifier in list(copy.modifiers):
+        copy.modifiers.remove(modifier)
+
+    modifier = copy.modifiers.new(_CONSUME_MODIFIER, "NODES")
+    modifier.node_group = _consume_node_group(source)
+
+
+def plan_linked_duplicates(scene: bpy.types.Scene) -> list[tuple[str, str]]:
+    """Claim datablock ownership and return ``(copy_name, source_name)`` to demote.
+
+    Sketch objects are grouped by their Curves datablock. A datablock used by a
+    single sketch object is that object's own (claim it). A datablock shared by
+    several is a linked duplicate: keep the owner, list the rest for demotion.
+    Only stamps ownership when it changes, so this is quiet on the common path.
+    """
+    by_data: dict[str, tuple[bpy.types.ID, list[bpy.types.Object]]] = {}
+    for obj in scene.objects:
+        if is_sketch_object(obj) and obj.data is not None:
+            by_data.setdefault(obj.data.name, (obj.data, []))[1].append(obj)
+
+    demote: list[tuple[str, str]] = []
+    for data, objs in by_data.values():
+        if len(objs) == 1:
+            owner = objs[0]
+            if data.get(_OWNER) != owner.name:
+                data[_OWNER] = owner.name
+            continue
+
+        # Shared datablock -> linked duplicate. Keep the stamped owner if it's
+        # among the users, else adopt the first deterministically.
+        owner_name = data.get(_OWNER)
+        keep = next((o for o in objs if o.name == owner_name), None) or objs[0]
+        if data.get(_OWNER) != keep.name:
+            data[_OWNER] = keep.name
+        demote.extend((o.name, keep.name) for o in objs if o is not keep)
+
+    return demote
+
+
+def _run_demotions() -> None:
+    """Timer: perform queued demotions (safe outside the depsgraph handler)."""
+    pending, _pending[:] = list(_pending), []
+    seen = set()
+    for copy_name, source_name in pending:
+        if (copy_name, source_name) in seen:
+            continue
+        seen.add((copy_name, source_name))
+        copy = bpy.data.objects.get(copy_name)
+        source = bpy.data.objects.get(source_name)
+        # Only demote if still a linked duplicate (guards against undo/edits
+        # between planning and this timer firing).
+        if copy and source and copy is not source and copy.data is source.data:
+            try:
+                demote_to_consumable(copy, source)
+            except Exception:
+                logger.exception("Failed to demote linked sketch '%s'", copy_name)
+    return None
+
+
+def schedule_linked_duplicate_demotions(scene: bpy.types.Scene) -> None:
+    """Plan linked-duplicate demotions and defer the object transforms to a timer.
+
+    Called from the depsgraph handler. Planning only writes a data custom
+    property; the heavier object mutation (data swap + modifier rebuild) can't run
+    mid-evaluation, so it's deferred.
+    """
+    plan = plan_linked_duplicates(scene)
+    if not plan:
+        return
+    _pending.extend(plan)
+    if not bpy.app.timers.is_registered(_run_demotions):
+        bpy.app.timers.register(_run_demotions)


### PR DESCRIPTION
Implements a linked duplicate (Alt+D) of a sketch
becomes a **live linked consumable of the source**, not a second sketch.

## Why
Alt+D shares the sketch's Curves datablock between two objects. That gave:
- a redundant second entry in the sketch list, and
- a self-heal that churns forever: `_dedup_constraint_uids` keeps re-minting a
  constraint uid it can never separate (both "copies" are the same shared
  constraint), returning `changed=True` every depsgraph pass and leaking a
  `scene["slvs:c:*"]` key each time (verified 1→7 over 6 passes).

## What it does
The depsgraph handler detects a sketch datablock used by more than one object and
**demotes the copy**: gives it its own empty data (so it stops sharing, ending
the churn), strips its sketch tag, and drives it from an `Object Info → Realize`
node reading the source sketch's evaluated result. The copy stays a live, linked
consumable, the depsgraph keeps it in sync, with **no companion object to manage**
(the concern raised about #682). The object transform is deferred to a one-shot
timer because it swaps `data`/modifiers, which can't run mid-evaluation.

Ownership is tracked by a name stamped on the data at creation (`_OWNER`) and
refreshed while the sketch is single-user, so a **full duplicate (Shift+D)**,
which copies the data, stays an independent sketch and is never demoted.

## Tests
`testing/test_linked_duplicate.py`:
- the linked copy is planned for demotion (owner kept, copy demoted),
- demotion stops the churn/leak (copy loses its tag + shared data, gets the
  consumable modifier, no more scene-key growth),
- a full duplicate stays an independent sketch.

Full suite passes (456).

## Honest limitation
The headless tests drive `plan_linked_duplicates` / `demote_to_consumable`
directly. The end-to-end **handler → timer** path and **undo/redo** of an Alt+D
can't be exercised headlessly (timers/GUI), so those want a manual check in the
viewport before merge.
