### PR TITLE
Add preference to turn off auto-boolean of new solids

### DIFF
--- a/base/preferences.py
+++ b/base/preferences.py
@@ -111,6 +111,15 @@ class Preferences(AddonPreferences):
         description="Fade curves/meshes while in sketch mode",
         default=True,
     )
+    use_auto_boolean: BoolProperty(
+        name="Auto Boolean",
+        description=(
+            "Automatically boolean a new Extrude/Revolve result into overlapping "
+            "bodies. Turn off to keep new solids separate; you can still choose a "
+            "boolean operation per tool in its redo panel"
+        ),
+        default=True,
+    )
     entity_scale: FloatProperty(
         name="Entity Scale", default=1.0, min=0.1, soft_max=3.0, update=theme.update
     )
@@ -172,6 +181,7 @@ class Preferences(AddonPreferences):
         box.label(text="General")
         col = box.column(align=True)
         col.prop(self, "auto_hide_objects")
+        col.prop(self, "use_auto_boolean")
         col.prop(self, "use_align_view")
 
         col.prop(self, "entity_scale")

--- a/base/preferences.py
+++ b/base/preferences.py
@@ -111,15 +111,6 @@ class Preferences(AddonPreferences):
         description="Fade curves/meshes while in sketch mode",
         default=True,
     )
-    use_auto_boolean: BoolProperty(
-        name="Auto Boolean",
-        description=(
-            "Automatically boolean a new Extrude/Revolve result into overlapping "
-            "bodies. Turn off to keep new solids separate; you can still choose a "
-            "boolean operation per tool in its redo panel"
-        ),
-        default=True,
-    )
     entity_scale: FloatProperty(
         name="Entity Scale", default=1.0, min=0.1, soft_max=3.0, update=theme.update
     )

--- a/base/preferences.py
+++ b/base/preferences.py
@@ -181,7 +181,6 @@ class Preferences(AddonPreferences):
         box.label(text="General")
         col = box.column(align=True)
         col.prop(self, "auto_hide_objects")
-        col.prop(self, "use_auto_boolean")
         col.prop(self, "use_align_view")
 
         col.prop(self, "entity_scale")

--- a/model/group_sketcher.py
+++ b/model/group_sketcher.py
@@ -204,6 +204,15 @@ class SketcherProps(PropertyGroup):
         options={"SKIP_SAVE"},
         update=update_cb,
     )
+    use_auto_boolean: BoolProperty(
+        name="Auto Boolean",
+        description=(
+            "Automatically boolean a new Extrude/Revolve result into overlapping "
+            "bodies. Turn off to keep new solids separate; you can still choose a "
+            "boolean operation per tool in its redo panel"
+        ),
+        default=True,
+    )
     version: IntVectorProperty(
         name="Extension Version",
         description="CAD Sketcher extension version this scene was saved with",

--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -226,10 +226,8 @@ class BooleanFromToolMixin:
 
         sketch = Sketch(cutter) if cutter.type == "CURVES" else None
 
-        from ..utilities.preferences import get_prefs
-
         if not self.boolean_detected:
-            if get_prefs().use_auto_boolean:
+            if context.scene.sketcher.use_auto_boolean:
                 has_source = (
                     sketch is not None and sketch_source_body(sketch) is not None
                 )

--- a/operators/modifiers.py
+++ b/operators/modifiers.py
@@ -226,14 +226,27 @@ class BooleanFromToolMixin:
 
         sketch = Sketch(cutter) if cutter.type == "CURVES" else None
 
-        # The solid must be evaluated before the overlap test can see it.
-        context.view_layer.update()
-        targets = detect_targets(context, cutter, sketch)
+        from ..utilities.preferences import get_prefs
 
         if not self.boolean_detected:
-            has_source = sketch is not None and sketch_source_body(sketch) is not None
-            self.operation = default_operation(self._boolean_offset(), has_source)
+            if get_prefs().use_auto_boolean:
+                has_source = (
+                    sketch is not None and sketch_source_body(sketch) is not None
+                )
+                self.operation = default_operation(self._boolean_offset(), has_source)
+            else:
+                # Auto boolean is off: leave the new solid standalone. The user can
+                # still pick an operation in the redo panel to boolean on demand.
+                self.operation = "None"
             self.boolean_detected = True
+
+        # The solid must be evaluated before the overlap test can see it. Skip the
+        # overlap detection entirely when there is no operation to apply.
+        if self.operation != "None":
+            context.view_layer.update()
+            targets = detect_targets(context, cutter, sketch)
+        else:
+            targets = []
 
         # Preserve exclusions across redo while adding newly-overlapping bodies; a
         # target that drops out of detection loses its (now moot) boolean anyway.

--- a/testing/test_boolean_targets.py
+++ b/testing/test_boolean_targets.py
@@ -173,15 +173,15 @@ class TestBooleanTargets(BgsTestCase):
         )
 
     def test_auto_boolean_off_skips_boolean(self):
