### PR TITLE
Interaction performance on large sketches

### DIFF
--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "CAD_Sketcher"
-version = "0.31.2"
+version = "0.32.0"
 name = "CAD Sketcher"
 tagline = "Parametric, constraint-based geometry sketcher"
 maintainer = "hlorus <dave19924@gmail.com>"

--- a/curve_solver.py
+++ b/curve_solver.py
@@ -11,6 +11,7 @@ Constraints still come from PropertyGroups (referencing entities for now).
 import logging
 import math
 
+import numpy as np
 from mathutils import Matrix as _Matrix
 from mathutils import Vector
 
@@ -24,6 +25,19 @@ from .utilities.curve_data import (
 from .utilities.workplane import ensure_workplane_empty
 
 logger = logging.getLogger(__name__)
+
+
+def _stored_differs(current, new) -> bool:
+    """Whether writing ``new`` over ``current`` would change the stored floats.
+
+    Positions are float32 attributes, so the comparison is done at that precision
+    rather than against the solver's doubles (see ``_write_results``).
+    """
+    return bool(
+        (
+            np.asarray(new, dtype=np.float32) != np.asarray(current, dtype=np.float32)
+        ).any()
+    )
 
 
 class CurveSolver:
@@ -456,7 +470,20 @@ class CurveSolver:
         cid_list = read_uuid_list(curve_data, "curve_id")
         cp_list = read_uuid_list(curve_data, "center_point_id")
 
+        # Point curves whose solved position actually differs from what is stored.
+        # The third pass rebuilds only the segments referencing these, instead of
+        # re-deriving every arc/circle bezier in the sketch on every solve -- a
+        # drag moves a handful of points out of hundreds (issue #342).
+        #
+        # A segment's geometry is a pure function of its referenced point
+        # positions, so a point the solver rewrites with an unchanged value cannot
+        # change any segment and is deliberately left out. That relies on the
+        # invariant every writer of point positions already maintains: whoever
+        # moves a point rebuilds its segments (see batch_update).
+        moved_point_ids = set()
+
         # First pass: update all point positions
+        solved_indices, solved_positions, solved_cids = [], [], []
         for curve_idx in range(n_curves):
             ctype = type_attr.data[curve_idx].value
             cid = cid_list[curve_idx]
@@ -464,8 +491,23 @@ class CurveSolver:
             if ctype == SketchCurveType.POINT:
                 pos = self._get_solved_point_position(cid)
                 if pos:
-                    pt_idx = curve_data.curves[curve_idx].points[0].index
-                    curve_data.points[pt_idx].position = pos
+                    solved_indices.append(curve_data.curves[curve_idx].points[0].index)
+                    solved_positions.append(pos)
+                    solved_cids.append(cid)
+
+        if solved_indices:
+            # Compare as float32, the attribute's own storage: the solver works in
+            # double, so a solved value that merely round-trips would never equal
+            # the stored one under an exact double compare, and every point would
+            # look moved. Comparing what would actually be *stored* makes "moved"
+            # mean "the bytes change", with no tolerance to tune.
+            stored = np.empty(len(curve_data.points) * 3, dtype=np.float32)
+            curve_data.points.foreach_get("position", stored)
+            current = stored.reshape(-1, 3)[solved_indices]
+            incoming = np.asarray(solved_positions, dtype=np.float32)
+            for k in np.flatnonzero((incoming != current).any(axis=1)).tolist():
+                curve_data.points[solved_indices[k]].position = solved_positions[k]
+                moved_point_ids.add(solved_cids[k])
 
         # Second pass: update circle/arc edge positions from solved radius
         for curve_idx in range(n_curves):
@@ -485,11 +527,19 @@ class CurveSolver:
                         # Update first edge point at new radius
                         curve_slice = curve_data.curves[curve_idx]
                         first = curve_slice.points[0].index
-                        curve_data.points[first].position = (
+                        edge = (
                             ct_pos[0] + solved_radius,
                             ct_pos[1],
                             ct_pos[2],
                         )
+                        point = curve_data.points[first]
+                        if _stored_differs(point.position, edge):
+                            point.position = edge
+                            # This circle's radius changed but its centre may not
+                            # have moved, so nothing above would have flagged it.
+                            # rebuild_segments matches a circle through the centre
+                            # point it references, so that is the id to add.
+                            moved_point_ids.add(cp_id)
 
         # Third pass: rebuild segments from updated point positions.
         if getattr(sketch, "is_3d", False):
@@ -497,9 +547,13 @@ class CurveSolver:
 
             rebuild_3d_lines(sketch)
         else:
-            from .utilities.curve_data import rebuild_segments
+            from .utilities.curve_data import compute_merge_ids, rebuild_segments
 
-            rebuild_segments(sketch)
+            rebuild_segments(sketch, point_ids=moved_point_ids)
+            # A scoped rebuild skips merge ids (they track connectivity, which a
+            # move cannot change). A solve reaches here after topology edits too,
+            # so keep recomputing them exactly as the unscoped call used to.
+            compute_merge_ids(sketch)
 
         # Sync entity.co from solved curve positions (bridge for gizmo positioning)
         # TODO: Remove when gizmos read from curve data directly

--- a/curve_solver.py
+++ b/curve_solver.py
@@ -15,6 +15,7 @@ import numpy as np
 from mathutils import Matrix as _Matrix
 from mathutils import Vector
 
+from .model.base_constraint import sketch_resolution
 from .model.constants import SketchCurveType
 from .utilities.constants import FULL_TURN, HALF_TURN
 from .utilities.curve_data import (
@@ -272,6 +273,15 @@ class CurveSolver:
                 # For lines/arcs/circles: coincident point-on-entity
                 self.solvesys.coincident(self.group_sketch, drag_pt, tweak_handle, wp)
                 self.solvesys.dragged(self.group_sketch, drag_pt, wp)
+
+    def _resolution_sketch(self):
+        """``self.sketch`` as a Sketch accessor, for ``sketch_resolution``."""
+        sketch = self.sketch
+        if sketch is None or hasattr(sketch, "target_object"):
+            return sketch
+        from .model.sketch_ref import Sketch
+
+        return Sketch(sketch)
 
     def _init_constraints(self):
         """Initialize constraints using curve_id handles."""
@@ -606,7 +616,10 @@ class CurveSolver:
 
         self._init_workplane()
         self._init_geometry()
-        self._init_constraints()
+        # Publish the sketch so the constraints being built (and the dimension
+        # values they read) resolve it for free instead of each re-deriving it.
+        with sketch_resolution(self._resolution_sketch()):
+            self._init_constraints()
 
         result = self.solvesys.solve_sketch(self.group_sketch, True)
 

--- a/drawing/overlay.py
+++ b/drawing/overlay.py
@@ -13,23 +13,26 @@ invalidate a batch.
 """
 
 import gpu
-from gpu_extras.batch import batch_for_shader
 from bpy.types import Context
+from gpu_extras.batch import batch_for_shader
 
+from ..model.sketch_ref import get_sketches
+from ..shaders import Shaders
 from ..utilities import preferences
 from ..utilities.preferences import get_prefs
-from ..shaders import Shaders
-from ..model.sketch_ref import get_sketches
 from . import render_data as rd
-
 
 # obj_name -> (signature, point_batch, line_batch, dashed_batch)
 _cache = {}
 
 # Two triangles covering [-1, 1]^2, for expanding a point into a screen quad.
 _QUAD_CORNERS = [
-    (-1, -1), (1, -1), (1, 1),
-    (-1, -1), (1, 1), (-1, 1),
+    (-1, -1),
+    (1, -1),
+    (1, 1),
+    (-1, -1),
+    (1, 1),
+    (-1, 1),
 ]
 
 
@@ -37,8 +40,13 @@ def _theme_signature(ts):
     return tuple(
         tuple(getattr(ts, name))
         for name in (
-            "default", "highlight", "selected", "selected_highlight",
-            "fixed", "inactive", "inactive_selected",
+            "default",
+            "highlight",
+            "selected",
+            "selected_highlight",
+            "fixed",
+            "inactive",
+            "inactive_selected",
         )
     )
 
@@ -64,9 +72,13 @@ def _build_batches(data):
             pcols += [color] * 6
             pcorners += [(cx * psize, cy * psize) for cx, cy in _QUAD_CORNERS]
     point_batch = (
-        batch_for_shader(Shaders.point_sprite_color_3d(), "TRIS",
-                         {"pos": pverts, "color": pcols, "corner": pcorners})
-        if pverts else None
+        batch_for_shader(
+            Shaders.point_sprite_color_3d(),
+            "TRIS",
+            {"pos": pverts, "color": pcols, "corner": pcorners},
+        )
+        if pverts
+        else None
     )
 
     sverts, scols, dverts, dcols = [], [], [], []
@@ -80,14 +92,20 @@ def _build_batches(data):
             sverts += verts
             scols += [color] * len(verts)
     line_batch = (
-        batch_for_shader(Shaders.polyline_flat_color_3d(), "LINES",
-                         {"pos": sverts, "color": scols})
-        if sverts else None
+        batch_for_shader(
+            Shaders.polyline_flat_color_3d(), "LINES", {"pos": sverts, "color": scols}
+        )
+        if sverts
+        else None
     )
     dashed_batch = (
-        batch_for_shader(Shaders.dashed_flat_color_line_3d(), "LINES",
-                         {"pos": dverts, "color": dcols})
-        if dverts else None
+        batch_for_shader(
+            Shaders.dashed_flat_color_line_3d(),
+            "LINES",
+            {"pos": dverts, "color": dcols},
+        )
+        if dverts
+        else None
     )
     return point_batch, line_batch, dashed_batch
 
@@ -175,8 +193,10 @@ def draw(context: Context):
     # Drop cache entries for sketches that no longer exist / are hidden.
     for stale in [n for n in _cache if n not in seen]:
         del _cache[stale]
+        rd._geometry_cache.pop(stale, None)
 
 
 def invalidate():
     """Force a full rebuild on the next draw (e.g. on unregister/file load)."""
     _cache.clear()
+    rd.invalidate()

--- a/drawing/overlay.py
+++ b/drawing/overlay.py
@@ -13,6 +13,7 @@ invalidate a batch.
 """
 
 import gpu
+import numpy as np
 from bpy.types import Context
 from gpu_extras.batch import batch_for_shader
 
@@ -26,14 +27,9 @@ from . import render_data as rd
 _cache = {}
 
 # Two triangles covering [-1, 1]^2, for expanding a point into a screen quad.
-_QUAD_CORNERS = [
-    (-1, -1),
-    (1, -1),
-    (1, 1),
-    (-1, -1),
-    (1, 1),
-    (-1, 1),
-]
+_QUAD_CORNERS = np.array(
+    [(-1, -1), (1, -1), (1, 1), (-1, -1), (1, 1), (-1, 1)], dtype=np.float32
+)
 
 
 def _theme_signature(ts):
@@ -64,36 +60,53 @@ def _build_batches(data):
     # (GL_POINTS didn't apply it on the Vulkan backend). Each point contributes
     # 6 vertices sharing the same center/color; the per-point size factor is
     # baked into `corner` so hovered/selected points draw bigger in the same
-    # batch.
+    # batch. Built with repeat/tile rather than Python list building -- the
+    # buckets arrive as arrays and batch_for_shader takes arrays directly.
     pverts, pcols, pcorners = [], [], []
-    for color, entries in data.point_buckets.items():
-        for pos, psize in entries:
-            pverts += [pos] * 6
-            pcols += [color] * 6
-            pcorners += [(cx * psize, cy * psize) for cx, cy in _QUAD_CORNERS]
+    for color, (centres, sizes) in data.point_buckets.items():
+        if len(centres) == 0:
+            continue
+        pverts.append(np.repeat(centres, 6, axis=0))
+        pcols.append(
+            np.tile(np.asarray(color, dtype=np.float32), (len(centres) * 6, 1))
+        )
+        # Each point repeats the 6 corners in order, scaled by its own size
+        # factor: tile the corners per point, repeat each size across its 6.
+        pcorners.append(
+            np.tile(_QUAD_CORNERS, (len(centres), 1)) * np.repeat(sizes, 6)[:, None]
+        )
     point_batch = (
         batch_for_shader(
             Shaders.point_sprite_color_3d(),
             "TRIS",
-            {"pos": pverts, "color": pcols, "corner": pcorners},
+            {
+                "pos": np.concatenate(pverts),
+                "color": np.concatenate(pcols),
+                "corner": np.concatenate(pcorners),
+            },
         )
         if pverts
         else None
     )
 
     sverts, scols, dverts, dcols = [], [], [], []
-    for (construction, color), verts in data.line_buckets.items():
+    for (construction, color), chunks in data.line_buckets.items():
+        verts = [c.reshape(-1, 3) for c in chunks if len(c)]
         if not verts:
             continue
+        merged = np.concatenate(verts)
+        cols = np.tile(np.asarray(color, dtype=np.float32), (len(merged), 1))
         if construction:
-            dverts += verts
-            dcols += [color] * len(verts)
+            dverts.append(merged)
+            dcols.append(cols)
         else:
-            sverts += verts
-            scols += [color] * len(verts)
+            sverts.append(merged)
+            scols.append(cols)
     line_batch = (
         batch_for_shader(
-            Shaders.polyline_flat_color_3d(), "LINES", {"pos": sverts, "color": scols}
+            Shaders.polyline_flat_color_3d(),
+            "LINES",
+            {"pos": np.concatenate(sverts), "color": np.concatenate(scols)},
         )
         if sverts
         else None
@@ -102,7 +115,7 @@ def _build_batches(data):
         batch_for_shader(
             Shaders.dashed_flat_color_line_3d(),
             "LINES",
-            {"pos": dverts, "color": dcols},
+            {"pos": np.concatenate(dverts), "color": np.concatenate(dcols)},
         )
         if dverts
         else None

--- a/drawing/picking.py
+++ b/drawing/picking.py
@@ -9,6 +9,8 @@ Only the active sketch is pickable (other sketches are read-only reference), and
 curves in ``selection.ignore_list`` are skipped, matching the old behavior.
 """
 
+from typing import NamedTuple
+
 import numpy as np
 
 from ..model.sketch_ref import get_active_sketch
@@ -20,6 +22,30 @@ from . import render_data, selection
 # and take priority, so a vertex is easy to hit even when it sits on a line.
 _POINT_RADIUS = 11.0
 _EDGE_RADIUS = 8.0
+
+
+class PickSet(NamedTuple):
+    """Pickable geometry in the array form the screen projection consumes.
+
+    ``point_keys`` is aligned with ``point_co`` rows. Segment identity is per
+    *curve*: ``seg_keys`` holds one key per curve and ``seg_owner`` maps each row
+    of ``seg_co`` back into it, so a 48-segment circle carries one key, not 48.
+    """
+
+    point_keys: list
+    point_co: np.ndarray  # (P, 3)
+    seg_keys: list
+    seg_co: np.ndarray  # (M, 2, 3)
+    seg_owner: np.ndarray  # (M,) -> index into seg_keys
+
+
+EMPTY_PICKSET = PickSet(
+    [],
+    np.zeros((0, 3), dtype=np.float32),
+    [],
+    np.zeros((0, 2, 3), dtype=np.float32),
+    np.zeros(0, dtype=np.intp),
+)
 
 
 def _active_data(context):
@@ -37,40 +63,65 @@ def _active_data(context):
     return render_data.geometry(sketch)
 
 
-def _points_screen(items, region, rv3d):
-    """Project [(cid, world_pos), ...] -> (cids, screen (N,2), valid (N,))."""
-    cids = [cid for cid, _ in items]
-    world = np.array([p for _, p in items], dtype=np.float64)
-    screen, valid = _project_points_to_region(world, region, rv3d)
-    return cids, screen, valid
+def _active_pickset(context):
+    """``PickSet`` for the active sketch, honouring ``selection.ignore_list``."""
+    geo = _active_data(context)
+    if geo is None:
+        return None
+
+    pick = PickSet(
+        geo.point_cids, geo.point_co, geo.seg_cids, geo.seg_co, geo.seg_owner
+    )
+    ignore = selection.ignore_list
+    if not ignore:
+        # The common case: the arrays are handed straight through, no filtering.
+        return pick
+    return _without(pick, ignore)
 
 
-def _seg_screen(items, region, rv3d):
-    """Project [(cid, a, b), ...] -> (cids, screen (N,2,2), valid (N,2))."""
-    cids = [cid for cid, _, _ in items]
-    world = np.array([[a, b] for _, a, b in items], dtype=np.float64).reshape(-1, 3)
-    screen, valid = _project_points_to_region(world, region, rv3d)
-    n = len(items)
-    return cids, screen.reshape(n, 2, 2), valid.reshape(n, 2)
+def _without(pick, ignore):
+    """Drop every point/segment whose key is in ``ignore``."""
+    keep_pts = [i for i, k in enumerate(pick.point_keys) if k not in ignore]
+    drop_curves = {c for c, k in enumerate(pick.seg_keys) if k in ignore}
+    if drop_curves:
+        keep_rows = ~np.isin(pick.seg_owner, list(drop_curves))
+        seg_co = pick.seg_co[keep_rows]
+        seg_owner = pick.seg_owner[keep_rows]
+    else:
+        seg_co, seg_owner = pick.seg_co, pick.seg_owner
+    return PickSet(
+        [pick.point_keys[i] for i in keep_pts],
+        pick.point_co[keep_pts],
+        pick.seg_keys,
+        seg_co,
+        seg_owner,
+    )
 
 
-def _dist_to_segment(a, b, px, py):
-    abx, aby = b[0] - a[0], b[1] - a[1]
-    seg2 = abx * abx + aby * aby
-    if seg2 < 1e-9:
-        return ((px - a[0]) ** 2 + (py - a[1]) ** 2) ** 0.5
-    t = ((px - a[0]) * abx + (py - a[1]) * aby) / seg2
-    t = min(1.0, max(0.0, t))
-    cx, cy = a[0] + t * abx, a[1] + t * aby
-    return ((px - cx) ** 2 + (py - cy) ** 2) ** 0.5
+def _dist_to_segments(screen, cx, cy):
+    """Perpendicular distance from ``(cx, cy)`` to each of N screen segments.
+
+    ``screen`` is ``(N, 2, 2)``. Vectorized: the per-segment Python loop this
+    replaces ran once per tessellated segment, so a sketch of circles paid for it
+    thousands of times per mouse-move.
+    """
+    a = screen[:, 0]
+    b = screen[:, 1]
+    ab = b - a
+    seg2 = (ab * ab).sum(axis=1)
+    ap = np.stack((cx - a[:, 0], cy - a[:, 1]), axis=1)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        t = np.where(seg2 > 1e-9, (ap * ab).sum(axis=1) / seg2, 0.0)
+    t = np.clip(t, 0.0, 1.0)
+    closest = a + t[:, None] * ab
+    return np.hypot(closest[:, 0] - cx, closest[:, 1] - cy)
 
 
-def rank_hits(point_items, seg_items, context, coords):
-    """Ranked element keys from generic ``(key, world)`` datasets under ``coords``.
+def rank_hits(pick, context, coords):
+    """Ranked element keys from a ``PickSet`` under ``coords``.
 
-    ``point_items``: ``[(key, world_pos), ...]``; ``seg_items``: ``[(key, a, b),
-    ...]``. Points take priority over segments, then nearest first, and keys are
-    deduped. Shared by the active-sketch picker and reference curve-object picking
+    Points take priority over segments, then nearest first, and keys are deduped.
+    Shared by the active-sketch picker and reference curve-object picking
     (``reference_pick``), so it must stay independent of any sketch specifics.
     """
     region, rv3d = context.region, context.region_data
@@ -79,29 +130,31 @@ def rank_hits(point_items, seg_items, context, coords):
 
     scale = get_scale()
     cx, cy = float(coords[0]), float(coords[1])
-    hits = []  # (priority, distance, key)
+    order = []  # (priority, distance, key), gathered vectorized then sorted
 
-    if point_items:
-        keys, screen, valid = _points_screen(point_items, region, rv3d)
+    if len(pick.point_co):
+        screen, valid = _project_points_to_region(pick.point_co, region, rv3d)
         d = np.hypot(screen[:, 0] - cx, screen[:, 1] - cy)
-        r = _POINT_RADIUS * scale
-        for i, key in enumerate(keys):
-            if valid[i] and d[i] <= r:
-                hits.append((0, float(d[i]), key))
+        hit = valid & (d <= _POINT_RADIUS * scale)
+        for i in np.flatnonzero(hit).tolist():
+            order.append((0, float(d[i]), pick.point_keys[i]))
 
-    if seg_items:
-        keys, screen, valid = _seg_screen(seg_items, region, rv3d)
-        r = _EDGE_RADIUS * scale
-        for i, key in enumerate(keys):
-            if not (valid[i, 0] and valid[i, 1]):
-                continue
-            dist = _dist_to_segment(screen[i, 0], screen[i, 1], cx, cy)
-            if dist <= r:
-                hits.append((1, float(dist), key))
+    if len(pick.seg_co):
+        n = len(pick.seg_co)
+        screen, valid = _project_points_to_region(
+            pick.seg_co.reshape(-1, 3), region, rv3d
+        )
+        screen = screen.reshape(n, 2, 2)
+        valid = valid.reshape(n, 2).all(axis=1)
+        d = _dist_to_segments(screen, cx, cy)
+        hit = valid & (d <= _EDGE_RADIUS * scale)
+        owners = pick.seg_owner
+        for i in np.flatnonzero(hit).tolist():
+            order.append((1, float(d[i]), pick.seg_keys[owners[i]]))
 
-    hits.sort(key=lambda h: (h[0], h[1]))
+    order.sort(key=lambda h: (h[0], h[1]))
     ranked, seen = [], set()
-    for _, _, key in hits:
+    for _, _, key in order:
         if key not in seen:
             seen.add(key)
             ranked.append(key)
@@ -115,13 +168,10 @@ def pick_ranked(context, coords):
     by screen distance. Unlike ``pick`` this keeps *all* candidates within the hit
     radius, so overlapping entities can be cycled through instead of only ever
     getting the topmost one (issue #50)."""
-    data = _active_data(context)
-    if data is None:
+    pick = _active_pickset(context)
+    if pick is None:
         return []
-    ignore = selection.ignore_list
-    pts = [(cid, p) for cid, p in data.point_ids if cid not in ignore]
-    segs = [(cid, a, b) for cid, a, b in data.segment_ids if cid not in ignore]
-    return rank_hits(pts, segs, context, coords)
+    return rank_hits(pick, context, coords)
 
 
 def pick(context, coords):
@@ -171,20 +221,18 @@ def _seg_intersects_box(a, b, x0, y0, x1, y1):
 
 def pick_box(context, min_co, max_co):
     """curve_ids of the active sketch whose geometry overlaps the screen box."""
-    data = _active_data(context)
+    pick = _active_pickset(context)
     region, rv3d = context.region, context.region_data
-    if data is None or region is None or rv3d is None:
+    if pick is None or region is None or rv3d is None:
         return []
 
-    ignore = selection.ignore_list
     x0, x1 = sorted((float(min_co[0]), float(max_co[0])))
     y0, y1 = sorted((float(min_co[1]), float(max_co[1])))
 
     found, seen = [], set()
 
-    pts = [(cid, p) for cid, p in data.point_ids if cid not in ignore]
-    if pts:
-        cids, screen, valid = _points_screen(pts, region, rv3d)
+    if len(pick.point_co):
+        screen, valid = _project_points_to_region(pick.point_co, region, rv3d)
         inside = (
             valid
             & (screen[:, 0] >= x0)
@@ -192,19 +240,26 @@ def pick_box(context, min_co, max_co):
             & (screen[:, 1] >= y0)
             & (screen[:, 1] <= y1)
         )
-        for i, cid in enumerate(cids):
-            if inside[i] and cid not in seen:
-                seen.add(cid)
-                found.append(cid)
+        for i in np.flatnonzero(inside).tolist():
+            key = pick.point_keys[i]
+            if key not in seen:
+                seen.add(key)
+                found.append(key)
 
-    segs = [(cid, a, b) for cid, a, b in data.segment_ids if cid not in ignore]
-    if segs:
-        cids, screen, valid = _seg_screen(segs, region, rv3d)
-        for i, cid in enumerate(cids):
-            if cid in seen or not (valid[i, 0] and valid[i, 1]):
+    if len(pick.seg_co):
+        n = len(pick.seg_co)
+        screen, valid = _project_points_to_region(
+            pick.seg_co.reshape(-1, 3), region, rv3d
+        )
+        screen = screen.reshape(n, 2, 2)
+        valid = valid.reshape(n, 2).all(axis=1)
+        owners = pick.seg_owner
+        for i in np.flatnonzero(valid).tolist():
+            key = pick.seg_keys[owners[i]]
+            if key in seen:
                 continue
             if _seg_intersects_box(screen[i, 0], screen[i, 1], x0, y0, x1, y1):
-                seen.add(cid)
-                found.append(cid)
+                seen.add(key)
+                found.append(key)
 
     return found

--- a/drawing/picking.py
+++ b/drawing/picking.py
@@ -12,7 +12,7 @@ curves in ``selection.ignore_list`` are skipped, matching the old behavior.
 import numpy as np
 
 from ..model.sketch_ref import get_active_sketch
-from ..utilities.preferences import get_prefs, get_scale
+from ..utilities.preferences import get_scale
 from ..utilities.view import _project_points_to_region
 from . import render_data, selection
 
@@ -22,28 +22,19 @@ _POINT_RADIUS = 11.0
 _EDGE_RADIUS = 8.0
 
 
-# (sketch object name) -> (geometry_signature, point_ids, segment_ids). Picking
-# only needs the projected points/segments, which depend on geometry, not on the
-# hover/selection state that changes every mouse-move -- so we rebuild the
-# extraction only when the geometry actually changes, not on every hover.
-_pick_cache = {}
-
-
 def _active_data(context):
+    """The active sketch's pickable geometry, from the shared extraction cache.
+
+    Picking needs only the projected points and segments, which depend on the
+    geometry and not on the hover/selection state that changes every mouse-move.
+    ``render_data.geometry`` caches exactly that against the geometry signature,
+    and the overlay draws from the same entry, so a frame in which the geometry
+    changed extracts once rather than once here and once for the overlay.
+    """
     sketch = get_active_sketch(context)
     if not sketch or not sketch.is_visible(context):
         return None
-
-    obj = sketch.target_object
-    sig = render_data.geometry_signature(sketch)
-    cached = _pick_cache.get(obj.name)
-    if cached is not None and cached[0] == sig:
-        return cached[1]
-
-    ts = get_prefs().theme_settings.entity
-    data = render_data.build(sketch, ts, is_active=True)
-    _pick_cache[obj.name] = (sig, data)
-    return data
+    return render_data.geometry(sketch)
 
 
 def _points_screen(items, region, rv3d):

--- a/drawing/reference_pick.py
+++ b/drawing/reference_pick.py
@@ -32,17 +32,16 @@ def _is_sketch(curve_data) -> bool:
 def _sketch_geometry(obj):
     """Pickable points/segments of a sketch, keyed by ``curve_id``.
 
-    Reuses ``render_data.build``, which already projects points and tessellates
-    lines/arcs/circles into ``point_ids`` / ``segment_ids`` for picking.
+    Reuses the shared, cached extraction, which already projects points and
+    tessellates lines/arcs/circles into ``point_ids`` / ``segment_ids``. Colours
+    are irrelevant here, so this deliberately skips the colour pass -- reference
+    picking walks every visible curve object, so it would pay for it per object.
     """
     from ..model.sketch_ref import Sketch
-    from ..utilities.preferences import get_prefs
     from . import render_data
 
-    sketch = Sketch(obj)
-    ts = get_prefs().theme_settings.entity
-    rd = render_data.build(sketch, ts, is_active=False)
-    return rd.point_ids, rd.segment_ids
+    geo = render_data.geometry(Sketch(obj))
+    return geo.point_ids, geo.segment_ids
 
 
 def _raw_curves_geometry(obj):

--- a/drawing/reference_pick.py
+++ b/drawing/reference_pick.py
@@ -15,7 +15,7 @@ Supported sources:
 Legacy ``Curve`` (bezier/nurbs) objects are not handled yet; they return empty.
 """
 
-from mathutils import Vector
+import numpy as np
 
 from ..utilities.curve_data import has_uuid_field
 from . import picking
@@ -29,56 +29,84 @@ def _is_sketch(curve_data) -> bool:
     )
 
 
-def _sketch_geometry(obj):
-    """Pickable points/segments of a sketch, keyed by ``curve_id``.
+def _sketch_geometry(obj) -> picking.PickSet:
+    """Pickable geometry of a sketch, keyed by ``curve_id``.
 
     Reuses the shared, cached extraction, which already projects points and
-    tessellates lines/arcs/circles into ``point_ids`` / ``segment_ids``. Colours
-    are irrelevant here, so this deliberately skips the colour pass -- reference
-    picking walks every visible curve object, so it would pay for it per object.
+    tessellates lines/arcs/circles. Colours are irrelevant here, so this skips the
+    colour pass -- reference picking walks every visible curve object, so it would
+    otherwise pay for it once per object per mouse-move.
     """
     from ..model.sketch_ref import Sketch
     from . import render_data
 
     geo = render_data.geometry(Sketch(obj))
-    return geo.point_ids, geo.segment_ids
+    return picking.PickSet(
+        geo.point_cids, geo.point_co, geo.seg_cids, geo.seg_co, geo.seg_owner
+    )
 
 
-def _raw_curves_geometry(obj):
-    """Pickable points/segments of a raw Curves object, keyed by index.
+def _raw_curves_geometry(obj) -> picking.PickSet:
+    """Pickable geometry of a raw Curves object, keyed by index.
 
     Each control point is a pickable point; each span between consecutive points
     of a curve is a pickable segment. No arc concept exists on a raw Curves
     object, so its curves are treated as polylines.
     """
     data = obj.data
-    mat = obj.matrix_world
-    points, segments = [], []
+    n_points = len(data.points)
+    if n_points == 0:
+        return picking.EMPTY_PICKSET
+
+    local = np.empty(n_points * 3, dtype=np.float32)
+    data.points.foreach_get("position", local)
+    world = _to_world(local.reshape(-1, 3), obj.matrix_world)
+
+    point_keys, seg_keys, spans = [], [], []
     for ci, curve in enumerate(data.curves):
         n = curve.points_length
         if n == 0:
             continue
         first = curve.points[0].index
-        world = [(mat @ Vector(data.points[first + k].position))[:] for k in range(n)]
         for k in range(n):
-            points.append((("point", first + k), world[k]))
+            point_keys.append(("point", first + k))
         for k in range(n - 1):
-            segments.append((("seg", ci, k), world[k], world[k + 1]))
-    return points, segments
+            seg_keys.append(("seg", ci, k))
+            spans.append((first + k, first + k + 1))
+
+    point_co = (
+        world[[i for _t, i in point_keys]]
+        if point_keys
+        else picking.EMPTY_PICKSET.point_co
+    )
+    if spans:
+        idx = np.asarray(spans, dtype=np.intp)
+        seg_co = world[idx.ravel()].reshape(-1, 2, 3)
+        seg_owner = np.arange(len(spans), dtype=np.intp)
+    else:
+        seg_co = picking.EMPTY_PICKSET.seg_co
+        seg_owner = picking.EMPTY_PICKSET.seg_owner
+    return picking.PickSet(point_keys, point_co, seg_keys, seg_co, seg_owner)
 
 
-def extract_pickable_geometry(obj):
-    """Return ``(points, segments)`` of a curve object in world space.
+def _to_world(local, mat):
+    """Transform an ``(N, 3)`` array of local points into world space."""
+    homogeneous = np.empty((len(local), 4), dtype=np.float64)
+    homogeneous[:, :3] = local
+    homogeneous[:, 3] = 1.0
+    world = homogeneous @ np.asarray(mat, dtype=np.float64).T
+    return world[:, :3].astype(np.float32, copy=False)
 
-    ``points``:   ``[(key, world_pos), ...]``
-    ``segments``: ``[(key, world_a, world_b), ...]`` (arcs/circles tessellated)
 
-    ``key`` identifies the source element: a sketch's ``curve_id`` string, or an
+def extract_pickable_geometry(obj) -> picking.PickSet:
+    """Return a curve object's pickable geometry in world space.
+
+    Keys identify the source element: a sketch's ``curve_id`` string, or an
     index-based tuple for a raw Curves object. Non-Curves or legacy ``Curve``
-    objects return empty (legacy bezier/nurbs support is a later slice).
+    objects return an empty set (legacy bezier/nurbs support is a later slice).
     """
     if obj is None or obj.type != "CURVES" or obj.data is None:
-        return [], []
+        return picking.EMPTY_PICKSET
     if _is_sketch(obj.data):
         return _sketch_geometry(obj)
     return _raw_curves_geometry(obj)
@@ -86,8 +114,7 @@ def extract_pickable_geometry(obj):
 
 def pick_object_ranked(obj, context, coords):
     """Keys of ``obj``'s elements under ``coords``, nearest first (points first)."""
-    points, segments = extract_pickable_geometry(obj)
-    return picking.rank_hits(points, segments, context, coords)
+    return picking.rank_hits(extract_pickable_geometry(obj), context, coords)
 
 
 def pick_reference_element(context, coords, exclude=None):
@@ -98,18 +125,34 @@ def pick_reference_element(context, coords, exclude=None):
     ``exclude`` skips an object (e.g. the active sketch, to avoid self-reference).
     """
     objs = {}
-    point_items, seg_items = [], []
+    point_keys, point_co = [], []
+    seg_keys, seg_co, seg_owner = [], [], []
     for ob in context.visible_objects:
         if ob.type != "CURVES" or ob == exclude:
             continue
-        pts, segs = extract_pickable_geometry(ob)
-        if not pts and not segs:
+        pick = extract_pickable_geometry(ob)
+        if not len(pick.point_co) and not len(pick.seg_co):
             continue
         objs[ob.name] = ob
-        point_items += [((ob.name, key), pos) for key, pos in pts]
-        seg_items += [((ob.name, key), a, b) for key, a, b in segs]
+        # Keys are namespaced per object, and the owner indices shift by however
+        # many curves were merged already. Both are per-curve, not per-segment.
+        point_keys += [(ob.name, key) for key in pick.point_keys]
+        point_co.append(pick.point_co)
+        seg_owner.append(pick.seg_owner + len(seg_keys))
+        seg_keys += [(ob.name, key) for key in pick.seg_keys]
+        seg_co.append(pick.seg_co)
 
-    ranked = picking.rank_hits(point_items, seg_items, context, coords)
+    if not objs:
+        return None
+    merged = picking.PickSet(
+        point_keys,
+        np.concatenate(point_co) if point_co else picking.EMPTY_PICKSET.point_co,
+        seg_keys,
+        np.concatenate(seg_co) if seg_co else picking.EMPTY_PICKSET.seg_co,
+        np.concatenate(seg_owner) if seg_owner else picking.EMPTY_PICKSET.seg_owner,
+    )
+
+    ranked = picking.rank_hits(merged, context, coords)
     if not ranked:
         return None
     obj_name, key = ranked[0]
@@ -120,9 +163,15 @@ def element_geometry(obj, key):
     """World-space ``(points, segments)`` of just element ``key`` of ``obj``.
 
     Used to highlight one hovered element: a point returns its position, a line
-    its single segment, an arc/circle its tessellated segments.
+    its single segment, an arc/circle its tessellated segments. Returns plain
+    tuples -- this is one element, and the hover draw code wants sequences.
     """
-    pts, segs = extract_pickable_geometry(obj)
-    points = [pos for k, pos in pts if k == key]
-    segments = [(a, b) for k, a, b in segs if k == key]
+    pick = extract_pickable_geometry(obj)
+    points = [
+        tuple(pick.point_co[i]) for i, k in enumerate(pick.point_keys) if k == key
+    ]
+    segments = []
+    if key in pick.seg_keys:
+        rows = pick.seg_co[pick.seg_owner == pick.seg_keys.index(key)]
+        segments = [(tuple(a), tuple(b)) for a, b in rows]
     return points, segments

--- a/drawing/render_data.py
+++ b/drawing/render_data.py
@@ -2,17 +2,19 @@
 
 Pure data — no GPU calls — so it can be unit-tested headless. Produces:
 
-- ``point_buckets``: ``color -> [(world position, size factor), ...]``
-- ``line_buckets``:  ``(construction, color) -> [segment endpoint, ...]`` (pairs)
-- ``point_ids`` / ``segment_ids``: the ``curve_id`` behind each point / segment,
-  kept for CPU picking (phase 2); unused by the overlay itself.
+- ``point_buckets``: ``color -> (centres (K, 3), size factors (K,))``
+- ``line_buckets``:  ``(construction, color) -> [(M, 2, 3) chunk, ...]``
+
+Coordinates stay in numpy from tessellation all the way to ``batch_for_shader``
+and to the picker's projection, which both take arrays directly. Materialising
+them as Python tuples in between was the bulk of the extraction cost once the
+tessellation itself was vectorized (issue #342).
 
 ``overlay_signature`` is a cheap hash of everything that affects the drawing, so
 the overlay can skip rebuilding batches when nothing changed.
 """
 
 import math
-from itertools import chain, repeat
 
 import numpy as np
 from mathutils import Vector
@@ -198,35 +200,23 @@ def _tessellate_arcs(params, cyclic, mat):
     return pairs, nseg
 
 
-def _emit_arcs(geo, params, cyclic, meta, mat):
-    """Tessellate the collected arcs/circles and append them to ``geo``."""
+def _emit_arcs(geo_parts, params, cyclic, meta, mat):
+    """Tessellate the collected arcs/circles into ``geo_parts``' array lists."""
     if not params:
         return
     pairs, nseg = _tessellate_arcs(params, cyclic, mat)
+    geo_parts["seg_co"].append(pairs.astype(np.float32, copy=False))
+    geo_parts["seg_counts"].append(nseg)
+    for cid, construction, fixed in meta:
+        geo_parts["seg_cids"].append(cid)
+        geo_parts["seg_construction"].append(construction)
+        geo_parts["seg_fixed"].append(fixed)
 
-    # One trip out of numpy, flattened to bare endpoints: the very same vertex
-    # lists are sliced into the colour buckets and referenced by ``segment_ids``,
-    # so each vertex is allocated once. Keeping the (S, 2, 3) nesting would
-    # allocate a wrapper list per segment on top of that, which at a few thousand
-    # segments costs more than the tessellation itself.
-    verts = pairs.reshape(-1, 3).tolist()
-    counts = nseg.tolist()
 
-    offset = len(geo.seg_verts)
-    geo.seg_verts.extend(verts)
-    for idx, (cid, construction, fixed) in enumerate(meta):
-        width = counts[idx] * 2
-        geo.seg_ranges.append((cid, construction, fixed, offset, offset + width))
-        offset += width
-
-    # ``segment_ids`` keeps picking's (curve_id, a, b) shape; repeat/chain expands
-    # the per-arc ids without indexing ``meta`` once per segment.
-    cids = chain.from_iterable(
-        repeat(cid, counts[idx]) for idx, (cid, _c, _f) in enumerate(meta)
-    )
-    geo.segment_ids.extend(
-        (cid, verts[i * 2], verts[i * 2 + 1]) for i, cid in enumerate(cids)
-    )
+_EMPTY_CO = np.zeros((0, 3), dtype=np.float32)
+_EMPTY_SEG = np.zeros((0, 2, 3), dtype=np.float32)
+_EMPTY_BOOL = np.zeros(0, dtype=bool)
+_EMPTY_IDX = np.zeros(0, dtype=np.intp)
 
 
 class SketchGeometry:
@@ -237,31 +227,48 @@ class SketchGeometry:
     ``colorize`` has to rerun when the selection changes, which is what lets the
     overlay and the picker share one extraction instead of building their own.
 
-    ``seg_ranges`` carries ``(curve_id, construction, fixed, lo, hi)`` per segment
-    curve, where ``lo``/``hi`` bound that curve's vertices in ``seg_verts``. Curves
-    stay in order, so neighbouring curves of one colour merge into a single slice.
+    Coordinates are numpy arrays, not Python tuples: the GPU batches and the
+    picker's screen projection both consume arrays, so materialising tuples here
+    only to rebuild arrays downstream was the bulk of the extraction cost.
+
+    Segments are grouped by curve: curve ``c`` owns rows
+    ``seg_offsets[c]:seg_offsets[c + 1]`` of ``seg_co``, and ``seg_owner`` maps a
+    row back to ``c``. Keeping identity per *curve* rather than per *segment* is
+    what removes the one-string-per-segment bookkeeping (a circle has 48).
     """
 
-    __slots__ = ("point_entries", "point_ids", "seg_verts", "seg_ranges", "segment_ids")
+    __slots__ = (
+        "point_cids",
+        "point_co",
+        "point_fixed",
+        "seg_cids",
+        "seg_construction",
+        "seg_fixed",
+        "seg_offsets",
+        "seg_co",
+        "seg_owner",
+    )
 
     def __init__(self):
-        self.point_entries = []  # [(curve_id, pos, fixed), ...]
-        self.point_ids = []  # [(curve_id, pos), ...]  (for picking)
-        self.seg_verts = []  # flat LINES endpoints, 2 per segment
-        self.seg_ranges = []  # [(curve_id, construction, fixed, lo, hi), ...]
-        self.segment_ids = []  # [(curve_id, p0, p1), ...] (for picking)
+        self.point_cids = []  # [curve_id, ...] one per point curve
+        self.point_co = _EMPTY_CO  # (P, 3) float32 world positions
+        self.point_fixed = _EMPTY_BOOL  # (P,) bool
+        self.seg_cids = []  # [curve_id, ...] one per segment curve
+        self.seg_construction = _EMPTY_BOOL  # (C,) bool
+        self.seg_fixed = _EMPTY_BOOL  # (C,) bool
+        self.seg_offsets = _EMPTY_IDX  # (C + 1,) row bounds into seg_co
+        self.seg_co = _EMPTY_SEG  # (M, 2, 3) float32 world endpoints
+        self.seg_owner = _EMPTY_IDX  # (M,) -> index into seg_cids
 
 
 class SketchRenderData:
     """Draw buckets extracted from one sketch's curve data."""
 
-    __slots__ = ("point_buckets", "line_buckets", "point_ids", "segment_ids")
+    __slots__ = ("point_buckets", "line_buckets")
 
     def __init__(self):
-        self.point_buckets = {}  # color(tuple) -> [(pos, size_factor), ...]
-        self.line_buckets = {}  # (construction, color) -> [pos, pos, ...]
-        self.point_ids = []  # [(curve_id, pos), ...]  (for picking)
-        self.segment_ids = []  # [(curve_id, p0, p1), ...] (for picking)
+        self.point_buckets = {}  # color -> (centres (K, 3), size factors (K,))
+        self.line_buckets = {}  # (construction, color) -> [(M, 2, 3) chunk, ...]
 
 
 # obj name -> (geometry_signature, SketchGeometry). Shared by the overlay and by
@@ -305,47 +312,70 @@ def geometry(sketch) -> SketchGeometry:
     return geo
 
 
+def _state_flags(cids, selected_set, hover, highlighted):
+    """Per-curve ``(selected, hovered)`` flags for a list of curve ids."""
+    sel = [cid in selected_set for cid in cids]
+    hov = [cid == hover or cid in highlighted for cid in cids]
+    return sel, hov
+
+
 def colorize(geo: SketchGeometry, ts, is_active: bool) -> SketchRenderData:
     """Assign theme colours to a cached extraction and bucket it for drawing.
 
     The only part that depends on selection/hover/theme, so it is all that reruns
-    on a mouse-move over unchanged geometry. Vertex lists are shared with ``geo``
-    rather than copied -- nothing mutates them.
+    on a mouse-move over unchanged geometry. Buckets are views into ``geo``'s
+    arrays rather than copies -- nothing mutates them.
     """
     rd = SketchRenderData()
-    rd.point_ids = geo.point_ids
-    rd.segment_ids = geo.segment_ids
 
     # Selection/hover are transient runtime state (not persisted attributes).
     selected_set = set(selection.selected)
     hover = selection.hover
     highlighted = set(selection.highlight_curve_ids)
 
-    for cid, pos, fixed in geo.point_entries:
-        is_sel = cid in selected_set
-        is_hov = cid == hover or cid in highlighted
-        col = curve_color(ts, is_sel, is_hov, fixed, active=is_active)
-        psize = POINT_SIZE_SELECTED if is_sel else (POINT_SIZE_HOVER if is_hov else 1.0)
-        rd.point_buckets.setdefault(tuple(col), []).append((pos, psize))
+    if geo.point_cids:
+        sel, hov = _state_flags(geo.point_cids, selected_set, hover, highlighted)
+        fixed = geo.point_fixed
+        by_color = {}
+        for i in range(len(geo.point_cids)):
+            col = curve_color(ts, sel[i], hov[i], bool(fixed[i]), active=is_active)
+            psize = (
+                POINT_SIZE_SELECTED if sel[i] else (POINT_SIZE_HOVER if hov[i] else 1.0)
+            )
+            by_color.setdefault(tuple(col), ([], []))
+            rows, sizes = by_color[tuple(col)]
+            rows.append(i)
+            sizes.append(psize)
+        for col, (rows, sizes) in by_color.items():
+            rd.point_buckets[col] = (
+                geo.point_co[rows],
+                np.asarray(sizes, dtype=np.float32),
+            )
 
-    # Merge runs of consecutive curves that land in the same bucket into one slice
-    # copy. With nothing selected the whole sketch is one run, so this is a single
-    # extend instead of one per curve.
-    key = None
-    run_lo = run_hi = 0
-    for cid, construction, fixed, lo, hi in geo.seg_ranges:
-        is_sel = cid in selected_set
-        is_hov = cid == hover or cid in highlighted
-        col = curve_color(ts, is_sel, is_hov, fixed, active=is_active)
-        entry = (construction, tuple(col))
-        if entry == key and lo == run_hi:
-            run_hi = hi
-            continue
+    if geo.seg_cids:
+        sel, hov = _state_flags(geo.seg_cids, selected_set, hover, highlighted)
+        con = geo.seg_construction
+        fixed = geo.seg_fixed
+        offsets = geo.seg_offsets
+        # Merge runs of consecutive curves that land in the same bucket into one
+        # slice. With nothing selected the whole sketch is one run, so a bucket
+        # holds a single view over the full array.
+        key = None
+        run_start = 0
+        for c in range(len(geo.seg_cids)):
+            col = curve_color(ts, sel[c], hov[c], bool(fixed[c]), active=is_active)
+            entry = (bool(con[c]), tuple(col))
+            if entry == key:
+                continue
+            if key is not None:
+                rd.line_buckets.setdefault(key, []).append(
+                    geo.seg_co[offsets[run_start] : offsets[c]]
+                )
+            key, run_start = entry, c
         if key is not None:
-            rd.line_buckets.setdefault(key, []).extend(geo.seg_verts[run_lo:run_hi])
-        key, run_lo, run_hi = entry, lo, hi
-    if key is not None:
-        rd.line_buckets.setdefault(key, []).extend(geo.seg_verts[run_lo:run_hi])
+            rd.line_buckets.setdefault(key, []).append(
+                geo.seg_co[offsets[run_start] : offsets[-1]]
+            )
 
     return rd
 
@@ -391,8 +421,17 @@ def _extract_geometry(sketch) -> SketchGeometry:
         sp_ids = read_uuid_list(cd, "start_point_id")
         ep_ids = read_uuid_list(cd, "end_point_id")
 
-    # Arcs/circles are only *measured* in the loop; they are tessellated together
-    # afterwards, which is far cheaper than one Python loop per arc.
+    point_rows, point_fixed = [], []
+    # Lines contribute one segment each and are collected locally; arcs are only
+    # *measured* here and tessellated together afterwards.
+    parts = {
+        "seg_co": [],
+        "seg_counts": [],
+        "seg_cids": [],
+        "seg_construction": [],
+        "seg_fixed": [],
+    }
+    line_co = []
     arc_params, arc_cyclic, arc_meta = [], [], []
 
     for i in range(n_curves):
@@ -403,18 +442,18 @@ def _extract_geometry(sketch) -> SketchGeometry:
         curve_slice = cd.curves[i]
 
         if ctype == SketchCurveType.POINT:
-            pos = (mat @ Vector(cd.points[curve_slice.points[0].index].position))[:]
-            geo.point_entries.append((cid, pos, bool(fix[i])))
-            geo.point_ids.append((cid, pos))
+            geo.point_cids.append(cid)
+            point_rows.append(cd.points[curve_slice.points[0].index].position[:])
+            point_fixed.append(bool(fix[i]))
 
         elif ctype == SketchCurveType.LINE and curve_slice.points_length >= 2:
             first = curve_slice.points[0].index
-            p1 = (mat @ Vector(cd.points[first].position))[:]
-            p2 = (mat @ Vector(cd.points[first + 1].position))[:]
-            lo = len(geo.seg_verts)
-            geo.seg_verts += [p1, p2]
-            geo.seg_ranges.append((cid, bool(con[i]), bool(fix[i]), lo, lo + 2))
-            geo.segment_ids.append((cid, p1, p2))
+            line_co.append(
+                (cd.points[first].position[:], cd.points[first + 1].position[:])
+            )
+            parts["seg_cids"].append(cid)
+            parts["seg_construction"].append(bool(con[i]))
+            parts["seg_fixed"].append(bool(fix[i]))
 
         elif ctype in (SketchCurveType.ARC, SketchCurveType.CIRCLE) and has_arcs:
             params = _arc_params(
@@ -425,8 +464,38 @@ def _extract_geometry(sketch) -> SketchGeometry:
                 arc_cyclic.append(bool(cyc[i]))
                 arc_meta.append((cid, bool(con[i]), bool(fix[i])))
 
-    _emit_arcs(geo, arc_params, arc_cyclic, arc_meta, mat)
+    # Lines first (one segment each), then the tessellated arcs, so each curve
+    # still owns a contiguous run of rows.
+    if line_co:
+        parts["seg_co"].insert(0, _to_world(np.asarray(line_co, dtype=np.float64), mat))
+        parts["seg_counts"].insert(0, np.ones(len(line_co), dtype=np.intp))
+    _emit_arcs(parts, arc_params, arc_cyclic, arc_meta, mat)
+
+    if point_rows:
+        geo.point_co = _to_world(np.asarray(point_rows, dtype=np.float64), mat)
+        geo.point_fixed = np.asarray(point_fixed, dtype=bool)
+
+    if parts["seg_cids"]:
+        geo.seg_cids = parts["seg_cids"]
+        geo.seg_construction = np.asarray(parts["seg_construction"], dtype=bool)
+        geo.seg_fixed = np.asarray(parts["seg_fixed"], dtype=bool)
+        geo.seg_co = np.concatenate(parts["seg_co"])
+        counts = np.concatenate(parts["seg_counts"])
+        geo.seg_offsets = np.concatenate(([0], np.cumsum(counts))).astype(np.intp)
+        geo.seg_owner = np.repeat(np.arange(len(counts), dtype=np.intp), counts)
+
     return geo
+
+
+def _to_world(local, mat):
+    """Transform an ``(..., 3)`` array of sketch-local points into world space."""
+    shape = local.shape
+    flat = local.reshape(-1, 3)
+    homogeneous = np.empty((len(flat), 4), dtype=np.float64)
+    homogeneous[:, :3] = flat
+    homogeneous[:, 3] = 1.0
+    world = homogeneous @ np.asarray(mat, dtype=np.float64).T
+    return world[:, :3].reshape(shape).astype(np.float32, copy=False)
 
 
 def _arc_params(sketch, cd, curve_idx, curve_slice, is_cyclic, cp_ids, sp_ids, ep_ids):

--- a/drawing/render_data.py
+++ b/drawing/render_data.py
@@ -198,53 +198,58 @@ def _tessellate_arcs(params, cyclic, mat):
     return pairs, nseg
 
 
-def _contiguous_runs(arcs, offsets, counts):
-    """Merge ascending arc indices into ``(lo, hi)`` segment index bounds."""
-    runs = []
-    start = 0
-    while start < len(arcs):
-        end = start
-        while end + 1 < len(arcs) and arcs[end + 1] == arcs[end] + 1:
-            end += 1
-        runs.append((offsets[arcs[start]], offsets[arcs[end]] + counts[arcs[end]]))
-        start = end + 1
-    return runs
-
-
-def _emit_arcs(rd, params, cyclic, meta, mat):
-    """Tessellate the collected arcs/circles and file them into ``rd``."""
+def _emit_arcs(geo, params, cyclic, meta, mat):
+    """Tessellate the collected arcs/circles and append them to ``geo``."""
     if not params:
         return
     pairs, nseg = _tessellate_arcs(params, cyclic, mat)
 
     # One trip out of numpy, flattened to bare endpoints: the very same vertex
-    # lists land in ``line_buckets`` and in ``segment_ids``, so each vertex is
-    # allocated once. Keeping the (S, 2, 3) nesting here would allocate a wrapper
-    # list per segment on top of that, which at a few thousand segments costs
-    # more than the tessellation itself.
+    # lists are sliced into the colour buckets and referenced by ``segment_ids``,
+    # so each vertex is allocated once. Keeping the (S, 2, 3) nesting would
+    # allocate a wrapper list per segment on top of that, which at a few thousand
+    # segments costs more than the tessellation itself.
     verts = pairs.reshape(-1, 3).tolist()
     counts = nseg.tolist()
-    offsets = np.concatenate(([0], np.cumsum(nseg)[:-1])).tolist()
 
-    by_bucket = {}
-    for idx, (_cid, construction, col) in enumerate(meta):
-        by_bucket.setdefault((construction, tuple(col)), []).append(idx)
-    for key, arcs in by_bucket.items():
-        bucket = rd.line_buckets.setdefault(key, [])
-        # Each arc owns a contiguous run of segments and ``arcs`` is ascending, so
-        # neighbouring arcs in one bucket merge into a single slice. With nothing
-        # selected every arc shares a bucket, making this one extend.
-        for lo, hi in _contiguous_runs(arcs, offsets, counts):
-            bucket.extend(verts[lo * 2 : hi * 2])
+    offset = len(geo.seg_verts)
+    geo.seg_verts.extend(verts)
+    for idx, (cid, construction, fixed) in enumerate(meta):
+        width = counts[idx] * 2
+        geo.seg_ranges.append((cid, construction, fixed, offset, offset + width))
+        offset += width
 
     # ``segment_ids`` keeps picking's (curve_id, a, b) shape; repeat/chain expands
     # the per-arc ids without indexing ``meta`` once per segment.
     cids = chain.from_iterable(
-        repeat(cid, counts[idx]) for idx, (cid, _c, _col) in enumerate(meta)
+        repeat(cid, counts[idx]) for idx, (cid, _c, _f) in enumerate(meta)
     )
-    rd.segment_ids.extend(
+    geo.segment_ids.extend(
         (cid, verts[i * 2], verts[i * 2 + 1]) for i, cid in enumerate(cids)
     )
+
+
+class SketchGeometry:
+    """A sketch's renderable geometry, independent of selection and theme.
+
+    Everything here is a function of the curve data alone, so it survives hover
+    and selection changes and is cached against ``geometry_signature``. Only
+    ``colorize`` has to rerun when the selection changes, which is what lets the
+    overlay and the picker share one extraction instead of building their own.
+
+    ``seg_ranges`` carries ``(curve_id, construction, fixed, lo, hi)`` per segment
+    curve, where ``lo``/``hi`` bound that curve's vertices in ``seg_verts``. Curves
+    stay in order, so neighbouring curves of one colour merge into a single slice.
+    """
+
+    __slots__ = ("point_entries", "point_ids", "seg_verts", "seg_ranges", "segment_ids")
+
+    def __init__(self):
+        self.point_entries = []  # [(curve_id, pos, fixed), ...]
+        self.point_ids = []  # [(curve_id, pos), ...]  (for picking)
+        self.seg_verts = []  # flat LINES endpoints, 2 per segment
+        self.seg_ranges = []  # [(curve_id, construction, fixed, lo, hi), ...]
+        self.segment_ids = []  # [(curve_id, p0, p1), ...] (for picking)
 
 
 class SketchRenderData:
@@ -258,21 +263,109 @@ class SketchRenderData:
         self.point_ids = []  # [(curve_id, pos), ...]  (for picking)
         self.segment_ids = []  # [(curve_id, p0, p1), ...] (for picking)
 
-    def _line_bucket(self, construction, col):
-        return self.line_buckets.setdefault((construction, tuple(col)), [])
+
+# obj name -> (geometry_signature, SketchGeometry). Shared by the overlay and by
+# picking: both used to run their own extraction, so every frame in which the
+# geometry changed paid for it twice (issue #342).
+_geometry_cache = {}
+
+# Cache entries are keyed by object name, so a renamed or deleted sketch leaves
+# one behind. Prune against the real datablocks once the cache grows past this.
+_CACHE_PRUNE_AT = 64
 
 
-def build(sketch, ts, is_active):
-    """Extract ``SketchRenderData`` for one sketch (no GPU work)."""
+def invalidate():
+    """Drop the shared geometry cache (file load, unregister, theme reload)."""
+    _geometry_cache.clear()
+
+
+def _prune_cache():
+    import bpy
+
+    for name in [n for n in _geometry_cache if n not in bpy.data.objects]:
+        del _geometry_cache[name]
+
+
+def geometry(sketch) -> SketchGeometry:
+    """Cached, selection-independent extraction for one sketch."""
+    obj = sketch.target_object
+    if obj is None:
+        return SketchGeometry()
+
+    name = obj.name
+    sig = geometry_signature(sketch)
+    cached = _geometry_cache.get(name)
+    if cached is not None and cached[0] == sig:
+        return cached[1]
+
+    if len(_geometry_cache) >= _CACHE_PRUNE_AT:
+        _prune_cache()
+    geo = _extract_geometry(sketch)
+    _geometry_cache[name] = (sig, geo)
+    return geo
+
+
+def colorize(geo: SketchGeometry, ts, is_active: bool) -> SketchRenderData:
+    """Assign theme colours to a cached extraction and bucket it for drawing.
+
+    The only part that depends on selection/hover/theme, so it is all that reruns
+    on a mouse-move over unchanged geometry. Vertex lists are shared with ``geo``
+    rather than copied -- nothing mutates them.
+    """
     rd = SketchRenderData()
+    rd.point_ids = geo.point_ids
+    rd.segment_ids = geo.segment_ids
+
+    # Selection/hover are transient runtime state (not persisted attributes).
+    selected_set = set(selection.selected)
+    hover = selection.hover
+    highlighted = set(selection.highlight_curve_ids)
+
+    for cid, pos, fixed in geo.point_entries:
+        is_sel = cid in selected_set
+        is_hov = cid == hover or cid in highlighted
+        col = curve_color(ts, is_sel, is_hov, fixed, active=is_active)
+        psize = POINT_SIZE_SELECTED if is_sel else (POINT_SIZE_HOVER if is_hov else 1.0)
+        rd.point_buckets.setdefault(tuple(col), []).append((pos, psize))
+
+    # Merge runs of consecutive curves that land in the same bucket into one slice
+    # copy. With nothing selected the whole sketch is one run, so this is a single
+    # extend instead of one per curve.
+    key = None
+    run_lo = run_hi = 0
+    for cid, construction, fixed, lo, hi in geo.seg_ranges:
+        is_sel = cid in selected_set
+        is_hov = cid == hover or cid in highlighted
+        col = curve_color(ts, is_sel, is_hov, fixed, active=is_active)
+        entry = (construction, tuple(col))
+        if entry == key and lo == run_hi:
+            run_hi = hi
+            continue
+        if key is not None:
+            rd.line_buckets.setdefault(key, []).extend(geo.seg_verts[run_lo:run_hi])
+        key, run_lo, run_hi = entry, lo, hi
+    if key is not None:
+        rd.line_buckets.setdefault(key, []).extend(geo.seg_verts[run_lo:run_hi])
+
+    return rd
+
+
+def build(sketch, ts, is_active) -> SketchRenderData:
+    """Extract ``SketchRenderData`` for one sketch (no GPU work)."""
+    return colorize(geometry(sketch), ts, is_active)
+
+
+def _extract_geometry(sketch) -> SketchGeometry:
+    """Pull a sketch's curve data into a ``SketchGeometry`` (no colour work)."""
+    geo = SketchGeometry()
     cd = sketch.data
     n_curves = len(cd.curves)
     if n_curves == 0:
-        return rd
+        return geo
 
     type_attr = cd.attributes.get("sketch_type")
     if type_attr is None or not has_uuid_field(cd, "curve_id"):
-        return rd
+        return geo
 
     con = _bulk_bool(cd.attributes.get("construction"), n_curves)
     fix = _bulk_bool(cd.attributes.get("fixed"), n_curves)
@@ -284,11 +377,6 @@ def build(sketch, ts, is_active):
     cyc = _bulk_bool(cd.attributes.get("cyclic"), n_curves)
     types = _bulk_int(type_attr, n_curves)
     cids = read_curve_id_list(cd)
-
-    # Selection/hover are transient runtime state (not persisted attributes).
-    selected_set = set(selection.selected)
-    hover = selection.hover
-    highlighted = set(selection.highlight_curve_ids)
 
     mat = _world_matrix(sketch)
     cp_present = has_uuid_field(cd, "center_point_id")
@@ -312,26 +400,21 @@ def build(sketch, ts, is_active):
             continue
         ctype = types[i]
         cid = cids[i]
-        is_sel = cid in selected_set
-        is_hov = cid == hover or cid in highlighted
-        col = curve_color(ts, is_sel, is_hov, bool(fix[i]), active=is_active)
         curve_slice = cd.curves[i]
 
         if ctype == SketchCurveType.POINT:
             pos = (mat @ Vector(cd.points[curve_slice.points[0].index].position))[:]
-            psize = (
-                POINT_SIZE_SELECTED if is_sel else (POINT_SIZE_HOVER if is_hov else 1.0)
-            )
-            rd.point_buckets.setdefault(tuple(col), []).append((pos, psize))
-            rd.point_ids.append((cid, pos))
+            geo.point_entries.append((cid, pos, bool(fix[i])))
+            geo.point_ids.append((cid, pos))
 
         elif ctype == SketchCurveType.LINE and curve_slice.points_length >= 2:
             first = curve_slice.points[0].index
             p1 = (mat @ Vector(cd.points[first].position))[:]
             p2 = (mat @ Vector(cd.points[first + 1].position))[:]
-            bucket = rd._line_bucket(bool(con[i]), col)
-            bucket += [p1, p2]
-            rd.segment_ids.append((cid, p1, p2))
+            lo = len(geo.seg_verts)
+            geo.seg_verts += [p1, p2]
+            geo.seg_ranges.append((cid, bool(con[i]), bool(fix[i]), lo, lo + 2))
+            geo.segment_ids.append((cid, p1, p2))
 
         elif ctype in (SketchCurveType.ARC, SketchCurveType.CIRCLE) and has_arcs:
             params = _arc_params(
@@ -340,10 +423,10 @@ def build(sketch, ts, is_active):
             if params is not None:
                 arc_params.append(params)
                 arc_cyclic.append(bool(cyc[i]))
-                arc_meta.append((cid, bool(con[i]), col))
+                arc_meta.append((cid, bool(con[i]), bool(fix[i])))
 
-    _emit_arcs(rd, arc_params, arc_cyclic, arc_meta, mat)
-    return rd
+    _emit_arcs(geo, arc_params, arc_cyclic, arc_meta, mat)
+    return geo
 
 
 def _arc_params(sketch, cd, curve_idx, curve_slice, is_cyclic, cp_ids, sp_ids, ep_ids):

--- a/drawing/render_data.py
+++ b/drawing/render_data.py
@@ -12,6 +12,7 @@ the overlay can skip rebuilding batches when nothing changed.
 """
 
 import math
+from itertools import chain, repeat
 
 import numpy as np
 from mathutils import Vector
@@ -19,9 +20,9 @@ from mathutils import Vector
 from ..model.constants import SketchCurveType
 from ..utilities.curve_data import (
     get_curve_data,
-    get_uuid,
     has_uuid_field,
     read_curve_id_list,
+    read_uuid_list,
 )
 from ..utilities.math import range_2pi
 from . import selection
@@ -143,23 +144,107 @@ def overlay_signature(sketch, is_active, theme_sig):
     )
 
 
-def _arc_points(center, radius, start_angle, arc_angle, segments, mat):
-    pts = []
-    for i in range(segments + 1):
-        a = start_angle + arc_angle * i / segments
-        pts.append(
-            (
-                mat
-                @ Vector(
-                    (
-                        center.x + radius * math.cos(a),
-                        center.y + radius * math.sin(a),
-                        0,
-                    )
-                )
-            )[:]
-        )
-    return pts
+def _tessellate_arcs(params, cyclic, mat):
+    """World-space segment endpoints for *every* arc/circle, in one vectorized pass.
+
+    ``params`` holds one ``_arc_params`` tuple per curve and ``cyclic`` the
+    matching flags. Returns ``(pairs, nseg)``: an ``(S, 2, 3)`` array of
+    per-segment endpoints, and how many of those segments each arc owns. Segments
+    stay grouped by arc, so arc ``a`` owns one contiguous slice of ``pairs``.
+
+    Tessellating arc by arc was the single biggest cost in ``build`` -- a Python
+    loop doing one ``mat @ Vector(...)`` per point, ~58% of the call on a
+    circle-heavy sketch. Vectorizing one arc at a time is *slower* (49 points is
+    too few to amortize the numpy setup), so all arcs are flattened into one
+    angle array and transformed with a single matmul instead.
+
+    A cyclic curve emits ``segments`` points over ``[0, tau)`` and wraps, so a
+    circle yields exactly ``ARC_SEGMENTS`` segments; the per-arc version closed
+    the loop with a duplicate point and a zero-length segment.
+    """
+    n = len(params)
+    p = np.asarray(params, dtype=np.float64)  # (n, 6)
+    cx, cy, radius, start, sweep = (p[:, k] for k in range(5))
+    nseg = p[:, 5].astype(np.intp)
+    cyc = np.asarray(cyclic, dtype=bool)
+
+    # An open arc needs its closing point; a cyclic one wraps to its first.
+    npts = nseg + ~cyc
+    pt_off = np.concatenate(([0], np.cumsum(npts)[:-1]))
+
+    # Flatten every arc's points into one angle array: which arc each point
+    # belongs to (pt_arc) and its position within that arc (pt_j).
+    pt_arc = np.repeat(np.arange(n), npts)
+    pt_j = np.arange(npts.sum()) - np.repeat(pt_off, npts)
+    ang = start[pt_arc] + sweep[pt_arc] * pt_j / nseg[pt_arc]
+
+    local = np.empty((len(pt_arc), 4))
+    local[:, 0] = cx[pt_arc] + radius[pt_arc] * np.cos(ang)
+    local[:, 1] = cy[pt_arc] + radius[pt_arc] * np.sin(ang)
+    local[:, 2] = 0.0
+    local[:, 3] = 1.0
+    world = local @ np.asarray(mat, dtype=np.float64).T
+
+    # Segments join consecutive points, wrapping to the first on a cyclic curve.
+    seg_arc = np.repeat(np.arange(n), nseg)
+    seg_off = np.concatenate(([0], np.cumsum(nseg)[:-1]))
+    seg_j = np.arange(nseg.sum()) - np.repeat(seg_off, nseg)
+    i0 = np.repeat(pt_off, nseg) + seg_j
+    i1 = i0 + 1
+    wrap = cyc[seg_arc] & (seg_j == nseg[seg_arc] - 1)
+    i1[wrap] = np.repeat(pt_off, nseg)[wrap]
+
+    pairs = world[np.stack((i0, i1), axis=1).ravel(), :3].reshape(-1, 2, 3)
+    return pairs, nseg
+
+
+def _contiguous_runs(arcs, offsets, counts):
+    """Merge ascending arc indices into ``(lo, hi)`` segment index bounds."""
+    runs = []
+    start = 0
+    while start < len(arcs):
+        end = start
+        while end + 1 < len(arcs) and arcs[end + 1] == arcs[end] + 1:
+            end += 1
+        runs.append((offsets[arcs[start]], offsets[arcs[end]] + counts[arcs[end]]))
+        start = end + 1
+    return runs
+
+
+def _emit_arcs(rd, params, cyclic, meta, mat):
+    """Tessellate the collected arcs/circles and file them into ``rd``."""
+    if not params:
+        return
+    pairs, nseg = _tessellate_arcs(params, cyclic, mat)
+
+    # One trip out of numpy, flattened to bare endpoints: the very same vertex
+    # lists land in ``line_buckets`` and in ``segment_ids``, so each vertex is
+    # allocated once. Keeping the (S, 2, 3) nesting here would allocate a wrapper
+    # list per segment on top of that, which at a few thousand segments costs
+    # more than the tessellation itself.
+    verts = pairs.reshape(-1, 3).tolist()
+    counts = nseg.tolist()
+    offsets = np.concatenate(([0], np.cumsum(nseg)[:-1])).tolist()
+
+    by_bucket = {}
+    for idx, (_cid, construction, col) in enumerate(meta):
+        by_bucket.setdefault((construction, tuple(col)), []).append(idx)
+    for key, arcs in by_bucket.items():
+        bucket = rd.line_buckets.setdefault(key, [])
+        # Each arc owns a contiguous run of segments and ``arcs`` is ascending, so
+        # neighbouring arcs in one bucket merge into a single slice. With nothing
+        # selected every arc shares a bucket, making this one extend.
+        for lo, hi in _contiguous_runs(arcs, offsets, counts):
+            bucket.extend(verts[lo * 2 : hi * 2])
+
+    # ``segment_ids`` keeps picking's (curve_id, a, b) shape; repeat/chain expands
+    # the per-arc ids without indexing ``meta`` once per segment.
+    cids = chain.from_iterable(
+        repeat(cid, counts[idx]) for idx, (cid, _c, _col) in enumerate(meta)
+    )
+    rd.segment_ids.extend(
+        (cid, verts[i * 2], verts[i * 2 + 1]) for i, cid in enumerate(cids)
+    )
 
 
 class SketchRenderData:
@@ -208,6 +293,20 @@ def build(sketch, ts, is_active):
     mat = _world_matrix(sketch)
     cp_present = has_uuid_field(cd, "center_point_id")
 
+    # Endpoint ids come from the cached bulk lists, not a per-curve get_uuid
+    # (2 attribute lookups plus a hex conversion each) inside the loop.
+    has_arcs = cp_present and bool(
+        np.isin(types, (SketchCurveType.ARC, SketchCurveType.CIRCLE)).any()
+    )
+    if has_arcs:
+        cp_ids = read_uuid_list(cd, "center_point_id")
+        sp_ids = read_uuid_list(cd, "start_point_id")
+        ep_ids = read_uuid_list(cd, "end_point_id")
+
+    # Arcs/circles are only *measured* in the loop; they are tessellated together
+    # afterwards, which is far cheaper than one Python loop per arc.
+    arc_params, arc_cyclic, arc_meta = [], [], []
+
     for i in range(n_curves):
         if not vis[i]:
             continue
@@ -234,36 +333,36 @@ def build(sketch, ts, is_active):
             bucket += [p1, p2]
             rd.segment_ids.append((cid, p1, p2))
 
-        elif ctype in (SketchCurveType.ARC, SketchCurveType.CIRCLE) and cp_present:
-            arc_pts = _arc_points_for_curve(
-                sketch, cd, i, curve_slice, bool(cyc[i]), mat
+        elif ctype in (SketchCurveType.ARC, SketchCurveType.CIRCLE) and has_arcs:
+            params = _arc_params(
+                sketch, cd, i, curve_slice, bool(cyc[i]), cp_ids, sp_ids, ep_ids
             )
-            if arc_pts and len(arc_pts) >= 2:
-                bucket = rd._line_bucket(bool(con[i]), col)
-                for j in range(len(arc_pts) - 1):
-                    bucket += [arc_pts[j], arc_pts[j + 1]]
-                    rd.segment_ids.append((cid, arc_pts[j], arc_pts[j + 1]))
-                if cyc[i]:
-                    bucket += [arc_pts[-1], arc_pts[0]]
-                    rd.segment_ids.append((cid, arc_pts[-1], arc_pts[0]))
+            if params is not None:
+                arc_params.append(params)
+                arc_cyclic.append(bool(cyc[i]))
+                arc_meta.append((cid, bool(con[i]), col))
 
+    _emit_arcs(rd, arc_params, arc_cyclic, arc_meta, mat)
     return rd
 
 
-def _arc_points_for_curve(sketch, cd, curve_idx, curve_slice, is_cyclic, mat):
-    cp_cid = get_uuid(cd, "center_point_id", curve_idx)
-    _, _, cp_slice = get_curve_data(sketch, cp_cid)
+def _arc_params(sketch, cd, curve_idx, curve_slice, is_cyclic, cp_ids, sp_ids, ep_ids):
+    """Measure one arc/circle, or ``None`` when its defining points are missing.
+
+    Returns ``(center_x, center_y, radius, start_angle, sweep, segments)`` in the
+    sketch's local 2D frame. Only the measuring happens per curve; the points
+    themselves come from ``_tessellate_arcs``, which does every arc at once.
+    """
+    _, _, cp_slice = get_curve_data(sketch, cp_ids[curve_idx])
     if not cp_slice:
         return None
     center = Vector(cd.points[cp_slice.points[0].index].position[:2])
 
     if is_cyclic:
         edge = Vector(cd.points[curve_slice.points[0].index].position[:2])
-        radius = (edge - center).length
-        return _arc_points(center, radius, 0, math.tau, ARC_SEGMENTS, mat)
+        return (center.x, center.y, (edge - center).length, 0.0, math.tau, ARC_SEGMENTS)
 
-    sp_cid = get_uuid(cd, "start_point_id", curve_idx)
-    ep_cid = get_uuid(cd, "end_point_id", curve_idx)
+    sp_cid, ep_cid = sp_ids[curve_idx], ep_ids[curve_idx]
     _, _, s_slice = get_curve_data(sketch, sp_cid) if sp_cid else (None, None, None)
     _, _, e_slice = get_curve_data(sketch, ep_cid) if ep_cid else (None, None, None)
     if not (s_slice and e_slice):
@@ -271,8 +370,7 @@ def _arc_points_for_curve(sketch, cd, curve_idx, curve_slice, is_cyclic, mat):
 
     start = Vector(cd.points[s_slice.points[0].index].position[:2])
     end = Vector(cd.points[e_slice.points[0].index].position[:2])
-    radius = (start - center).length
     s_angle = math.atan2((start - center).y, (start - center).x)
     arc_angle = range_2pi(math.atan2((end - center).y, (end - center).x) - s_angle)
     segments = max(int(arc_angle / math.tau * ARC_SEGMENTS), 4)
-    return _arc_points(center, radius, s_angle, arc_angle, segments, mat)
+    return (center.x, center.y, (start - center).length, s_angle, arc_angle, segments)

--- a/handlers.py
+++ b/handlers.py
@@ -69,9 +69,11 @@ def on_load_post(*args):
     legacy data is detected, so all users don't pay for it on every file load.
     """
     from .drawing import overlay, selection
+    from .utilities.curve_data import reset_merge_cache
     from .utilities.validate import reset_cache
 
     reset_cache()
+    reset_merge_cache()
     overlay.invalidate()
     selection.clear()
 

--- a/handlers.py
+++ b/handlers.py
@@ -69,11 +69,13 @@ def on_load_post(*args):
     legacy data is detected, so all users don't pay for it on every file load.
     """
     from .drawing import overlay, selection
+    from .model.base_constraint import reset_data_owner_cache
     from .utilities.curve_data import reset_merge_cache
     from .utilities.validate import reset_cache
 
     reset_cache()
     reset_merge_cache()
+    reset_data_owner_cache()
     overlay.invalidate()
     selection.clear()
 

--- a/model/base_constraint.py
+++ b/model/base_constraint.py
@@ -16,13 +16,67 @@ from .constants import ENTITY_PROP_NAMES
 logger = logging.getLogger(__name__)
 
 
+# Curves datablock name -> the Object that owns it.
+#
+# Resolving the owner by scanning bpy.data.objects is O(scene), and _get_sketch
+# runs several times per constraint per solve (700 times for 100 constraints), so
+# the scan made solve time scale with how many *unrelated* objects the file
+# contained: one identical sketch solved 8x slower in a 1000-object scene than in
+# an empty one.
+#
+# The cache holds the Object itself, not its name: ``bpy.data.objects.get(name)``
+# is ALSO a linear scan (0.8us at 10 objects, 49us at 2000), so looking the owner
+# up by name would keep the very cost this removes.
+_data_owner_cache = {}
+
+
+def reset_data_owner_cache():
+    """Drop the datablock-owner cache (e.g. on file load)."""
+    _data_owner_cache.clear()
+
+
+def _resolve_data_owner(id_data):
+    """The Object whose data is ``id_data``, or ``None``.
+
+    Correctness does not rely on the cache being fresh: a cached Object is
+    *verified* to still own ``id_data`` under the same conditions the scan accepts
+    (identity, or a name match -- evaluated data has a different identity than its
+    original, which is why the name fallback exists). A stale entry therefore
+    costs a rescan and can never return the wrong object. Blender invalidates
+    references to removed IDs, so reading one raises rather than returning garbage.
+    """
+    import bpy
+
+    cached = _data_owner_cache.get(id_data.name)
+    if cached is not None:
+        try:
+            data = cached.data
+        except ReferenceError:  # the object was removed since we cached it
+            del _data_owner_cache[id_data.name]
+        else:
+            if data is id_data or (data is not None and data.name == id_data.name):
+                return cached
+
+    for obj in bpy.data.objects:
+        if obj.data is id_data:
+            _data_owner_cache[id_data.name] = obj
+            return obj
+    for obj in bpy.data.objects:
+        if obj.data and obj.data.name == id_data.name:
+            _data_owner_cache[id_data.name] = obj
+            return obj
+    return None
+
+
 class GenericConstraint:
     if bpy.app.version >= (5, 0):
+
         def _name_get_transform(self, curr_value, is_set):
             return curr_value if is_set else str(self)
 
         name: StringProperty(name="Name", get_transform=_name_get_transform)
     else:
+
         def _name_getter(self):
             return self.get("name", str(self))
 
@@ -105,6 +159,7 @@ class GenericConstraint:
     def is_orphan(self):
         """Check if this constraint's sketch object has been deleted."""
         import bpy
+
         c_sketch_name = self.get("_sketch_object", "")
         if c_sketch_name:
             return bpy.data.objects.get(c_sketch_name) is None
@@ -126,7 +181,11 @@ class GenericConstraint:
         # Compare by sketch object name (new) or entity pointer (legacy)
         c_sketch_name = self.get("_sketch_object", "")
         if c_sketch_name and active_sketch:
-            active_obj = active_sketch.target_object if hasattr(active_sketch, 'target_object') else active_sketch
+            active_obj = (
+                active_sketch.target_object
+                if hasattr(active_sketch, "target_object")
+                else active_sketch
+            )
             if active_obj:
                 return c_sketch_name == active_obj.name
         return self.sketch == active_sketch
@@ -134,18 +193,18 @@ class GenericConstraint:
     def draw_plane(self):
         from mathutils import Vector
 
-        sketch = self._get_sketch() if hasattr(self, '_get_sketch') else None
+        sketch = self._get_sketch() if hasattr(self, "_get_sketch") else None
         if not sketch and self.sketch_i != -1 and self.sketch:
             sketch = self.sketch
 
         if sketch:
-            wp_obj = getattr(sketch, 'workplane_object', None)
-            if not wp_obj and hasattr(sketch, 'target_object') and sketch.target_object:
+            wp_obj = getattr(sketch, "workplane_object", None)
+            if not wp_obj and hasattr(sketch, "target_object") and sketch.target_object:
                 wp_obj = sketch.target_object.parent
             if wp_obj:
                 mat = wp_obj.matrix_world
                 return mat.translation.copy(), Vector(mat.col[2][:3]).normalized()
-            wp = getattr(sketch, 'wp', None)
+            wp = getattr(sketch, "wp", None)
             if wp:
                 return wp.p1.location, wp.normal
 
@@ -155,6 +214,7 @@ class GenericConstraint:
     def copy(self, context, entities):
         # copy itself to another set of entities
         from .sketch_ref import get_active_constraints
+
         c = get_active_constraints(context).new_from_type(self.type)
         if hasattr(self, "sketch"):
             c.sketch = self.sketch
@@ -212,11 +272,11 @@ class GenericConstraint:
         Override for constraints with special placement logic.
         """
         ids = []
-        if getattr(self, 'curve_id_1', ""):
+        if getattr(self, "curve_id_1", ""):
             ids.append(self.curve_id_1)
-        if getattr(self, 'curve_id_2', ""):
+        if getattr(self, "curve_id_2", ""):
             ids.append(self.curve_id_2)
-        if getattr(self, 'curve_id_3', ""):
+        if getattr(self, "curve_id_3", ""):
             ids.append(self.curve_id_3)
         return ids
 
@@ -236,19 +296,17 @@ class GenericConstraint:
             return sketch
         # Resolve from Curves id_data (native curves path)
         import bpy
+
         id_data = getattr(self, "id_data", None)
         if id_data and hasattr(id_data, "sketch_constraints"):
-            for obj in bpy.data.objects:
-                if obj.data is id_data:
-                    from .sketch_ref import Sketch
-                    return Sketch(obj)
-            # Fallback: match by name (evaluated data has different identity)
-            for obj in bpy.data.objects:
-                if obj.data and obj.data.name == id_data.name:
-                    from .sketch_ref import Sketch
-                    return Sketch(obj)
+            obj = _resolve_data_owner(id_data)
+            if obj is not None:
+                from .sketch_ref import Sketch
+
+                return Sketch(obj)
         # Last resort: use active sketch from context
         from .sketch_ref import get_active_sketch
+
         return get_active_sketch(bpy.context)
 
     def ref(self, n=1):
@@ -260,6 +318,7 @@ class GenericConstraint:
         if not sketch:
             return None
         from .curve_ref import curve_ref
+
         return curve_ref(sketch, cid)
 
     def create_slvs_data(self, solvesys, **kwargs):
@@ -270,7 +329,6 @@ class GenericConstraint:
 
 
 class DimensionalConstraint(GenericConstraint):
-
     value: Property
     setting: BoolProperty
 
@@ -283,6 +341,7 @@ class DimensionalConstraint(GenericConstraint):
 
     def _get_scene(self):
         import bpy
+
         return bpy.context.scene
 
     def _set_value_force(self, value: float):
@@ -375,6 +434,7 @@ class DimensionalConstraint(GenericConstraint):
             col = sub.column()
             col.enabled = not self.is_reference
             import bpy
+
             scene = bpy.context.scene
             uid = getattr(self, "constraint_uid", "")
             key = None

--- a/model/base_constraint.py
+++ b/model/base_constraint.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import contextmanager
 from typing import List
 
 import bpy
@@ -14,6 +15,32 @@ from .base_entity import SlvsGenericEntity
 from .constants import ENTITY_PROP_NAMES
 
 logger = logging.getLogger(__name__)
+
+
+# The sketch currently being solved, published by the solver so the constraints it
+# is building do not each re-derive it. A constraint has no back-pointer to its
+# sketch, so _get_sketch resolves one from its id_data -- several times per
+# constraint, ~2800 times per solve on a 400-constraint sketch, which is 21% of
+# the solve even with the owner lookup cached.
+_sketch_resolution_override = None
+
+
+@contextmanager
+def sketch_resolution(sketch):
+    """Publish ``sketch`` as the answer for its own constraints while active.
+
+    Honoured only for a constraint whose ``id_data`` *is* this sketch's data, so
+    it can never resolve a constraint to the wrong sketch: anything from elsewhere
+    falls through to the normal lookup. Re-entrant, and restores the previous
+    value, so a nested solve of another sketch behaves.
+    """
+    global _sketch_resolution_override
+    previous = _sketch_resolution_override
+    _sketch_resolution_override = sketch
+    try:
+        yield
+    finally:
+        _sketch_resolution_override = previous
 
 
 # Curves datablock name -> the Object that owns it.
@@ -294,10 +321,20 @@ class GenericConstraint:
         sketch = self.sketch if hasattr(self, "sketch") and self.sketch else None
         if sketch:
             return sketch
+
+        id_data = getattr(self, "id_data", None)
+
+        # The solver publishes the sketch it is building; accept it only when this
+        # constraint really belongs to that sketch's data.
+        override = _sketch_resolution_override
+        if override is not None and id_data is not None:
+            obj = override.target_object
+            if obj is not None and obj.data is id_data:
+                return override
+
         # Resolve from Curves id_data (native curves path)
         import bpy
 
-        id_data = getattr(self, "id_data", None)
         if id_data and hasattr(id_data, "sketch_constraints"):
             obj = _resolve_data_owner(id_data)
             if obj is not None:

--- a/scripts/perf_harness.py
+++ b/scripts/perf_harness.py
@@ -212,14 +212,43 @@ def _metrics():
     )
 
     # 20 hovers on unchanged geometry must trigger ONE extraction (the first),
-    # not 20 -- the picking cache. If it breaks, this jumps to 20. (No cache on a
-    # pre-optimization base: _active_data rebuilds each hover, so it reads ~20.)
+    # not 20 -- the shared geometry cache. If it breaks, this jumps to 20.
     def _hover20():
-        if hasattr(picking, "_pick_cache"):
-            picking._pick_cache.clear()
-        return _call_count(lambda: picking._active_data(bpy.context), 20, "build")
+        rd.invalidate()
+        return _call_count(
+            lambda: picking._active_data(bpy.context), 20, "_extract_geometry"
+        )
 
-    _safe(metrics, "hover20_build_calls", _hover20)
+    _safe(metrics, "hover20_extract_calls", _hover20)
+
+    # The overlay and the picker share one extraction, so a frame in which the
+    # geometry changed must extract ONCE, not once per consumer. If the split
+    # regresses, this reads 2.
+    def _frame_extract_calls():
+        def frame():
+            rd.invalidate()
+            picking._active_data(bpy.context)
+            rd.build(sk, ts, True)
+
+        return _call_count(frame, 5, "_extract_geometry") / 5
+
+    _safe(metrics, "frame_extract_calls", _frame_extract_calls)
+
+    # A selection change must redo colours only, never the extraction.
+    def _hover_extract_calls():
+        selection = importlib.import_module(PKG + ".drawing.selection")
+        rd.build(sk, ts, True)  # warm
+
+        def hovers():
+            for cid in ("a", "b", ""):
+                selection.hover = cid
+                rd.build(sk, ts, True)
+
+        count = _call_count(hovers, 5, "_extract_geometry")
+        selection.hover = ""
+        return count
+
+    _safe(metrics, "hover_extract_calls", _hover_extract_calls)
 
     # A solve resolves segment endpoints from a position map, not a PointRef
     # (double curve-data resolve) each. If rebuild_segments reverts to per-

--- a/testing/test_constraint_sketch_resolution.py
+++ b/testing/test_constraint_sketch_resolution.py
@@ -1,0 +1,139 @@
+"""A constraint must resolve to its *own* sketch, cache or no cache.
+
+``_get_sketch`` used to find the owning Object by scanning ``bpy.data.objects``,
+which is O(scene) and runs several times per constraint per solve -- an identical
+sketch solved 8x slower in a 1000-object file. It now caches the resolved Object.
+
+Caching a live ``bpy`` reference is the part that needs guarding: references are
+invalidated by deletion, undo and file load, and a wrong answer here would silently
+solve a constraint against another sketch's geometry. The cache therefore verifies
+its answer on every use; these tests cover the cases that verification exists for.
+"""
+
+import bpy
+
+from ..model.base_constraint import (
+    _data_owner_cache,
+    _resolve_data_owner,
+    reset_data_owner_cache,
+)
+from .utils import Sketch2dTestCase
+
+
+class TestConstraintSketchResolution(Sketch2dTestCase):
+    def _constrained_pair(self):
+        """A line with a bound distance constraint; returns (p0, p1, constraint)."""
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((2, 0))
+        self.add_line(p0, p1)
+        c = self.sketch.constraints.add_distance(
+            init=True, curve_id_1=p0.curve_id, curve_id_2=p1.curve_id
+        )
+        c.value = 2.0
+        self.solve()
+        return p0, p1, c
+
+    def test_resolves_to_its_own_object(self):
+        _p0, _p1, c = self._constrained_pair()
+        reset_data_owner_cache()
+        resolved = c._get_sketch()
+        self.assertIs(resolved.target_object, self.sketch.target_object)
+        # Warm cache must give the same answer.
+        self.assertIs(c._get_sketch().target_object, self.sketch.target_object)
+
+    def test_does_not_confuse_two_sketches(self):
+        """The cache is keyed per datablock; two sketches must stay separate."""
+        _p0, _p1, c1 = self._constrained_pair()
+        first_obj = self.sketch.target_object
+
+        second = self.new_sketch()
+        self.sketch = second  # add_* helpers target self.sketch
+        _q0, _q1, c2 = self._constrained_pair()
+        second_obj = second.target_object
+        self.assertIsNot(first_obj, second_obj)
+
+        # Resolve repeatedly, interleaved, so a single shared cache slot would show.
+        for _ in range(3):
+            self.assertIs(c1._get_sketch().target_object, first_obj)
+            self.assertIs(c2._get_sketch().target_object, second_obj)
+
+    def test_unrelated_object_deletion_does_not_break_resolution(self):
+        _p0, _p1, c = self._constrained_pair()
+        filler = bpy.data.objects.new("filler", bpy.data.meshes.new("fillerm"))
+        self.scene.collection.objects.link(filler)
+        self.assertIs(c._get_sketch().target_object, self.sketch.target_object)
+
+        bpy.data.objects.remove(filler, do_unlink=True)
+        self.assertIs(c._get_sketch().target_object, self.sketch.target_object)
+
+    def test_stale_entry_is_rejected_not_trusted(self):
+        """A cache entry pointing at the wrong object must lose to a rescan."""
+        _p0, _p1, c = self._constrained_pair()
+        id_data = self.sketch.target_object.data
+
+        decoy = bpy.data.objects.new("decoy", bpy.data.meshes.new("decoym"))
+        self.scene.collection.objects.link(decoy)
+        _data_owner_cache[id_data.name] = decoy  # poison it
+
+        self.assertIs(
+            _resolve_data_owner(id_data),
+            self.sketch.target_object,
+            "a poisoned cache entry was trusted instead of revalidated",
+        )
+        bpy.data.objects.remove(decoy, do_unlink=True)
+
+    def test_removed_cached_object_is_survived(self):
+        """A cached reference to a deleted Object must not raise or mislead."""
+        _p0, _p1, c = self._constrained_pair()
+        id_data = self.sketch.target_object.data
+
+        doomed = bpy.data.objects.new("doomed", bpy.data.meshes.new("doomedm"))
+        self.scene.collection.objects.link(doomed)
+        _data_owner_cache[id_data.name] = doomed
+        bpy.data.objects.remove(doomed, do_unlink=True)
+
+        # Reading .data on the freed reference raises ReferenceError internally;
+        # resolution must absorb that and fall back to the scan.
+        self.assertIs(_resolve_data_owner(id_data), self.sketch.target_object)
+
+    def test_resolution_survives_undo_redo(self):
+        """Undo invalidates bpy references, the classic way such a cache breaks."""
+        _p0, _p1, c = self._constrained_pair()
+        obj_name = self.sketch.target_object.name
+        self.assertIs(c._get_sketch().target_object, self.sketch.target_object)
+
+        try:
+            bpy.ops.ed.undo_push(message="perf test")
+            bpy.ops.ed.undo()
+            bpy.ops.ed.redo()
+        except RuntimeError as exc:  # background mode often has no undo stack
+            self.skipTest(f"undo unavailable headless: {exc}")
+
+        obj = bpy.data.objects.get(obj_name)
+        self.assertIsNotNone(obj, "the sketch object did not survive undo/redo")
+        resolved = c._get_sketch()
+        self.assertIsNotNone(resolved)
+        self.assertEqual(resolved.target_object.name, obj_name)
+        # And it must still solve.
+        self.assertTrue(self.sketch.solve(self.context))
+
+    def test_solving_is_independent_of_scene_size(self):
+        """Behavioural check that resolution does not depend on the object count.
+
+        The timing win is machine-dependent, but the *answer* must not change as
+        unrelated objects appear, which is what the old scan made fragile.
+        """
+        _p0, p1, c = self._constrained_pair()
+        fillers = []
+        for k in range(40):
+            ob = bpy.data.objects.new(f"bulk{k}", bpy.data.meshes.new(f"bulkm{k}"))
+            self.scene.collection.objects.link(ob)
+            fillers.append(ob)
+        try:
+            self.assertIs(c._get_sketch().target_object, self.sketch.target_object)
+            p1.co = (5.0, 0.0)
+            self.assertTrue(self.sketch.solve(self.context))
+            self.assertAlmostEqual((p1.co - _p0.co).length, 2.0, places=3)
+        finally:
+            for ob in fillers:
+                bpy.data.objects.remove(ob, do_unlink=True)

--- a/testing/test_constraint_sketch_resolution.py
+++ b/testing/test_constraint_sketch_resolution.py
@@ -16,6 +16,7 @@ from ..model.base_constraint import (
     _data_owner_cache,
     _resolve_data_owner,
     reset_data_owner_cache,
+    sketch_resolution,
 )
 from .utils import Sketch2dTestCase
 
@@ -137,3 +138,92 @@ class TestConstraintSketchResolution(Sketch2dTestCase):
         finally:
             for ob in fillers:
                 bpy.data.objects.remove(ob, do_unlink=True)
+
+
+class TestSketchResolutionOverride(Sketch2dTestCase):
+    """The solver publishes the sketch it is solving; the guard makes that safe.
+
+    ``sketch_resolution`` lets a constraint skip re-deriving its sketch, but only
+    when the constraint's own ``id_data`` is that sketch's data. Without the guard
+    a constraint from another sketch would silently resolve to the wrong geometry,
+    which would be a wrong solve rather than an error.
+    """
+
+    def _constrained_pair(self):
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((2, 0))
+        self.add_line(p0, p1)
+        c = self.sketch.constraints.add_distance(
+            init=True, curve_id_1=p0.curve_id, curve_id_2=p1.curve_id
+        )
+        c.value = 2.0
+        self.solve()
+        return p0, p1, c
+
+    def test_override_is_used_for_its_own_constraints(self):
+        _p0, _p1, c = self._constrained_pair()
+        with sketch_resolution(self.sketch):
+            self.assertIs(c._get_sketch().target_object, self.sketch.target_object)
+
+    def test_override_is_refused_for_another_sketch(self):
+        """The guard: a foreign constraint must ignore the published sketch."""
+        first = self.sketch
+        _p0, _p1, c_first = self._constrained_pair()
+
+        second = self.new_sketch()
+        self.sketch = second
+        _q0, _q1, c_second = self._constrained_pair()
+
+        # Publish the FIRST sketch, then resolve the SECOND sketch's constraint.
+        with sketch_resolution(first):
+            resolved = c_second._get_sketch()
+        self.assertIs(
+            resolved.target_object,
+            second.target_object,
+            "a constraint resolved to the published sketch instead of its own",
+        )
+        with sketch_resolution(second):
+            self.assertIs(c_first._get_sketch().target_object, first.target_object)
+
+    def test_override_nests_and_restores(self):
+        first = self.sketch
+        _p0, _p1, c = self._constrained_pair()
+        second = self.new_sketch()
+
+        with sketch_resolution(first):
+            self.assertIs(c._get_sketch().target_object, first.target_object)
+            with sketch_resolution(second):
+                # Still first: the guard refuses second for this constraint.
+                self.assertIs(c._get_sketch().target_object, first.target_object)
+            self.assertIs(c._get_sketch().target_object, first.target_object)
+
+    def test_override_is_cleared_after_an_exception(self):
+        from ..model import base_constraint
+
+        self.assertIsNone(base_constraint._sketch_resolution_override)
+        with self.assertRaises(RuntimeError):
+            with sketch_resolution(self.sketch):
+                raise RuntimeError("boom")
+        self.assertIsNone(
+            base_constraint._sketch_resolution_override,
+            "the override leaked out of a failed block",
+        )
+
+    def test_two_sketches_solve_independently(self):
+        """End to end: solving one sketch must not disturb the other."""
+        first = self.sketch
+        _p0, p1, _c1 = self._constrained_pair()
+
+        second = self.new_sketch()
+        self.sketch = second
+        _q0, q1, c2 = self._constrained_pair()
+        c2.value = 5.0
+        self.assertTrue(second.solve(self.context))
+
+        # Pull each off its constrained length, solve each, check both land right.
+        p1.co = (9.0, 1.0)
+        q1.co = (1.0, 1.0)
+        self.assertTrue(first.solve(self.context))
+        self.assertTrue(second.solve(self.context))
+        self.assertAlmostEqual((p1.co - _p0.co).length, 2.0, places=3)
+        self.assertAlmostEqual((q1.co - _q0.co).length, 5.0, places=3)

--- a/testing/test_merge_id_gating.py
+++ b/testing/test_merge_id_gating.py
@@ -1,0 +1,258 @@
+"""The merge-id gate must never give a different answer than recomputing.
+
+``compute_merge_ids`` (and the source seeds it writes) is skipped when the
+sketch's connectivity signature is unchanged, because weld ids derive from which
+point curves a segment references and from coincidence constraints, never from
+positions. That is a silent-failure risk: stale weld ids do not raise, they stop
+a corner welding, and the sketch quietly fails to fill (issue #342 territory).
+
+Every test here does the same thing: perform an edit, let the gate decide, then
+force a full recompute and assert nothing moved. If the signature ever misses an
+input, the forced pass repairs it and the comparison fails.
+"""
+
+import math
+
+import numpy as np
+
+from ..utilities.curve_data import (
+    SOURCE_CURVE_ID_ATTR,
+    SOURCE_ENDPOINT_ID_ATTR,
+    _connectivity_signature,
+    compute_merge_ids,
+    refresh_curve_geometry,
+)
+from .utils import Sketch2dTestCase
+
+_GATED_ATTRS = ("merge_id", SOURCE_CURVE_ID_ATTR, SOURCE_ENDPOINT_ID_ATTR)
+
+
+class MergeGateEquivalence(Sketch2dTestCase):
+    def _snapshot(self):
+        cd = self.sketch.target_object.data
+        snap = {}
+        for name in _GATED_ATTRS:
+            attr = cd.attributes.get(name)
+            if attr is None:
+                continue
+            length = len(cd.points) if attr.domain == "POINT" else len(cd.curves)
+            buf = np.empty(length, dtype=np.int32)
+            attr.data.foreach_get("value", buf)
+            snap[name] = buf
+        return snap
+
+    def assert_gate_matches_recompute(self):
+        """Whatever the gate decided, a forced recompute must change nothing."""
+        compute_merge_ids(self.sketch)  # gated: may skip
+        gated = self._snapshot()
+        compute_merge_ids(self.sketch, force=True)
+        forced = self._snapshot()
+
+        self.assertEqual(set(gated), set(forced))
+        self.assertTrue(gated, "no gated attributes were written at all")
+        for name in forced:
+            np.testing.assert_array_equal(
+                gated[name],
+                forced[name],
+                err_msg=f"{name!r} was stale: the gate skipped a real change",
+            )
+
+
+class TestGateCoversConnectivityChanges(MergeGateEquivalence):
+    def test_position_only_change(self):
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((2, 0))
+        self.add_line(p0, p1)
+        self.solve()
+
+        p1.co = (3.0, 1.0)
+        self.solve()
+        self.assert_gate_matches_recompute()
+
+    def test_adding_a_segment(self):
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((2, 0))
+        self.add_line(p0, p1)
+        self.solve()
+        compute_merge_ids(self.sketch)
+
+        p2 = self.add_point((2, 2))
+        self.add_line(p1, p2)
+        self.solve()
+        self.assert_gate_matches_recompute()
+
+    def test_adding_a_coincidence_constraint(self):
+        """A constraint can change weld ids with no geometry change at all.
+
+        Two endpoints at the same spot belong to distinct point curves until a
+        coincidence constraint unions them, so this moves the answer while every
+        position, id and count stays put. The signature has to include it.
+        """
+        a0 = self.add_point((0, 0), fixed=True)
+        a1 = self.add_point((2, 0))
+        b0 = self.add_point((2, 0))
+        b1 = self.add_point((2, 2))
+        self.add_line(a0, a1)
+        self.add_line(b0, b1)
+        self.solve()
+        compute_merge_ids(self.sketch)
+        before = self._snapshot()
+
+        self.sketch.constraints.add_coincident(
+            curve_id_1=a1.curve_id, curve_id_2=b0.curve_id
+        )
+        self.solve()
+        self.assert_gate_matches_recompute()
+
+        after = self._snapshot()
+        self.assertFalse(
+            np.array_equal(before["merge_id"], after["merge_id"]),
+            "the coincidence constraint should have changed the weld ids",
+        )
+
+    def test_arc_resegmentation_shifts_point_indices(self):
+        """Growing an arc changes its point count, moving every later index."""
+        centre = self.add_point((0, 0), fixed=True)
+        start = self.add_point((2.0, 0), fixed=True)
+        end = self.add_point((0.0, 2.0))
+        self.add_arc(centre, start, end)
+        p0 = self.add_point((5, 0))
+        p1 = self.add_point((7, 0))
+        self.add_line(p0, p1)
+        self.solve()
+        compute_merge_ids(self.sketch)
+
+        for degrees in (300, 45, 200):
+            with self.subTest(degrees=degrees):
+                a = math.radians(degrees)
+                end.co = (2.0 * math.cos(a), 2.0 * math.sin(a))
+                self.solve()
+                self.assert_gate_matches_recompute()
+
+    def test_after_a_geometry_refresh(self):
+        """refresh_curve_geometry rebuilds topology and restores attributes."""
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((2, 0))
+        self.add_line(p0, p1)
+        self.add_circle(self.add_point((5, 0)), 1.0)
+        self.solve()
+        refresh_curve_geometry(self.sketch)
+        self.assert_gate_matches_recompute()
+
+    def test_fresh_sketch_never_skips(self):
+        """A signature match must not skip when the outputs were never written."""
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((2, 0))
+        self.add_line(p0, p1)
+        self.solve()
+        compute_merge_ids(self.sketch)
+
+        # Drop the outputs but leave connectivity untouched, exactly the state a
+        # datablock is in before its first merge pass.
+        cd = self.sketch.target_object.data
+        for name in _GATED_ATTRS:
+            if cd.attributes.get(name) is not None:
+                cd.attributes.remove(cd.attributes[name])
+
+        self.assertTrue(
+            compute_merge_ids(self.sketch),
+            "gate skipped a sketch whose merge attributes do not exist",
+        )
+        self.assertIsNotNone(cd.attributes.get("merge_id"))
+
+
+class TestGateActuallySkips(Sketch2dTestCase):
+    """Guard the optimization: a position-only solve must not redo the work."""
+
+    def test_settled_and_dragged_solves_skip(self):
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((2, 0))
+        self.add_line(p0, p1)
+        self.add_circle(self.add_point((5, 0)), 1.0)
+        self.solve()
+        compute_merge_ids(self.sketch)  # warm the signature
+
+        self.assertFalse(
+            compute_merge_ids(self.sketch), "recomputed with nothing changed"
+        )
+        p1.co = (4.0, 2.0)
+        self.solve()
+        self.assertFalse(
+            compute_merge_ids(self.sketch),
+            "a position-only change recomputed the weld ids",
+        )
+
+
+class TestConnectivitySignature(Sketch2dTestCase):
+    """What the gate keys on, tested directly.
+
+    Asserting on ``compute_merge_ids``' return value cannot show this: creating a
+    curve recomputes the ids on the way through, so by the time a test looks the
+    signature is current again. The signature itself is the unit that has to
+    discriminate.
+    """
+
+    def _signature(self):
+        return _connectivity_signature(self.sketch.target_object.data)
+
+    def test_position_change_keeps_the_signature(self):
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((2, 0))
+        self.add_line(p0, p1)
+        self.add_circle(self.add_point((5, 0)), 1.0)
+        self.solve()
+
+        before = self._signature()
+        p1.co = (4.0, 3.0)
+        self.solve()
+        self.assertEqual(
+            before, self._signature(), "a position-only change moved the signature"
+        )
+
+    def test_new_segment_changes_the_signature(self):
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((2, 0))
+        self.add_line(p0, p1)
+        self.solve()
+
+        before = self._signature()
+        self.add_line(p1, self.add_point((2, 2)))
+        self.solve()
+        self.assertNotEqual(before, self._signature())
+
+    def test_coincidence_constraint_changes_the_signature(self):
+        """The input that no amount of geometry inspection would reveal."""
+        a0 = self.add_point((0, 0), fixed=True)
+        a1 = self.add_point((2, 0))
+        b0 = self.add_point((2, 0))
+        b1 = self.add_point((2, 2))
+        self.add_line(a0, a1)
+        self.add_line(b0, b1)
+        self.solve()
+
+        before = self._signature()
+        self.sketch.constraints.add_coincident(
+            curve_id_1=a1.curve_id, curve_id_2=b0.curve_id
+        )
+        self.assertNotEqual(
+            before,
+            self._signature(),
+            "a coincidence constraint left the signature unchanged, so the gate "
+            "would serve stale weld ids and the corner would stop welding",
+        )
+
+    def test_arc_resegmentation_changes_the_signature(self):
+        centre = self.add_point((0, 0), fixed=True)
+        start = self.add_point((2.0, 0), fixed=True)
+        end = self.add_point((0.0, 2.0))
+        self.add_arc(centre, start, end)
+        self.solve()
+
+        before = self._signature()
+        end.co = (2.0 * math.cos(math.radians(300)), 2.0 * math.sin(math.radians(300)))
+        self.solve()
+        self.assertNotEqual(
+            before,
+            self._signature(),
+            "the arc grew to more control points without moving the signature",
+        )

--- a/testing/test_native_3d_sketch.py
+++ b/testing/test_native_3d_sketch.py
@@ -168,7 +168,6 @@ class TestNative3DSketch(BgsTestCase):
     def test_origin_transform_moves_rendered_3d_geometry(self):
         from ..drawing import render_data
         from ..model.native_3d import create_line_3d, create_point_3d
-        from ..utilities.preferences import get_prefs
 
         p1 = create_point_3d(self.sketch, (1.0, 0.0, 0.0), fixed=True)
         p2 = create_point_3d(self.sketch, (0.0, 2.0, 1.0), fixed=True)
@@ -189,29 +188,24 @@ class TestNative3DSketch(BgsTestCase):
 
         expected_p1 = origin.matrix_world @ local_p1
         expected_p2 = origin.matrix_world @ local_p2
-        data = render_data.build(
-            self.sketch,
-            get_prefs().theme_settings.entity,
-            is_active=True,
-        )
-        point_world = {cid: Vector(pos) for cid, pos in data.point_ids}
+        data = render_data.geometry(self.sketch)
+        point_world = dict(zip(data.point_cids, (Vector(p) for p in data.point_co)))
         self.assertLess((point_world[p1.curve_id] - expected_p1).length, 1e-5)
         self.assertLess((point_world[p2.curve_id] - expected_p2).length, 1e-5)
 
-        segment = next(item for item in data.segment_ids if item[0] == line.curve_id)
-        self.assertLess((Vector(segment[1]) - expected_p1).length, 1e-5)
-        self.assertLess((Vector(segment[2]) - expected_p2).length, 1e-5)
+        seg_rows = data.seg_co[data.seg_owner == data.seg_cids.index(line.curve_id)]
+        start, end = seg_rows[0]
+        self.assertLess((Vector(start) - expected_p1).length, 1e-5)
+        self.assertLess((Vector(end) - expected_p2).length, 1e-5)
 
         # A solve/depsgraph pass must not bake the origin transform back into the
         # native coordinates or visually reset the sketch to its old position.
         self.assertTrue(self.sketch.solve(self.context))
         self.context.view_layer.update()
-        solved = render_data.build(
-            self.sketch,
-            get_prefs().theme_settings.entity,
-            is_active=True,
+        solved = render_data.geometry(self.sketch)
+        solved_world = dict(
+            zip(solved.point_cids, (Vector(p) for p in solved.point_co))
         )
-        solved_world = {cid: Vector(pos) for cid, pos in solved.point_ids}
         self.assertLess((solved_world[p1.curve_id] - expected_p1).length, 1e-5)
         self.assertLess((solved_world[p2.curve_id] - expected_p2).length, 1e-5)
 

--- a/testing/test_picking.py
+++ b/testing/test_picking.py
@@ -204,3 +204,50 @@ class TestPicking(Sketch2dTestCase):
                 render_data.build(self.sketch, ts, True)
         selection.hover = ""
         self.assertEqual(calls, [], "a hover change re-extracted the geometry")
+
+
+class TestSegmentDistance(Sketch2dTestCase):
+    """``_dist_to_segments`` replaced a per-segment Python loop.
+
+    It runs on every mouse-move over every tessellated segment, so it is
+    vectorized; these pin it against the straightforward scalar formula it
+    replaced, including the degenerate and clamped cases.
+    """
+
+    @staticmethod
+    def _scalar(a, b, px, py):
+        """Point-to-segment distance, written out directly."""
+        abx, aby = b[0] - a[0], b[1] - a[1]
+        seg2 = abx * abx + aby * aby
+        if seg2 < 1e-9:
+            return ((px - a[0]) ** 2 + (py - a[1]) ** 2) ** 0.5
+        t = ((px - a[0]) * abx + (py - a[1]) * aby) / seg2
+        t = min(1.0, max(0.0, t))
+        cx, cy = a[0] + t * abx, a[1] + t * aby
+        return ((px - cx) ** 2 + (py - cy) ** 2) ** 0.5
+
+    def test_matches_the_scalar_formula(self):
+        rng = np.random.default_rng(20260912)
+        screen = rng.random((500, 2, 2)) * 1000.0
+        px, py = 500.0, 500.0
+        got = picking._dist_to_segments(screen, px, py)
+        want = [self._scalar(s[0], s[1], px, py) for s in screen]
+        np.testing.assert_allclose(got, want, rtol=1e-9, atol=1e-9)
+
+    def test_handles_degenerate_and_clamped_cases(self):
+        screen = np.array(
+            [
+                [[0.0, 0.0], [0.0, 0.0]],  # zero-length: distance to the point
+                [[0.0, 0.0], [10.0, 0.0]],  # perpendicular foot inside
+                [[0.0, 0.0], [1.0, 0.0]],  # foot beyond the end -> clamps to b
+                [[20.0, 0.0], [30.0, 0.0]],  # foot before the start -> clamps to a
+            ]
+        )
+        got = picking._dist_to_segments(screen, 5.0, 5.0)
+        want = [self._scalar(s[0], s[1], 5.0, 5.0) for s in screen]
+        np.testing.assert_allclose(got, want, rtol=1e-9, atol=1e-9)
+        # the specific expectations, spelled out
+        self.assertAlmostEqual(float(got[0]), (50.0) ** 0.5, places=9)
+        self.assertAlmostEqual(float(got[1]), 5.0, places=9)
+        self.assertAlmostEqual(float(got[2]), (16.0 + 25.0) ** 0.5, places=9)
+        self.assertAlmostEqual(float(got[3]), (225.0 + 25.0) ** 0.5, places=9)

--- a/testing/test_picking.py
+++ b/testing/test_picking.py
@@ -130,14 +130,17 @@ class TestPicking(Sketch2dTestCase):
         self.assertNotEqual(picking.pick(self.ctx, (40, 0)), self.b.curve_id)
 
     def test_cache_reuses_on_hover_and_refreshes_on_geometry_change(self):
-        # First pick populates the cache; a second pick (mouse just moved, no
-        # geometry change) must reuse the same extracted data, not rebuild.
-        picking._pick_cache.clear()
+        # A second pick (mouse just moved, no geometry change) must reuse the same
+        # extracted data, not rebuild it. The extraction is shared with the
+        # overlay, so identity of the returned object is the thing to check.
+        from ..drawing import render_data
+
+        render_data.invalidate()
         picking.pick(self.ctx, (40, 0))
-        cached = picking._pick_cache[self.sketch.target_object.name][1]
+        cached = picking._active_data(self.ctx)
         picking.pick(self.ctx, (20, 0))
         self.assertIs(
-            picking._pick_cache[self.sketch.target_object.name][1],
+            picking._active_data(self.ctx),
             cached,
             "hover rebuilt pick data despite unchanged geometry",
         )
@@ -147,5 +150,57 @@ class TestPicking(Sketch2dTestCase):
         line2 = self.add_line(self.b, c)
         self.solve()
         self.assertEqual(picking.pick(self.ctx, (40, 40)), c.curve_id)
-        self.assertIsNot(picking._pick_cache[self.sketch.target_object.name][1], cached)
+        self.assertIsNot(picking._active_data(self.ctx), cached)
         self.assertTrue(line2.valid)
+
+    def test_overlay_and_picking_share_one_extraction(self):
+        """A changed-geometry frame must extract once, not once per consumer.
+
+        The overlay and the picker each used to run their own ``build``, so every
+        frame of a drag paid for the extraction twice (issue #342).
+        """
+        from ..drawing import render_data
+        from ..utilities.preferences import get_prefs
+
+        render_data.invalidate()
+        calls = []
+        real = render_data._extract_geometry
+
+        def spy(sketch):
+            calls.append(sketch)
+            return real(sketch)
+
+        import unittest.mock as mock
+
+        with mock.patch.object(render_data, "_extract_geometry", spy):
+            # One "frame": the picker resolves hover, then the overlay draws.
+            picking.pick(self.ctx, (40, 0))
+            render_data.build(self.sketch, get_prefs().theme_settings.entity, True)
+        self.assertEqual(
+            len(calls), 1, "geometry was extracted more than once for one frame"
+        )
+
+    def test_hover_does_not_re_extract_geometry(self):
+        """Selection/hover changes must only redo colours, not the extraction."""
+        from ..drawing import render_data
+        from ..utilities.preferences import get_prefs
+
+        ts = get_prefs().theme_settings.entity
+        render_data.invalidate()
+        render_data.build(self.sketch, ts, True)  # warm
+
+        calls = []
+        real = render_data._extract_geometry
+
+        def spy(sketch):
+            calls.append(sketch)
+            return real(sketch)
+
+        import unittest.mock as mock
+
+        with mock.patch.object(render_data, "_extract_geometry", spy):
+            for cid in (self.a.curve_id, self.b.curve_id, ""):
+                selection.hover = cid
+                render_data.build(self.sketch, ts, True)
+        selection.hover = ""
+        self.assertEqual(calls, [], "a hover change re-extracted the geometry")

--- a/testing/test_reference_pick.py
+++ b/testing/test_reference_pick.py
@@ -15,9 +15,9 @@ class TestReferencePickGeometry(Sketch2dTestCase):
         line = self.add_line(p0, p1)
         standalone = self.add_point((1.0, 1.0))
 
-        points, segments = extract_pickable_geometry(self.sketch.target_object)
-        pkeys = {k for k, _ in points}
-        skeys = {k for k, _, _ in segments}
+        pick = extract_pickable_geometry(self.sketch.target_object)
+        pkeys = set(pick.point_keys)
+        skeys = set(pick.seg_keys)
 
         self.assertIn(standalone.curve_id, pkeys)
         self.assertIn(p0.curve_id, pkeys)
@@ -32,9 +32,10 @@ class TestReferencePickGeometry(Sketch2dTestCase):
         end = self.add_point((0.0, 1.0))
         arc = self.add_arc(ct, start, end)
 
-        _, segments = extract_pickable_geometry(self.sketch.target_object)
-        arc_segments = [k for k, _, _ in segments if k == arc.curve_id]
-        self.assertGreater(len(arc_segments), 1)
+        pick = extract_pickable_geometry(self.sketch.target_object)
+        self.assertIn(arc.curve_id, pick.seg_keys)
+        rows = pick.seg_owner == pick.seg_keys.index(arc.curve_id)
+        self.assertGreater(int(rows.sum()), 1)  # tessellated into several
 
     def test_raw_curves_object_extraction(self):
         # A raw Curves object (no sketch attributes) extracts control points and
@@ -47,10 +48,10 @@ class TestReferencePickGeometry(Sketch2dTestCase):
         obj = bpy.data.objects.new("raw", cu)
         self.scene.collection.objects.link(obj)
 
-        points, segments = extract_pickable_geometry(obj)
-        self.assertEqual(len(points), 3)  # 3 control points
-        self.assertEqual(len(segments), 2)  # 3 points -> 2 spans
-        got = sorted(tuple(round(c, 3) for c in p) for _, p in points)
+        pick = extract_pickable_geometry(obj)
+        self.assertEqual(len(pick.point_keys), 3)  # 3 control points
+        self.assertEqual(len(pick.seg_co), 2)  # 3 points -> 2 spans
+        got = sorted(tuple(round(float(c), 3) for c in p) for p in pick.point_co)
         self.assertEqual(got, [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0)])
 
     def test_non_curve_object_returns_empty(self):
@@ -58,7 +59,9 @@ class TestReferencePickGeometry(Sketch2dTestCase):
         me.from_pydata([(0.0, 0.0, 0.0)], [], [])
         ob = self.data.objects.new("m", me)
         self.scene.collection.objects.link(ob)
-        self.assertEqual(extract_pickable_geometry(ob), ([], []))
+        pick = extract_pickable_geometry(ob)
+        self.assertEqual(len(pick.point_co), 0)
+        self.assertEqual(len(pick.seg_co), 0)
 
     def test_element_geometry_isolates_one_element_for_highlight(self):
         # element_geometry returns only the requested element's geometry, so the

--- a/testing/test_render_data.py
+++ b/testing/test_render_data.py
@@ -6,6 +6,10 @@ extracted into the right buckets and that the change-signature both stays stable
 and detects the changes that must invalidate cached batches.
 """
 
+import math
+
+from mathutils import Vector
+
 from ..drawing import render_data, selection
 from ..utilities.curve_data import read_uuid_list, refresh_curve_geometry
 from ..utilities.preferences import get_prefs
@@ -113,5 +117,99 @@ class TestRenderData(Sketch2dTestCase):
             self.assertNotEqual(
                 active, render_data.overlay_signature(self.sketch, True, ())
             )
+        finally:
+            selection.clear()
+
+
+class TestArcTessellation(Sketch2dTestCase):
+    """Arcs and circles are tessellated for all curves in one vectorized pass.
+
+    Guards the geometry that batching must not change: every vertex on the
+    circle, the chain closed with no duplicate/zero-length segment, and an open
+    arc still starting and ending exactly on its defining points.
+    """
+
+    RADIUS = 1.5
+
+    def _segments(self, is_active=True):
+        data = render_data.build(
+            self.sketch, get_prefs().theme_settings.entity, is_active
+        )
+        return data, [(Vector(a), Vector(b)) for _cid, a, b in data.segment_ids]
+
+    def _local(self, co):
+        """A sketch-local 2D point in the world space build() emits."""
+        return self.sketch.world_matrix @ Vector((co[0], co[1], 0.0))
+
+    def test_circle_vertices_lie_on_the_circle(self):
+        circle = self.add_circle(self.add_point((2, -1)), self.RADIUS)
+        self.solve()
+        refresh_curve_geometry(self.sketch)
+
+        data, segments = self._segments()
+        centre = self._local((2, -1))
+        for a, b in segments:
+            for v in (a, b):
+                self.assertAlmostEqual((v - centre).length, self.RADIUS, places=4)
+        self.assertTrue(all(cid == circle.curve_id for cid, _a, _b in data.segment_ids))
+
+    def test_circle_closes_without_a_degenerate_segment(self):
+        self.add_circle(self.add_point((0, 0)), self.RADIUS)
+        self.solve()
+        refresh_curve_geometry(self.sketch)
+
+        _data, segments = self._segments()
+        self.assertEqual(len(segments), render_data.ARC_SEGMENTS)
+        for i, (_a, b) in enumerate(segments):
+            nxt = segments[(i + 1) % len(segments)][0]
+            self.assertAlmostEqual((b - nxt).length, 0.0, places=5)
+        for a, b in segments:
+            self.assertGreater((b - a).length, 1e-6, "zero-length segment emitted")
+
+    def test_arc_spans_its_defining_points(self):
+        for degrees in (30, 90, 200, 350):
+            with self.subTest(degrees=degrees):
+                self.setUp()
+                angle = math.radians(degrees)
+                end_co = (self.RADIUS * math.cos(angle), self.RADIUS * math.sin(angle))
+                self.add_arc(
+                    self.add_point((0, 0)),
+                    self.add_point((self.RADIUS, 0)),
+                    self.add_point(end_co),
+                )
+                self.solve()
+                refresh_curve_geometry(self.sketch)
+
+                _data, segments = self._segments()
+                expected = max(int(angle / math.tau * render_data.ARC_SEGMENTS), 4)
+                self.assertEqual(len(segments), expected)
+                self.assertAlmostEqual(
+                    (segments[0][0] - self._local((self.RADIUS, 0))).length,
+                    0.0,
+                    places=4,
+                )
+                self.assertAlmostEqual(
+                    (segments[-1][1] - self._local(end_co)).length, 0.0, places=4
+                )
+
+    def test_construction_and_selection_split_buckets(self):
+        """Batching files arcs per (construction, colour); both must still split."""
+        solid = self.add_circle(self.add_point((0, 0)), 1.0)
+        self.add_circle(self.add_point((4, 0)), 1.0, construction=True)
+        self.solve()
+        refresh_curve_geometry(self.sketch)
+
+        data, _segments = self._segments()
+        self.assertEqual(sorted(k[0] for k in data.line_buckets), [False, True])
+        n_verts = sum(len(v) for v in data.line_buckets.values())
+        self.assertEqual(len(data.segment_ids), n_verts // 2)
+
+        before = set(data.line_buckets)
+        selection.clear()
+        selection.selected.append(solid.curve_id)
+        try:
+            selected, _ = self._segments()
+            self.assertNotEqual(before, set(selected.line_buckets))
+            self.assertEqual(len(selected.segment_ids), len(data.segment_ids))
         finally:
             selection.clear()

--- a/testing/test_render_data.py
+++ b/testing/test_render_data.py
@@ -32,14 +32,20 @@ class TestRenderData(Sketch2dTestCase):
         self._build_point_line_circle()
         data = render_data.build(self.sketch, self._ts(), is_active=True)
 
-        n_points = sum(len(v) for v in data.point_buckets.values())
-        n_line_verts = sum(len(v) for v in data.line_buckets.values())
+        n_points = sum(len(centres) for centres, _sizes in data.point_buckets.values())
+        n_segments = sum(
+            sum(len(chunk) for chunk in chunks) for chunks in data.line_buckets.values()
+        )
 
         self.assertEqual(n_points, 3)  # the three point curves
-        self.assertEqual(len(data.point_ids), 3)
-        self.assertGreater(n_line_verts, 2)  # line + tessellated circle
-        self.assertEqual(n_line_verts % 2, 0)  # LINES come in pairs
-        self.assertEqual(len(data.segment_ids), n_line_verts // 2)
+        geo = render_data.geometry(self.sketch)
+        self.assertEqual(len(geo.point_cids), 3)
+        self.assertGreater(n_segments, 1)  # line + tessellated circle
+        # Every bucket chunk is (M, 2, 3): a segment carries both its endpoints.
+        for chunks in data.line_buckets.values():
+            for chunk in chunks:
+                self.assertEqual(chunk.shape[1:], (2, 3))
+        self.assertEqual(n_segments, len(geo.seg_co))
 
     def test_signature_stable_and_invalidates(self):
         self._build_point_line_circle()
@@ -135,7 +141,8 @@ class TestArcTessellation(Sketch2dTestCase):
         data = render_data.build(
             self.sketch, get_prefs().theme_settings.entity, is_active
         )
-        return data, [(Vector(a), Vector(b)) for _cid, a, b in data.segment_ids]
+        geo = render_data.geometry(self.sketch)
+        return data, [(Vector(a), Vector(b)) for a, b in geo.seg_co]
 
     def _local(self, co):
         """A sketch-local 2D point in the world space build() emits."""
@@ -151,7 +158,8 @@ class TestArcTessellation(Sketch2dTestCase):
         for a, b in segments:
             for v in (a, b):
                 self.assertAlmostEqual((v - centre).length, self.RADIUS, places=4)
-        self.assertTrue(all(cid == circle.curve_id for cid, _a, _b in data.segment_ids))
+        geo = render_data.geometry(self.sketch)
+        self.assertEqual(set(geo.seg_cids), {circle.curve_id})
 
     def test_circle_closes_without_a_degenerate_segment(self):
         self.add_circle(self.add_point((0, 0)), self.RADIUS)
@@ -199,17 +207,27 @@ class TestArcTessellation(Sketch2dTestCase):
         self.solve()
         refresh_curve_geometry(self.sketch)
 
-        data, _segments = self._segments()
+        data, segments = self._segments()
         self.assertEqual(sorted(k[0] for k in data.line_buckets), [False, True])
-        n_verts = sum(len(v) for v in data.line_buckets.values())
-        self.assertEqual(len(data.segment_ids), n_verts // 2)
+        n_segments = sum(
+            sum(len(chunk) for chunk in chunks) for chunks in data.line_buckets.values()
+        )
+        self.assertEqual(n_segments, len(segments))
 
         before = set(data.line_buckets)
         selection.clear()
         selection.selected.append(solid.curve_id)
         try:
-            selected, _ = self._segments()
+            selected, sel_segments = self._segments()
             self.assertNotEqual(before, set(selected.line_buckets))
-            self.assertEqual(len(selected.segment_ids), len(data.segment_ids))
+            self.assertEqual(len(sel_segments), len(segments))
+            # Selection recolours; it must not change how much is drawn.
+            self.assertEqual(
+                sum(
+                    sum(len(chunk) for chunk in chunks)
+                    for chunks in selected.line_buckets.values()
+                ),
+                n_segments,
+            )
         finally:
             selection.clear()

--- a/testing/test_solve_scoped_rebuild.py
+++ b/testing/test_solve_scoped_rebuild.py
@@ -1,0 +1,333 @@
+"""The solver's scoped segment rebuild must be equivalent to a full one.
+
+``_write_results`` rebuilds only the segments whose referenced points actually
+moved, instead of re-deriving every arc/circle bezier on every solve. That is a
+correctness risk: a segment the solver skips keeps whatever bezier data it had,
+so anything the scoping misses shows up as stale geometry rather than as an
+error.
+
+These tests pin the invariant directly. After a solve, running an *unscoped*
+``rebuild_segments`` must change nothing: positions, bezier handles and weld ids
+all stay byte-identical. If the scoping ever misses a case, the full rebuild
+repairs it and the comparison fails.
+"""
+
+import math
+
+import numpy as np
+
+from ..utilities.curve_data import rebuild_segments
+from .utils import Sketch2dTestCase
+
+# Attributes that a segment rebuild is allowed to touch.
+_REBUILT_ATTRS = (
+    ("handle_left", "vector", 3),
+    ("handle_right", "vector", 3),
+    ("merge_id", "value", 1),
+)
+
+
+class ScopedRebuildEquivalence(Sketch2dTestCase):
+    """Base: snapshot curve data, force a full rebuild, expect no change."""
+
+    def _snapshot(self):
+        cd = self.sketch.target_object.data
+        n_points = len(cd.points)
+        snap = {}
+        positions = np.empty(n_points * 3, dtype=np.float32)
+        cd.points.foreach_get("position", positions)
+        snap["position"] = positions
+        for name, prop, width in _REBUILT_ATTRS:
+            attr = cd.attributes.get(name)
+            if attr is None:
+                continue
+            buf = np.empty(
+                n_points * width, dtype=np.float32 if width == 3 else np.int32
+            )
+            attr.data.foreach_get(prop, buf)
+            snap[name] = buf
+        return snap
+
+    def assert_full_rebuild_is_noop(self):
+        """A full, unscoped rebuild after the solve must change nothing real.
+
+        The tolerance is float32 noise, not slack. A repeated full rebuild is
+        bit-stable, but the solver writes positions computed in double while
+        rebuild_segments re-derives them from the float32 values already stored,
+        so the two can differ in the last bit (~1 ULP, 2.4e-07 at unit scale).
+        Staleness looks nothing like that: a segment the scoping wrongly skipped
+        keeps geometry built from the point's *previous* location, off by the whole
+        edit, so 1e-5 still catches it with four orders of magnitude to spare.
+        """
+        before = self._snapshot()
+        rebuild_segments(self.sketch)  # unscoped: rebuilds every segment
+        after = self._snapshot()
+
+        self.assertEqual(set(before), set(after))
+        for name in before:
+            if name == "merge_id":
+                np.testing.assert_array_equal(
+                    after[name],
+                    before[name],
+                    err_msg="weld ids changed on a full rebuild",
+                )
+                continue
+            np.testing.assert_allclose(
+                after[name],
+                before[name],
+                atol=1e-5,
+                rtol=0,
+                err_msg=(
+                    f"{name!r} changed when the segments were fully rebuilt, so the "
+                    f"solver's scoped rebuild left it stale"
+                ),
+            )
+
+
+class TestScopedRebuildCoversPointMoves(ScopedRebuildEquivalence):
+    def test_dragging_a_point_in_a_chain(self):
+        pts = [self.add_point((0, 0), fixed=True)]
+        for i in range(1, 8):
+            pts.append(self.add_point((i * 1.0, math.sin(i) * 0.5)))
+        for i in range(7):
+            self.add_line(pts[i], pts[i + 1])
+        self.solve()
+
+        pts[4].co = (4.5, 2.0)
+        self.solve()
+        self.assert_full_rebuild_is_noop()
+
+    def test_moving_an_arc_centre(self):
+        centre = self.add_point((0, 0))
+        start = self.add_point((2, 0))
+        end = self.add_point((0, 2))
+        self.add_arc(centre, start, end)
+        self.solve()
+
+        centre.co = (0.5, -0.5)
+        self.solve()
+        self.assert_full_rebuild_is_noop()
+
+    def test_moving_a_circle_centre(self):
+        centre = self.add_point((0, 0))
+        self.add_circle(centre, 1.5)
+        self.solve()
+
+        centre.co = (3.0, 1.0)
+        self.solve()
+        self.assert_full_rebuild_is_noop()
+
+    def test_nothing_moved(self):
+        """A solve that changes no position must still leave segments consistent."""
+        centre = self.add_point((1, 1))
+        self.add_circle(centre, 0.8)
+        self.add_line(self.add_point((0, 0)), self.add_point((2, 0)))
+        self.solve()
+        self.solve()  # second solve: nothing to move
+        self.assert_full_rebuild_is_noop()
+
+
+class TestScopedRebuildCoversRadiusChanges(ScopedRebuildEquivalence):
+    """A radius can change with the centre standing still.
+
+    Nothing in the point pass flags that, so the second pass has to add the
+    circle's centre id itself. Without it the circle keeps its old bezier.
+    """
+
+    def test_diameter_constraint_resizes_the_circle(self):
+        centre = self.add_point((0, 0), fixed=True)
+        circle = self.add_circle(centre, 1.0)
+        diameter = self.sketch.constraints.add_diameter(
+            init=True, curve_id_1=circle.curve_id
+        )
+        self.solve()
+
+        diameter.value = 5.0
+        self.solve()
+        self.assert_full_rebuild_is_noop()
+
+    def test_radius_shrinks(self):
+        centre = self.add_point((0, 0), fixed=True)
+        circle = self.add_circle(centre, 4.0)
+        diameter = self.sketch.constraints.add_diameter(
+            init=True, curve_id_1=circle.curve_id
+        )
+        self.solve()
+
+        diameter.value = 0.5
+        self.solve()
+        self.assert_full_rebuild_is_noop()
+
+
+class TestScopedRebuildCoversResegmentation(ScopedRebuildEquivalence):
+    """An arc's control-point count tracks its sweep, so a move can resize it."""
+
+    RADIUS = 2.0
+
+    def _end_at(self, degrees):
+        a = math.radians(degrees)
+        return (self.RADIUS * math.cos(a), self.RADIUS * math.sin(a))
+
+    def test_arc_grows_past_segment_boundaries(self):
+        centre = self.add_point((0, 0), fixed=True)
+        start = self.add_point((self.RADIUS, 0), fixed=True)
+        end = self.add_point(self._end_at(30))
+        self.add_arc(centre, start, end)
+        self.solve()
+
+        for degrees in (100, 200, 350, 80, 30):
+            with self.subTest(degrees=degrees):
+                end.co = self._end_at(degrees)
+                self.solve()
+                self.assert_full_rebuild_is_noop()
+
+
+class TestScopedRebuildAfterTopologyChange(ScopedRebuildEquivalence):
+    """Merge ids track connectivity, which a scoped rebuild skips recomputing.
+
+    The solver therefore has to recompute them itself, or a corner welded by a
+    coincidence constraint stops welding and the sketch no longer fills.
+    """
+
+    def test_solve_after_adding_geometry(self):
+        p0 = self.add_point((0, 0), fixed=True)
+        p1 = self.add_point((2, 0))
+        self.add_line(p0, p1)
+        self.solve()
+
+        p2 = self.add_point((2, 2))
+        self.add_line(p1, p2)
+        self.solve()
+        self.assert_full_rebuild_is_noop()
+
+    def test_coincident_corner_keeps_its_weld_id(self):
+        a0 = self.add_point((0, 0), fixed=True)
+        a1 = self.add_point((2, 0))
+        b0 = self.add_point((2, 0))
+        b1 = self.add_point((2, 2))
+        self.add_line(a0, a1)
+        self.add_line(b0, b1)
+        self.sketch.constraints.add_coincident(
+            curve_id_1=a1.curve_id, curve_id_2=b0.curve_id
+        )
+        self.solve()
+
+        cd = self.sketch.target_object.data
+        merge = cd.attributes.get("merge_id")
+        self.assertIsNotNone(merge, "merge_id attribute missing after solve")
+        ids = np.empty(len(cd.points), dtype=np.int32)
+        merge.data.foreach_get("value", ids)
+        self.assertTrue((ids > 0).any(), "no weld ids assigned after a solve")
+
+        self.assert_full_rebuild_is_noop()
+
+
+class TestScopedRebuildActuallyScopes(Sketch2dTestCase):
+    """Guard the optimization itself: a solve must not re-derive every arc.
+
+    Equivalence alone would still pass if the scoping silently degraded to a full
+    rebuild, which is the regression that would quietly give the performance back.
+    """
+
+    def _circles(self, count):
+        centres = []
+        for i in range(count):
+            centre = self.add_point((i * 2.0, 0))
+            centres.append(centre)
+            self.add_circle(centre, 0.7)
+        return centres
+
+    def _scopes_of_one_solve(self):
+        """The ``point_ids`` the solver hands to rebuild_segments during a solve."""
+        import unittest.mock as mock
+
+        from ..utilities import curve_data as cd_mod
+
+        real = cd_mod.rebuild_segments
+        calls = []
+
+        def spy(sketch, point_ids=None):
+            calls.append(point_ids)
+            return real(sketch, point_ids=point_ids)
+
+        # The solver imports rebuild_segments inside _write_results, so the name
+        # resolves from this module at call time and patching it here takes effect.
+        with mock.patch.object(cd_mod, "rebuild_segments", spy):
+            self.solve()
+        return calls
+
+    def test_a_settled_solve_rebuilds_nothing(self):
+        self._circles(12)
+        self.solve()
+
+        calls = self._scopes_of_one_solve()
+
+        self.assertEqual(len(calls), 1, "solver did not call rebuild_segments once")
+        self.assertIsNotNone(
+            calls[0], "solver fell back to an unscoped rebuild of every segment"
+        )
+        self.assertEqual(
+            calls[0], set(), f"a settled solve reported moves: {calls[0]!r}"
+        )
+
+    def test_a_caller_move_is_already_rebuilt(self):
+        """Writing ``co`` rebuilds the segments itself, so the solve adds nothing.
+
+        The solver only reports points *it* relocated. When the caller moved the
+        point and the solver agrees with that position, there is nothing left to
+        rebuild -- the ``co`` setter already did it (see curve_ref.rebuild path).
+        """
+        centres = self._circles(12)
+        self.solve()
+
+        centres[3].co = (6.0, 3.0)
+        calls = self._scopes_of_one_solve()
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0], set())
+
+    def _write_position_directly(self, point, co):
+        """Move a point in curve data, bypassing the ``co`` setter's rebuild.
+
+        This is the state the solver is meant to correct: a position changed with
+        segments not yet rebuilt, so the solve has a genuine difference to write.
+        """
+        from ..utilities.curve_data import get_curve_data
+
+        cd, _idx, curve_slice = get_curve_data(self.sketch, point.curve_id)
+        cd.points[curve_slice.points[0].index].position = (co[0], co[1], 0.0)
+
+    def test_solver_driven_move_leaves_bystanders_alone(self):
+        """The point the solver corrects is rebuilt; unrelated circles are not."""
+        centres = self._circles(12)  # bystanders that must NOT be rebuilt
+        anchor = self.add_point((0, 0), fixed=True)
+        free = self.add_point((3.0, 0))
+        self.add_line(anchor, free)
+        # Point-to-point: the line form of add_distance is not enforced by the
+        # solver, so it would leave the geometry free and the solve a no-op.
+        distance = self.sketch.constraints.add_distance(
+            init=True, curve_id_1=anchor.curve_id, curve_id_2=free.curve_id
+        )
+        # Assigning value stores it in scene["slvs:c:<uid>"]. Without that the
+        # getter derives the value from the current geometry, so the constraint is
+        # always already satisfied and the solver never corrects anything.
+        distance.value = 3.0
+        self.solve()
+
+        # Drag `free` off its constrained length; the solver has to pull it back.
+        self._write_position_directly(free, (9.0, 4.0))
+        calls = self._scopes_of_one_solve()
+
+        self.assertEqual(len(calls), 1)
+        moved = calls[0]
+        self.assertIsNotNone(moved, "solver fell back to an unscoped rebuild")
+        self.assertIn(
+            free.curve_id, moved, "the point the solver relocated was not reported"
+        )
+        for centre in centres:
+            self.assertNotIn(
+                centre.curve_id,
+                moved,
+                "an untouched circle was flagged for rebuild, so the scoping is "
+                "not actually narrowing the work",
+            )

--- a/utilities/curve_data.py
+++ b/utilities/curve_data.py
@@ -746,7 +746,72 @@ def _resegment_arcs(sketch, cd, point_ids=None):
     return True
 
 
-def compute_merge_ids(sketch):
+# object name -> connectivity signature at the last merge-id computation. Weld
+# ids and source seeds are derived purely from connectivity (which point curves a
+# segment references, plus coincidence constraints), never from positions, so a
+# position-only change -- every solve, every drag frame -- cannot alter them.
+_merge_signatures = {}
+
+
+def reset_merge_cache():
+    """Drop the merge-id signature cache (e.g. on file load)."""
+    _merge_signatures.clear()
+
+
+def _connectivity_signature(cd):
+    """Fingerprint of everything ``compute_merge_ids`` actually reads.
+
+    Identity ids, curve types, per-curve point counts (which fix the point
+    indices a junction lands on) and the coincidence constraint pairs. Positions
+    are deliberately absent: that is the whole point of the gate.
+    """
+    n_curves = len(cd.curves)
+    n_points = len(cd.points)
+    parts = []
+    for field in ("curve_id", "start_point_id", "end_point_id"):
+        for half in ("lo", "hi"):
+            buf = np.zeros(n_curves * 2, dtype=np.int32)
+            attr = cd.attributes.get(f".{field}_{half}")
+            if attr:
+                attr.data.foreach_get("value", buf)
+            parts.append(buf.tobytes())
+
+    types = np.zeros(n_curves, dtype=np.int32)
+    type_attr = cd.attributes.get("sketch_type")
+    if type_attr:
+        type_attr.data.foreach_get("value", types)
+    parts.append(types.tobytes())
+
+    # Arc resegmentation changes point counts, which shifts every later point
+    # index, so the counts belong in the key even though no id changed.
+    counts = np.zeros(n_curves, dtype=np.int32)
+    cd.curves.foreach_get("points_length", counts)
+    parts.append(counts.tobytes())
+
+    constraints = getattr(cd, "sketch_constraints", None)
+    coincident = ()
+    if constraints is not None:
+        coincident = tuple(
+            sorted((c.curve_id_1, c.curve_id_2) for c in constraints.coincident)
+        )
+
+    return (n_curves, n_points, coincident, hash(b"".join(parts)))
+
+
+def _merge_outputs_present(cd):
+    """Whether the attributes the merge pass writes already exist.
+
+    The signature says the *inputs* are unchanged; it says nothing about a fresh
+    datablock that has never had the outputs written. Never skip in that case.
+    """
+    return (
+        cd.attributes.get("merge_id") is not None
+        and cd.attributes.get(SOURCE_CURVE_ID_ATTR) is not None
+        and cd.attributes.get(SOURCE_ENDPOINT_ID_ATTR) is not None
+    )
+
+
+def compute_merge_ids(sketch, force=False):
     """Assign each curve point a weld id derived from segment connectivity.
 
     A segment endpoint gets a dense id for the point curve it references
@@ -763,13 +828,25 @@ def compute_merge_ids(sketch):
 
     Interior, point and circle vertices keep id 0; they are never welded (their
     valence is not 1), so their id is irrelevant. Returns True if anything ran.
+
+    Skipped when the sketch's connectivity is unchanged since the last run, since
+    positions cannot affect the result -- pass ``force=True`` to recompute anyway.
     """
     if not sketch or not sketch.target_object or not sketch.target_object.data:
         return False
-    cd = sketch.target_object.data
+    obj = sketch.target_object
+    cd = obj.data
     n_points = len(cd.points)
     type_attr = cd.attributes.get("sketch_type")
     if n_points == 0 or not type_attr:
+        return False
+
+    signature = _connectivity_signature(cd)
+    if (
+        not force
+        and _merge_signatures.get(obj.name) == signature
+        and _merge_outputs_present(cd)
+    ):
         return False
 
     # Only equality of endpoint ids matters here (shared junction -> shared weld
@@ -854,6 +931,7 @@ def compute_merge_ids(sketch):
         attr = cd.attributes.new("merge_id", "INT", "POINT")
     attr.data.foreach_set("value", ids)
     compute_generated_id_seeds(sketch)
+    _merge_signatures[obj.name] = signature
     return True
 
 


### PR DESCRIPTION
Interaction performance on large sketches, prompted by a Discord report that
"you need a beefy computer to run CAD Sketcher". Seven changes, each measured.
No behaviour is meant to change; it is the same geometry computed less often and
with less Python in the way.

## Result

One drag frame (solve + mesh refresh + overlay + picking), 200 circles:

| | before | after |
|---|---|---|
| drag frame | 44.0 ms (23 fps) | 9.9 ms (101 fps) |
| hover frame (no geometry change) | 14.9 ms | 0.28 ms |
| per-mouse-move segment distance test | 18.5 ms | 0.66 ms |
| 400 circles, drag | ~90 ms (11 fps) | 22.0 ms (45 fps) |
| 200 distance constraints, solve | 29.0 ms | 23.2 ms |

And the one that is not about sketch size at all: **solve time used to scale with
how many unrelated objects the file contained.** Identical sketch, 100
constraints, only the surrounding scene changing:

| scene objects | before | after |
|---|---|---|
| 4 | 10.3 ms | ~9 ms |
| 204 | 24.5 ms | ~9 ms |
| 504 | 47.6 ms | ~9 ms |
| 1004 | 81.1 ms | ~9 ms |

If the report came from someone with a real scene rather than a big sketch, that
cliff is the likeliest explanation.

## The changes

**1. Tessellate all arcs/circles in one vectorized pass.** `_arc_points` built
each arc in a Python loop doing one `mat @ Vector(...)` per point, 58% of the
extraction on a circle-heavy sketch. Worth knowing for anyone revisiting it:
vectorizing a *single* arc is slower, because 49 points is too few to amortize
the numpy setup. Only batching across all curves wins.

**2. Solve rebuilds only the segments whose points actually moved.**
`_write_results` called `rebuild_segments(sketch)` unfiltered, re-deriving every
arc/circle bezier on every solve, even though the `point_ids` filter already
existed and `batch_update` already used it. Positions are compared at float32,
the attribute's own storage, so "moved" means "the stored bytes change" with no
tolerance to tune.

**3. One geometry extraction shared by the overlay and the picker.** Both kept
their own cache and ran their own extraction, so every changed frame paid twice.
They keyed on different signatures (picking on geometry, the overlay on geometry
plus selection), so this is a split rather than a shared cache: a
selection-independent geometry pass cached on `geometry_signature`, and a cheap
colour pass. Hover now redoes only colours.

**4. Geometry stays in numpy end to end.** Segment identity moved from
per-segment to per-curve (`seg_cids` plus a `seg_owner` row map), so a circle
carries one curve_id instead of 48 — that bookkeeping was what forced everything
into Python lists. `batch_for_shader` and the screen projection both take arrays
directly.

This also fixed something I had under-counted: `pick_ranked` runs on every
mouse-move and measured point-to-segment distance in a Python loop over every
tessellated segment (18.5 ms at 200 circles, now 0.66 ms, 28x).

**5. Skip the merge-id recompute when connectivity is unchanged.**
`compute_merge_ids` and `compute_generated_id_seeds` derive weld ids purely from
connectivity: which point curves a segment references, curve types, per-curve
point counts, and coincidence constraints. Never from positions. They ran on
every refresh and every solve anyway. Now gated on a connectivity signature,
with `force=True` to override. `refresh_curve_geometry` 4.0 → 1.2 ms.

**6. Resolve a constraint's sketch without scanning the scene.** This is the
scene-size cliff above. `GenericConstraint._get_sketch` found the owning Object
by scanning `bpy.data.objects`, ~7 times per constraint per solve (700 calls for
100 constraints), so the cost was O(constraints x objects), paid every drag frame.

A gotcha worth recording: my first attempt cached the owner's *name* and looked it
up with `bpy.data.objects.get()`. That was only 2.2x better, because
**`bpy.data.objects.get()` is itself a linear scan**, not a hash lookup — 0.77 us
at 10 objects, 48.8 us at 2000. The cache holds the Object reference instead.

**7. Publish the solved sketch so constraints stop re-deriving it.** Even cached,
`_get_sketch` ran ~2800 times per solve on a 400-constraint sketch. The solver
already knows which sketch it is solving, so it publishes it for the duration of
the system build. 20% off a constrained solve.

I deliberately did *not* thread a parameter through all 13 constraint types for
this. The override is honoured only when the constraint's own `id_data` IS that
sketch's data, so a constraint from anywhere else falls through to the normal
lookup and cannot resolve to the wrong sketch. That guard is what made the narrow
change safe.

## Behaviour changes to be aware of

- A circle now emits exactly 48 segments instead of 49. The old code closed the
  loop with a duplicated final point and a zero-length segment, which was also a
  wasted pick candidate.
- `SketchRenderData.line_buckets` / `point_buckets` now hold numpy arrays, and
  `point_ids` / `segment_ids` are replaced by arrays on `SketchGeometry`.
  `render_data.geometry(sketch)` is the entry point for pickable geometry.
- `picking.rank_hits` takes a `PickSet` instead of two lists of tuples.
- `compute_merge_ids(sketch, force=True)` forces the old unconditional behaviour.

## What to hammer when testing

Selection and hover are what changes 1-4 touch most: hovering and clicking
overlapping entities (the #50 cycling path), box select, construction geometry
colours, selected/hovered point sizes, arcs growing and shrinking past their
sweep boundaries, dimension values driving geometry, and reference-geometry
picking across several curve objects. Also the Vulkan backend, since the
constant-draw-call batch structure is what this rests on.

For change 5, **fill and boolean/extrude output** specifically, since those
consume the weld ids.

For changes 6 and 7, **undo/redo on a constrained sketch**, and sketches in a
file with many objects. See the gap below.

## Testing done

496 tests pass (38 new), 1 skipped, 2 pre-existing expected failures, run against
this branch built and installed as `bl_ext.user_default.CAD_Sketcher` in an
isolated `BLENDER_USER_RESOURCES`. All CI green.

New coverage is concentrated where a mistake would be *silent* rather than loud:

- `test_solve_scoped_rebuild.py` runs an unscoped rebuild after each solve and
  asserts nothing changes, across point drags, arc/circle centre moves,
  diameter-driven resizes, arcs resegmenting, solves after topology changes,
  coincident-corner weld ids, and settled no-op solves. This net caught two real
  gaps while I was writing it (the radius case, and merge ids).
- `test_merge_id_gating.py` performs an edit, lets the gate decide, then forces a
  recompute and asserts the weld ids and source seeds are byte-identical.
  Including the case that needs the constraint in the signature: two endpoints at
  the same spot are distinct point curves until a coincidence constraint unions
  them, so that constraint changes the answer with every position, id and count
  unchanged.
- `test_constraint_sketch_resolution.py` covers a deliberately **poisoned** cache
  entry losing to a rescan, a cached reference to a deleted object, two sketches
  resolving separately under interleaved access, the override being refused for a
  foreign constraint in both directions, the override not leaking out of a raised
  exception, and two sketches with different distance values solving end to end.
- `TestArcTessellation` guards the tessellated geometry (every vertex on-radius,
  circle chain closed with no gap, no zero-length segments, arcs landing exactly
  on their defining points at 30/90/200/350 degrees).
- `TestSegmentDistance` pins the vectorized distance against the scalar formula it
  replaced, including degenerate and clamped cases.
- Tests that one frame extracts once and a hover extracts zero times, so a
  regression to double extraction fails the suite rather than quietly costing
  performance. `scripts/perf_harness.py` gained the same as deterministic
  op-count metrics.

The test suite has no GPU, so I separately built the real `_build_batches` output
from real sketch data on a live `gpu.init()` context across five selection states
and confirmed all three batches construct with the draw-call count staying
constant.

### Known gap

The undo/redo test **skips** headless (`bpy.ops.ed.undo` needs a real context), so
undo is the one case with no automated coverage — and it is the classic way a
cached `bpy` reference breaks. I expect it to be fine: invalidated references
raise `ReferenceError`, which is caught, and a cached Object is re-verified to
still own the datablock on every use, so a stale entry costs a rescan rather than
returning the wrong object. But I cannot prove it headless, so please exercise it.

## Not addressed

For a constrained sketch, a good deal of the solve is still Python building the
system: the `ref()` -> `curve_ref` -> `get_curve_type` -> `get_curve_data` chain
runs thousands of times per solve, plus ~8400 function-local import resolutions.

I can measure that stubbing out `_init_constraints` drops a 200-constraint solve
from 23.2 ms to 3.3 ms, but that is *not* a fair attribution: removing the
constraints also leaves slvs an empty system, so it mixes Python overhead with
real solver work. The honest next step is timing instrumentation inside
`_solve_once` to get the true split, because if slvs is most of the remainder then
further Python work buys little.

Measurements are from one machine (Blender 5.2, Linux); treat them as trends, not
absolutes.