-        # With the Auto Boolean preference off, finishing an extrude/revolve must
-        # not boolean the new solid into an overlapping body (issue: new sketches
-        # auto-booling into existing ones). The user can still opt in per-tool.
+        # With Auto Boolean off, finishing an extrude/revolve must not boolean the
+        # new solid into an overlapping body (issue: new sketches auto-booling into
+        # existing ones). The user can still opt in per-tool.
         from ..operators.modifiers import (
             BooleanFromToolMixin,
             boolean_modifier_name,
         )
-        from ..utilities.preferences import get_prefs
 
+        sketcher = self.context.scene.sketcher
         cutter = self._gn_solid("Cutter", (0, 0, 0))  # [-1,1]^3 GN solid
         body = self._box("Body", (1, 1, 1))  # overlaps
 
@@ -207,7 +207,7 @@ class TestBooleanTargets(BgsTestCase):
 
         name = boolean_modifier_name(cutter)
 
-        get_prefs().use_auto_boolean = False
+        sketcher.use_auto_boolean = False
         try:
             BooleanFromToolMixin.finish_booleans(fake, self.context)
             self.assertEqual(fake.operation, "None")
@@ -215,4 +215,4 @@ class TestBooleanTargets(BgsTestCase):
                 body.modifiers.get(name), "auto boolean off must not apply a boolean"
             )
         finally:
-            get_prefs().use_auto_boolean = True
+            sketcher.use_auto_boolean = True

--- a/testing/test_boolean_targets.py
+++ b/testing/test_boolean_targets.py
@@ -171,3 +171,48 @@ class TestBooleanTargets(BgsTestCase):
         self.assertIsNone(
             dropped.modifiers.get(name), "dropped body's stale boolean is removed"
         )
+
+    def test_auto_boolean_off_skips_boolean(self):
+        # With the Auto Boolean preference off, finishing an extrude/revolve must
+        # not boolean the new solid into an overlapping body (issue: new sketches
+        # auto-booling into existing ones). The user can still opt in per-tool.
+        from ..operators.modifiers import (
+            BooleanFromToolMixin,
+            boolean_modifier_name,
+        )
+        from ..utilities.preferences import get_prefs
+
+        cutter = self._gn_solid("Cutter", (0, 0, 0))  # [-1,1]^3 GN solid
+        body = self._box("Body", (1, 1, 1))  # overlaps
+
+        class _Coll(list):
+            def add(self):
+                item = types.SimpleNamespace(name="", enabled=True)
+                self.append(item)
+                return item
+
+        fake = types.SimpleNamespace(
+            _obj=cutter,
+            operation="Difference",
+            boolean_detected=False,
+            boolean_targets=_Coll(),
+            offset=1.0,
+        )
+        fake._boolean_offset = types.MethodType(
+            BooleanFromToolMixin._boolean_offset, fake
+        )
+        fake._apply_boolean_targets = types.MethodType(
+            BooleanFromToolMixin._apply_boolean_targets, fake
+        )
+
+        name = boolean_modifier_name(cutter)
+
+        get_prefs().use_auto_boolean = False
+        try:
+            BooleanFromToolMixin.finish_booleans(fake, self.context)
+            self.assertEqual(fake.operation, "None")
+            self.assertIsNone(
+                body.modifiers.get(name), "auto boolean off must not apply a boolean"
+            )
+        finally:
+            get_prefs().use_auto_boolean = True

--- a/workspacetools/extrude.py
+++ b/workspacetools/extrude.py
@@ -4,7 +4,6 @@ from ..declarations import GizmoGroups, Operators, WorkSpaceTools
 from ..keymaps import tool_node
 from ..stateful_operator.tool import GenericStateTool
 from ..stateful_operator.utilities.keymap import operator_access
-from ..utilities.preferences import get_prefs
 
 
 class VIEW3D_T_slvs_node_extrude(GenericStateTool, WorkSpaceTool):
@@ -21,6 +20,6 @@ class VIEW3D_T_slvs_node_extrude(GenericStateTool, WorkSpaceTool):
     )
 
     def draw_settings(context, layout, tool):
-        # Shared across the boolean-capable tools: the single addon preference
-        # gating whether a new solid auto-booleans into overlapping bodies.
-        layout.prop(get_prefs(), "use_auto_boolean")
+        # Shared across the boolean-capable tools (scene.sketcher): whether a new
+        # solid auto-booleans into overlapping bodies. Saved per-file.
+        layout.prop(context.scene.sketcher, "use_auto_boolean")

--- a/workspacetools/extrude.py
+++ b/workspacetools/extrude.py
@@ -4,6 +4,7 @@ from ..declarations import GizmoGroups, Operators, WorkSpaceTools
 from ..keymaps import tool_node
 from ..stateful_operator.tool import GenericStateTool
 from ..stateful_operator.utilities.keymap import operator_access
+from ..utilities.preferences import get_prefs
 
 
 class VIEW3D_T_slvs_node_extrude(GenericStateTool, WorkSpaceTool):
@@ -18,3 +19,8 @@ class VIEW3D_T_slvs_node_extrude(GenericStateTool, WorkSpaceTool):
         *tool_node,
         *operator_access(Operators.NodeExtrude),
     )
+
+    def draw_settings(context, layout, tool):
+        # Shared across the boolean-capable tools: the single addon preference
+        # gating whether a new solid auto-booleans into overlapping bodies.
+        layout.prop(get_prefs(), "use_auto_boolean")

--- a/workspacetools/revolve.py
+++ b/workspacetools/revolve.py
@@ -4,6 +4,7 @@ from ..declarations import GizmoGroups, Operators, WorkSpaceTools
 from ..keymaps import tool_node
 from ..stateful_operator.tool import GenericStateTool
 from ..stateful_operator.utilities.keymap import operator_access
+from ..utilities.preferences import get_prefs
 
 
 class VIEW3D_T_slvs_node_revolve(GenericStateTool, WorkSpaceTool):
@@ -18,3 +19,8 @@ class VIEW3D_T_slvs_node_revolve(GenericStateTool, WorkSpaceTool):
         *tool_node,
         *operator_access(Operators.NodeRevolve),
     )
+
+    def draw_settings(context, layout, tool):
+        # Shared across the boolean-capable tools: the single addon preference
+        # gating whether a new solid auto-booleans into overlapping bodies.
+        layout.prop(get_prefs(), "use_auto_boolean")

--- a/workspacetools/revolve.py
+++ b/workspacetools/revolve.py
@@ -4,7 +4,6 @@ from ..declarations import GizmoGroups, Operators, WorkSpaceTools
 from ..keymaps import tool_node
 from ..stateful_operator.tool import GenericStateTool
 from ..stateful_operator.utilities.keymap import operator_access
-from ..utilities.preferences import get_prefs
 
 
 class VIEW3D_T_slvs_node_revolve(GenericStateTool, WorkSpaceTool):
@@ -21,6 +20,6 @@ class VIEW3D_T_slvs_node_revolve(GenericStateTool, WorkSpaceTool):
     )
 
     def draw_settings(context, layout, tool):
-        # Shared across the boolean-capable tools: the single addon preference
-        # gating whether a new solid auto-booleans into overlapping bodies.
-        layout.prop(get_prefs(), "use_auto_boolean")
+        # Shared across the boolean-capable tools (scene.sketcher): whether a new
+        # solid auto-booleans into overlapping bodies. Saved per-file.
+        layout.prop(context.scene.sketcher, "use_auto_boolean")


### PR DESCRIPTION
Adds a single **Auto Boolean** toggle. When off, a new Extrude/Revolve result stays a separate solid instead of auto-booleaning into an overlapping body.

Requested by a user: auto-boolean gets in the way when building many sketches, new solids kept booleaning into existing ones.

Stored as `scene.sketcher.use_auto_boolean` (default on), surfaced in the tool settings header of the **Extrude** and **Revolve** tools so both share it. It saves with the .blend, so the choice is scoped to the file/task where it matters (unlike the transient `SKIP_SAVE` tool settings, and unlike a global preference that would leak the choice across files). `finish_booleans` reads it: off seeds the operation to `None`, leaving the solid standalone. The per-tool boolean choice in the redo panel still works.

Test: `test_auto_boolean_off_skips_boolean` drives `finish_booleans` with the setting off and asserts no boolean modifier is applied to an overlapping body.